### PR TITLE
unprivileged ctrl socket

### DIFF
--- a/ctrl.h
+++ b/ctrl.h
@@ -42,10 +42,11 @@ struct pv_cmd {
 	char* payload;
 };
 
-struct pv_cmd* pv_ctrl_socket_wait(int ctrl_fd, int timeout);
-void pv_ctrl_free_cmd(struct pv_cmd *cmd);
-
+int pv_ctrl_socket_open(const char *name);
 void pv_ctrl_socket_close(int ctrl_fd);
+
+struct pv_cmd* pv_ctrl_socket_wait(int timeout);
+void pv_ctrl_free_cmd(struct pv_cmd *cmd);
 
 static inline const char* pv_ctrl_string_cmd_operation(const pv_cmd_operation_t op)
 {

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -482,7 +482,7 @@ static pv_state_t _pv_wait(struct pantavisor *pv)
 
 	// receive new command. Set 2 secs as the select max blocking time, so we can do the
 	// rest of WAIT operations
-	pv->cmd = pv_ctrl_socket_wait(pv->ctrl_fd, 2);
+	pv->cmd = pv_ctrl_socket_wait(2);
 	if (pv->cmd)
 		next_state = PV_STATE_COMMAND;
 
@@ -765,8 +765,6 @@ void pv_stop()
 	struct pantavisor *pv = pv_get_instance();
 	if (!pv)
 		return;
-
-	pv_ctrl_socket_close(pv->ctrl_fd);
 
 	pv_bootloader_remove();
 	pv_remove(pv);

--- a/pantavisor.h
+++ b/pantavisor.h
@@ -51,7 +51,6 @@ struct pantavisor {
 	bool unclaimed;
 	bool synced;
 	bool loading_objects;
-	int ctrl_fd;
 };
 
 void pv_init(void);

--- a/platforms.h
+++ b/platforms.h
@@ -50,6 +50,7 @@ struct pv_platform {
 	int runlevel;
 	bool mgmt;
 	bool updated;
+	int ctrl_fd;
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
 	/*

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -193,10 +193,6 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 	if (p->mgmt) {
 		c->set_config_item(c, "lxc.mount.entry", "/pv pantavisor"
 							" none bind,ro,create=dir 0 0");
-		c->set_config_item(c, "lxc.mount.entry", "/pv/logs pantavisor/logs"
-							" none bind,ro,create=dir 0 0");
-		c->set_config_item(c, "lxc.mount.entry", "/pv/user-meta pantavisor/user-meta"
-							" none bind,ro,create=dir 0 0");
 	} else {
 		c->set_config_item(c, "lxc.mount.entry", "/pv/pv-ctrl-log pantavisor/pv-ctrl-log"
 							" none bind,rw,create=file 0 0");
@@ -207,6 +203,9 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 			p->name);
 		c->set_config_item(c, "lxc.mount.entry", entry);
 	}
+	sprintf(entry, "/pv/ctrl/pv-ctrl-%s pantavisor/pv-ctrl none bind,rw,create=file 0 0",
+		p->name);
+	c->set_config_item(c, "lxc.mount.entry", entry);
 	if (stat("/lib/firmware", &st) == 0)
 		c->set_config_item(c, "lxc.mount.entry", "/lib/firmware"
 					" lib/firmware none bind,ro,create=dir"


### PR DESCRIPTION
In this change:
* ctrl: remove /pv/pv-ctrl
* ctrl: add one ctrl socket for each platform as /pv/ctrl/pv-ctrl-platform
* ctrl: wait for data on a set of platform ctrl sockets
* pantavisor: remove general pv-ctrl
* platform: add platform specific pv-ctrl
* pv_lxc: bind mount each platform ctrl socket to /pantavisor/pv-ctrl
TODO:
* debug bind mount
* avoid legacy ctrl requests for non mgmt containers