### PR TITLE
refactor: improve protection of bootloader env file loading

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -40,6 +40,8 @@
 #define pv_log(level, msg, ...)		vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
+#define SIZE_CMDLINE_BUF 1024
+
 struct pv_bootloader {
 	char *pv_rev;
 	char *pv_try;
@@ -159,27 +161,27 @@ void pv_bootloader_remove()
 		free(pv_bootloader.pv_done);
 }
 
-static int pv_bl_init(struct pantavisor *pv)
+static int pv_bl_init()
 {
 	int ret;
 
 	switch (pv_config_get_bl_type()) {
-	case BL_UBOOT_PLAIN:
-	case BL_UBOOT_PVK:
-		ops = &uboot_ops;
-		break;
-	case BL_GRUB:
-		ops = &grub_ops;
-		break;
-	default:
-		pv_log(ERROR, "Unknown bootoader type!");
-		return -1;
-		break;
+		case BL_UBOOT_PLAIN:
+		case BL_UBOOT_PVK:
+			ops = &uboot_ops;
+			break;
+		case BL_GRUB:
+			ops = &grub_ops;
+			break;
+		default:
+			pv_log(ERROR, "unknown bootoader type!");
+			return -1;
+			break;
 	}
 
 	ret = ops->init();
 	if (ret)
-		pv_log(ERROR, "Unable to initialize bl controls");
+		pv_log(ERROR, "unable to initialize bl controls");
 
 	return ret;
 }
@@ -188,34 +190,36 @@ static int pv_bl_early_init(struct pv_init *this)
 {
 	struct pantavisor *pv = pv_get_instance();
 	int fd = -1, len;
-	char *buf = NULL, *token = NULL;
+	char buf[SIZE_CMDLINE_BUF];
+	char *done = NULL, *token = NULL;
 	ssize_t bytes = 0;
 	const int CMDLINE_OFFSET = 7;
 
 	if (!pv)
 		return -1;
 
+	// initialize to factory revision
 	len = strlen("0") + 1;
-	pv_bootloader.pv_rev = calloc(1, len * sizeof(char*));
-	snprintf(pv_bootloader.pv_rev, len, "%d", 0);
+	pv_bootloader.pv_rev = calloc(1, len);
+	snprintf(pv_bootloader.pv_rev, len, "0");
 	pv_bootloader.pv_try = NULL;
+	pv_bootloader.pv_done = strdup(pv_bootloader.pv_rev);
 
-	// get current step bootloader from cmdline
+	// overload with values from kernel command line
 	fd = open("/proc/cmdline", O_RDONLY);
 	if (fd < 0)
 		return -1;
 
-	buf = calloc(1, sizeof(char) * (1024 + 1));
-	if (!buf)
+	bytes = pv_fops_read_nointr(fd, buf, SIZE_CMDLINE_BUF);
+	if (bytes < 0)
 		return -1;
-	bytes = pv_fops_read_nointr(fd, buf, sizeof(char)*1024);
+
 	close(fd);
-	if (bytes <= 0)
-		return -1;
 
 	// remove trailing \n
 	buf[bytes-1] = '\0';
 
+	// parse command line
 	token = strtok(buf, " ");
 	while (token) {
 		if (strncmp("pv_rev=", token, CMDLINE_OFFSET) == 0) {
@@ -229,19 +233,19 @@ static int pv_bl_early_init(struct pv_init *this)
 		}
 		token = strtok(NULL, " ");
 	}
-	free(buf);
 
-	// init bootloader ops
-	if (pv_bl_init(pv) < 0)
+	free(pv_bootloader.pv_done);
+	pv_bootloader.pv_done = strdup(pv_bootloader.pv_rev);
+
+	// init boot env file
+	if (pv_bl_init() < 0)
 		return -1;
 
-	// get done revision from cmd line pv_rev
-	pv_bootloader.pv_done = strdup(pv_bootloader.pv_rev);
-	// overwrite done revision from boot env file if available
-	buf = ops->get_env_key("pv_rev");
-	if (buf) {
+	// overload pv_done with value from boot env file
+	done = ops->get_env_key("pv_rev");
+	if (done) {
 		free(pv_bootloader.pv_done);
-		pv_bootloader.pv_done = buf;
+		pv_bootloader.pv_done = done;
 	}
 
 	return 0;

--- a/storage.c
+++ b/storage.c
@@ -602,17 +602,31 @@ int pv_storage_make_config(struct pantavisor *pv)
 
 bool pv_storage_is_revision_local(const char *rev)
 {
+	bool ret = false;
 	char *first = strchr(rev, '/');
 	char *last = strrchr(rev, '/');
 
-	if (strncmp(rev, "locals/", strlen("locals/")))
-		return false;
+	int pre_len = strlen(PREFIX_LOCAL_REV);
+	int rev_len = strlen(rev) - pre_len;
+	if ((strlen(rev) - pre_len) > SIZE_LOCAL_REV) {
+		pv_log(WARN, "revision name longer than %d", SIZE_LOCAL_REV);
+		goto out;
+	}
 
-	if (first && (first == last))
-		return true;
+	if (strncmp(rev, PREFIX_LOCAL_REV, pre_len)) {
+		pv_log(WARN, "revision name does not start with %s",
+			PREFIX_LOCAL_REV);
+		goto out;
+	}
 
-	pv_log(WARN, "revision name %s not valid", rev);
-	return false;
+	if (!first || (first != last)) {
+		pv_log(WARN, "revision name contains more than one '/'");
+		goto out;
+	}
+
+	ret = true;
+out:
+	return ret;
 }
 
 static char* pv_storage_get_file_date(const char *path)

--- a/storage.c
+++ b/storage.c
@@ -607,7 +607,6 @@ bool pv_storage_is_revision_local(const char *rev)
 	char *last = strrchr(rev, '/');
 
 	int pre_len = strlen(PREFIX_LOCAL_REV);
-	int rev_len = strlen(rev) - pre_len;
 	if ((strlen(rev) - pre_len) > SIZE_LOCAL_REV) {
 		pv_log(WARN, "revision name longer than %d", SIZE_LOCAL_REV);
 		goto out;

--- a/storage.h
+++ b/storage.h
@@ -34,6 +34,9 @@
 #define PATH_USERMETA_PLAT "/pv/user-meta.%s"
 #define PATH_USERMETA_PLAT_KEY "/pv/user-meta.%s/%s"
 
+#define PREFIX_LOCAL_REV "locals/"
+#define SIZE_LOCAL_REV 64
+
 struct pv_path {
 	char* path;
 	struct dl_list list;


### PR DESCRIPTION
This refactor contains improvements for securely loading bootloader env files. These improvements have been made following these two premises:
* set limits to revision names to 64 bytes max
* use fixed buffer sizes of 1024 bytes to read from bootloader env files

Detailed list of changes:
* bootloader: refactor early init to use constants for cmdline buffer read
* bootloader: fixed one memory leak that could happen when cmdline read went bad
* ctrl: limit the size of all HTTP requests to avoid memory usage flood
* storage: limit the size of revision names to avoid memory usage flood
* uboot: use fixed size buffers to read from uboot.txt file
* uboot: use dynamic buffer allocation to better fit the needs depending on boot env file being in MTD or default