### PR TITLE
open pv-ctrl for non-mgmt platforms; forbid all existing request to non-mgmt plats

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -62,7 +62,7 @@ LOCAL_SRC_FILES := init.c \
 			utils/str.c \
 			utils/strrep.c \
 			utils/json.c \
-			utils/fops.c \
+			utils/file.c \
 			utils/base64.c \
 			utils/math.c \
 			utils/timer.c \

--- a/bootloader.c
+++ b/bootloader.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include <mtd/mtd-user.h>
 
-#include "fops.h"
+#include "file.h"
 
 #include "bootloader.h"
 #include "init.h"
@@ -210,7 +210,7 @@ static int pv_bl_early_init(struct pv_init *this)
 	if (fd < 0)
 		return -1;
 
-	bytes = pv_fops_read_nointr(fd, buf, SIZE_CMDLINE_BUF);
+	bytes = pv_file_read_nointr(fd, buf, SIZE_CMDLINE_BUF);
 	if (bytes < 0)
 		return -1;
 

--- a/config_parser.c
+++ b/config_parser.c
@@ -30,7 +30,7 @@
 #include <sys/stat.h>
 
 #include "config_parser.h"
-#include "fops.h"
+#include "file.h"
 
 #define MODULE_NAME             "config_parser"
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
@@ -148,7 +148,7 @@ int config_parse_cmdline(struct dl_list *list, char *hint)
 		return -1;
 	}
 
-	bytes = pv_fops_read_nointr(fd, buf, sizeof(char)*1024);
+	bytes = pv_file_read_nointr(fd, buf, sizeof(char)*1024);
 	if (!bytes) {
 		close(fd);
 		return -1;

--- a/ctrl.c
+++ b/ctrl.c
@@ -42,8 +42,6 @@
 #include <jsmn/jsmnutil.h>
 
 #include "ctrl.h"
-#include "utils/math.h"
-#include "utils/fs.h"
 #include "json.h"
 #include "str.h"
 #include "pvlogger.h"
@@ -54,6 +52,9 @@
 #include "metadata.h"
 #include "version.h"
 #include "platforms.h"
+#include "utils/math.h"
+#include "utils/fs.h"
+#include "utils/file.h"
 
 #define MODULE_NAME             "ctrl"
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
@@ -220,7 +221,21 @@ err:
 	return -1;
 }
 
-static void pv_ctrl_write_response(int req_fd,
+static void pv_ctrl_write_cont_response(int req_fd)
+{
+	if (write(req_fd, HTTP_RES_CONT, sizeof(HTTP_RES_CONT)-1) <= 0)
+		pv_log(WARN, "HTTP CONTINUE response could not be sent to ctrl socket with fd %d: %s",
+			req_fd, strerror(errno));
+}
+
+static void pv_ctrl_write_ok_response(int req_fd)
+{
+	if (write(req_fd, HTTP_RES_OK, strlen(HTTP_RES_OK)) <= 0)
+		pv_log(WARN, "HTTP OK response could not be written to ctrl socket with fd %d: %s",
+			req_fd, strerror(errno));
+}
+
+static void pv_ctrl_write_error_response(int req_fd,
 								pv_http_status_code_t code,
 								const char* message)
 {
@@ -268,14 +283,12 @@ static int pv_ctrl_process_put_file(int req_fd, size_t content_length, char* fil
 
 	pv_log(DEBUG, "reading file from endpoint and putting it in %s...", file_path);
 
-	if (write(req_fd, HTTP_RES_CONT, sizeof(HTTP_RES_CONT)-1) <= 0)
-		pv_log(WARN, "HTTP CONTINUE response could not be sent to ctrl socket with fd %d: %s",
-			req_fd, strerror(errno));
+	pv_ctrl_write_cont_response(req_fd);
 
 	obj_fd = open(file_path, O_CREAT | O_EXCL | O_WRONLY | O_TRUNC, 0644);
 	if (obj_fd < 0) {
 		pv_log(ERROR, "%s could not be created: %s", file_path, strerror(errno));
-		pv_ctrl_write_response(req_fd, HTTP_STATUS_ERROR, "Cannot create file");
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR, "Cannot create file");
 		// skip clean if the error was about the file already existing
 		if (errno == EEXIST)
 			goto out;
@@ -294,14 +307,14 @@ static int pv_ctrl_process_put_file(int req_fd, size_t content_length, char* fil
 		if (write_length <= 0) {
 			pv_log(WARN, "HTTP PUT content could not be read from ctrl socket with fd %d: %s",
 				req_fd, strerror(errno));
-			pv_ctrl_write_response(req_fd, HTTP_STATUS_ERROR, "Cannot read from socket");
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR, "Cannot read from socket");
 			goto clean;
 		}
 
 		if (write(obj_fd, req, write_length) <= 0) {
 			pv_log(WARN, "HTTP PUT content could not be written from ctrl socket with fd %d: %s",
 				req_fd, strerror(errno));
-			pv_ctrl_write_response(req_fd, HTTP_STATUS_ERROR, "Cannot write into file");
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR, "Cannot write into file");
 			goto clean;
 		}
 
@@ -399,7 +412,7 @@ static size_t pv_ctrl_get_value_header_int(struct phr_header *headers,
 static void pv_ctrl_process_get_file(int req_fd, char *file_path)
 {
 	int obj_fd;
-	ssize_t sent, file_size = pv_storage_get_file_size(file_path);
+	ssize_t sent, file_size = pv_file_get_size(file_path);
 	off_t offset = 0;
 
 	pv_log(DEBUG, "reading file from %s and sending it to endpoint...", file_path);
@@ -410,9 +423,7 @@ static void pv_ctrl_process_get_file(int req_fd, char *file_path)
 		goto error;
 	}
 
-	if (write(req_fd, HTTP_RES_OK, sizeof(HTTP_RES_OK)-1) <= 0)
-		pv_log(WARN, "HTTP OK response could not be written to ctrl socket with fd %d: %s",
-			req_fd, strerror(errno));
+	pv_ctrl_write_ok_response(req_fd);
 
 	// read and send
 	for (size_t to_send = file_size; to_send > 0; ) {
@@ -430,7 +441,7 @@ static void pv_ctrl_process_get_file(int req_fd, char *file_path)
 	goto out;
 
 error:
-	pv_ctrl_write_response(req_fd, HTTP_STATUS_NOT_FOUND, "Resource does not exist");
+	pv_ctrl_write_error_response(req_fd, HTTP_STATUS_NOT_FOUND, "Resource does not exist");
 out:
 	close(obj_fd);
 }
@@ -473,9 +484,7 @@ static void pv_ctrl_process_get_string(int req_fd, char* buf)
 
 	buf_len = strlen(buf);
 
-	if (write(req_fd, HTTP_RES_OK, sizeof(HTTP_RES_OK)-1) <= 0)
-		pv_log(WARN, "HTTP OK response could not be written to ctrl socket with fd %d: %s",
-			req_fd, strerror(errno));
+	pv_ctrl_write_ok_response(req_fd);
 
 	if (write(req_fd, buf, buf_len) != buf_len)
 		pv_log(WARN, "HTTP GET content could not be written to ctrl socket with fd %d: %s",
@@ -522,7 +531,7 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 
 	if (!pv->remote_mode &&
 		((*cmd)->op == CMD_UPDATE_METADATA)) {
-		pv_ctrl_write_response(req_fd,
+		pv_ctrl_write_error_response(req_fd,
 			HTTP_STATUS_CONFLICT,
 			"Cannot do this operation while on local mode");
 		goto error;
@@ -533,7 +542,7 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 		 ((*cmd)->op == CMD_POWEROFF_DEVICE) ||
 		 ((*cmd)->op == CMD_LOCAL_RUN) ||
 		 ((*cmd)->op == CMD_MAKE_FACTORY))) {
-		pv_ctrl_write_response(req_fd,
+		pv_ctrl_write_error_response(req_fd,
 			HTTP_STATUS_CONFLICT,
 			"Cannot do this operation while update is ongoing");
 		goto error;
@@ -541,7 +550,7 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 
 	if (!pv->unclaimed &&
 		((*cmd)->op == CMD_MAKE_FACTORY)) {
-		pv_ctrl_write_response(req_fd,
+		pv_ctrl_write_error_response(req_fd,
 			HTTP_STATUS_CONFLICT,
 			"Cannot do this operation if device is already claimed");
 		goto error;
@@ -626,6 +635,189 @@ out:
 	return mgmt;
 }
 
+static struct pv_cmd* pv_ctrl_process_endpoint_and_reply(int req_fd,
+														const char *method,
+														size_t method_len,
+														const char *path,
+														size_t path_len,
+														size_t content_length,
+														bool mgmt)
+{
+	struct pv_cmd *cmd = NULL;
+	char *file_name = NULL, *file_path_parent = NULL, *file_path = NULL, *file_path_tmp = NULL;
+	char *metakey = NULL, *metavalue = NULL;
+
+	// all requests are forbidden for non mgmt platforms for now
+	if (!mgmt) {
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_FORBIDDEN, "Request not sent from mgmt platform");
+		goto out;
+	}
+
+	if (pv_str_startswith(ENDPOINT_COMMANDS, strlen(ENDPOINT_COMMANDS), path)) {
+		if (!strncmp("POST", method, method_len)) {
+			if (pv_ctrl_process_cmd(req_fd, content_length, &cmd) < 0) {
+				pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Command has bad format");
+				goto out;
+			}
+			if (pv_ctrl_check_command(req_fd, &cmd) < 0)
+				goto out;
+			pv_ctrl_write_ok_response(req_fd);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_matches(ENDPOINT_OBJECTS, strlen(ENDPOINT_OBJECTS), path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_string(req_fd, pv_objects_get_list_string());
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_startswith(ENDPOINT_OBJECTS, strlen(ENDPOINT_OBJECTS), path)) {
+		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_OBJECTS), path_len);
+		file_path_tmp = pv_ctrl_get_file_path(PATH_OBJECTS_TMP, file_name);
+		file_path = pv_ctrl_get_file_path(PATH_OBJECTS, file_name);
+
+		// sha must have 64 characters
+		if (!file_name || !file_path_tmp || !file_path || (strlen(file_name) != 64)) {
+			pv_log(WARN, "HTTP request has bad object name %s", file_name);
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad object name");
+			goto out;
+		}
+
+		if (!strncmp("PUT", method, method_len)) {
+			if (pv_ctrl_process_put_file(req_fd, content_length, file_path_tmp) < 0) {
+				goto out;
+			} else {
+				if (pv_ctrl_validate_object_checksum(file_path_tmp, file_path, file_name) < 0) {
+					pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Object has bad checksum");
+					goto out;
+				}
+
+				pv_storage_gc_defer_run_threshold();
+				pv_ctrl_write_ok_response(req_fd);
+			}
+		} else if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_file(req_fd, file_path);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_matches(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_string(req_fd, pv_storage_get_revisions_string());
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path) &&
+		pv_str_endswith(ENDPOINT_PROGRESS, strlen(ENDPOINT_PROGRESS), path, path_len)) {
+		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len - strlen(ENDPOINT_PROGRESS));
+		file_path = pv_ctrl_get_file_path(PATH_TRAILS_PROGRESS, file_name);
+
+		if (!file_name || !file_path) {
+			pv_log(WARN, "HTTP request has bad step name %s", file_name);
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad step name");
+			goto out;
+		}
+
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_file(req_fd, file_path);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+		goto out;
+	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path) &&
+		pv_str_endswith(ENDPOINT_COMMITMSG, strlen(ENDPOINT_COMMITMSG), path, path_len)) {
+		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len - strlen(ENDPOINT_COMMITMSG));
+		file_path_parent = pv_ctrl_get_file_path(PATH_TRAILS_PV_PARENT, file_name);
+		file_path = pv_ctrl_get_file_path(PATH_TRAILS_COMMITMSG, file_name);
+
+		if (!file_name || !file_path) {
+			pv_log(WARN, "HTTP request has bad step name %s", file_name);
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad step name");
+			goto out;
+		}
+
+		if (!strncmp("PUT", method, method_len)) {
+			mkdir_p(file_path_parent, 0755);
+			if (pv_ctrl_process_put_file(req_fd, content_length, file_path) < 0)
+				goto out;
+			pv_ctrl_write_ok_response(req_fd);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path)) {
+		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len);
+		file_path_parent = pv_ctrl_get_file_path(PATH_TRAILS_PVR_PARENT, file_name);
+		file_path = pv_ctrl_get_file_path(PATH_TRAILS, file_name);
+
+		if (!file_name || !file_path_parent || !file_path) {
+			pv_log(WARN, "HTTP request has bad step name %s", file_name);
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad step name");
+			goto out;
+		}
+
+		if (!strncmp("PUT", method, method_len)) {
+			if (pv_storage_is_revision_local(file_name)) {
+				mkdir_p(file_path_parent, 0755);
+				if (pv_ctrl_process_put_file(req_fd, content_length, file_path) < 0)
+					goto out;
+				pv_ctrl_write_ok_response(req_fd);
+			}
+		} else if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_file(req_fd, file_path);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_matches(ENDPOINT_USER_META, strlen(ENDPOINT_USER_META), path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_string(req_fd, pv_metadata_get_user_meta_string());
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_matches(ENDPOINT_DEVICE_META, strlen(ENDPOINT_DEVICE_META), path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_string(req_fd, pv_metadata_get_device_meta_string());
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_matches(ENDPOINT_BUILDINFO, strlen(ENDPOINT_BUILDINFO), path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			pv_ctrl_process_get_string(req_fd, strdup(pv_build_manifest));
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else if (pv_str_startswith(ENDPOINT_USER_META, strlen(ENDPOINT_USER_META), path)) {
+		metakey = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_USER_META), path_len);
+
+		if (!metakey) {
+			pv_log(WARN, "HTTP request has bad meta name %s", file_name);
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad metadata key name");
+			goto out;
+		}
+
+		if (!strncmp("PUT", method, method_len)) {
+			metavalue = pv_ctrl_get_body(req_fd, content_length);
+			if (pv_metadata_add_usermeta(metakey, metavalue) < 0)
+				pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR, "Cannot add or update user meta");
+			pv_ctrl_write_ok_response(req_fd);
+		} else if (!strncmp("DELETE", method, method_len)) {
+			if (pv_metadata_rm_usermeta(metakey) < 0)
+				pv_ctrl_write_error_response(req_fd, HTTP_STATUS_NOT_FOUND, "User meta does not exist");
+			pv_ctrl_write_ok_response(req_fd);
+		} else
+			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Method not supported for this endpoint");
+	} else {
+		pv_log(WARN, "HTTP request received has unknown endpoint");
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Unknown endpoint");
+	}
+
+out:
+	if (file_name)
+		free(file_name);
+	if (file_path_parent)
+		free(file_path_parent);
+	if (file_path)
+		free(file_path);
+	if (file_path_tmp) {
+		remove(file_path_tmp);
+		free(file_path_tmp);
+	}
+	if (metakey)
+		free(metakey);
+	if (metavalue)
+		free(metavalue);
+
+	return cmd;
+}
+
 static struct pv_cmd* pv_ctrl_read_parse_request(int req_fd)
 {
 	char buf[HTTP_REQ_BUFFER_SIZE];
@@ -635,8 +827,6 @@ static struct pv_cmd* pv_ctrl_read_parse_request(int req_fd)
 	size_t method_len, path_len, num_headers = HTTP_REQ_NUM_HEADERS, content_length;
 	struct phr_header headers[HTTP_REQ_NUM_HEADERS];
 	struct pv_cmd *cmd = NULL;
-	char *file_name = NULL, *file_path_parent = NULL, *file_path = NULL, *file_path_tmp = NULL;
-	char *metakey = NULL, *metavalue = NULL;
 
 	memset(buf, 0, sizeof(buf));
 	mgmt = pv_ctrl_check_sender_privileged(req_fd);
@@ -666,7 +856,7 @@ static struct pv_cmd* pv_ctrl_read_parse_request(int req_fd)
 												headers,
 												&num_headers);
 	if (buf_index < 0) {
-		pv_ctrl_write_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad format");
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has bad format");
 		goto out;
 	}
 
@@ -675,196 +865,18 @@ static struct pv_cmd* pv_ctrl_read_parse_request(int req_fd)
 	content_length = pv_ctrl_get_value_header_int(headers, num_headers, "Content-Length");
 	if (content_length <= 0) {
 		pv_log(WARN, "HTTP request received has empty body");
-		pv_ctrl_write_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has empty body");
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_BAD_REQ, "Request has empty body");
 		goto out;
 	}
 
-	// all requests are forbidden for non mgmt platforms for now
-	if (!mgmt) {
-		pv_ctrl_write_response(req_fd,
-			HTTP_STATUS_FORBIDDEN,
-			"Request not sent from mgmt platform");
-		goto out;
-	}
-
-	// read and parse rest of message
-	if (pv_str_startswith(ENDPOINT_COMMANDS, strlen(ENDPOINT_COMMANDS), path)) {
-		if (!strncmp("POST", method, method_len)) {
-			res = pv_ctrl_process_cmd(req_fd, content_length, &cmd);
-			if (res < 0) {
-				pv_ctrl_write_response(req_fd,
-					HTTP_STATUS_BAD_REQ,
-					"Command has bad format");
-				goto out;
-			}
-			res = pv_ctrl_check_command(req_fd, &cmd);
-			if (res < 0)
-				goto out;
-		}
-	} else if (pv_str_matches(ENDPOINT_OBJECTS, strlen(ENDPOINT_OBJECTS), path, path_len)) {
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_string(req_fd, pv_objects_get_list_string());
-			goto out;
-		}
-	} else if (pv_str_startswith(ENDPOINT_OBJECTS, strlen(ENDPOINT_OBJECTS), path)) {
-		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_OBJECTS), path_len);
-		file_path_tmp = pv_ctrl_get_file_path(PATH_OBJECTS_TMP, file_name);
-		file_path = pv_ctrl_get_file_path(PATH_OBJECTS, file_name);
-
-		// sha must have 64 characters
-		if (!file_name || !file_path_tmp || !file_path || (strlen(file_name) != 64)) {
-			pv_log(WARN, "HTTP request has bad object name %s", file_name);
-			pv_ctrl_write_response(req_fd,
-				HTTP_STATUS_BAD_REQ,
-				"Request has bad object name");
-			goto out;
-		}
-
-		if (!strncmp("PUT", method, method_len)) {
-			res = pv_ctrl_process_put_file(req_fd, content_length, file_path_tmp);
-			if (res < 0) {
-				goto out;
-			} else {
-				res = pv_ctrl_validate_object_checksum(file_path_tmp, file_path, file_name);
-				if (res < 0) {
-					pv_ctrl_write_response(req_fd,
-						HTTP_STATUS_BAD_REQ,
-						"Object has bad checksum");
-					goto out;
-				}
-
-				pv_storage_gc_defer_run_threshold();
-			}
-		} else if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_file(req_fd, file_path);
-			goto out;
-		}
-	} else if (pv_str_matches(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path, path_len)) {
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_string(req_fd, pv_storage_get_revisions_string());
-			goto out;
-		}
-	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path) &&
-		pv_str_endswith(ENDPOINT_PROGRESS, strlen(ENDPOINT_PROGRESS), path, path_len)) {
-		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len - strlen(ENDPOINT_PROGRESS));
-		file_path = pv_ctrl_get_file_path(PATH_TRAILS_PROGRESS, file_name);
-
-		if (!file_name || !file_path) {
-			pv_log(WARN, "HTTP request has bad step name %s", file_name);
-			pv_ctrl_write_response(req_fd,
-				HTTP_STATUS_BAD_REQ,
-				"Request has bad step name");
-			goto out;
-		}
-
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_file(req_fd, file_path);
-			goto out;
-		}
-		goto out;
-	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path) &&
-		pv_str_endswith(ENDPOINT_COMMITMSG, strlen(ENDPOINT_COMMITMSG), path, path_len)) {
-		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len - strlen(ENDPOINT_COMMITMSG));
-		file_path_parent = pv_ctrl_get_file_path(PATH_TRAILS_PV_PARENT, file_name);
-		file_path = pv_ctrl_get_file_path(PATH_TRAILS_COMMITMSG, file_name);
-
-		if (!file_name || !file_path) {
-			pv_log(WARN, "HTTP request has bad step name %s", file_name);
-			pv_ctrl_write_response(req_fd,
-				HTTP_STATUS_BAD_REQ,
-				"Request has bad step name");
-			goto out;
-		}
-
-		if (!strncmp("PUT", method, method_len)) {
-			mkdir_p(file_path_parent, 0755);
-			res = pv_ctrl_process_put_file(req_fd, content_length, file_path);
-			if (res < 0)
-				goto out;
-		}
-	} else if (pv_str_startswith(ENDPOINT_STEPS, strlen(ENDPOINT_STEPS), path)) {
-		file_name = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_STEPS), path_len);
-		file_path_parent = pv_ctrl_get_file_path(PATH_TRAILS_PVR_PARENT, file_name);
-		file_path = pv_ctrl_get_file_path(PATH_TRAILS, file_name);
-
-		if (!file_name || !file_path_parent || !file_path) {
-			pv_log(WARN, "HTTP request has bad step name %s", file_name);
-			pv_ctrl_write_response(req_fd,
-				HTTP_STATUS_BAD_REQ,
-				"Request has bad step name");
-			goto out;
-		}
-
-		if (!strncmp("PUT", method, method_len)) {
-			if (pv_storage_is_revision_local(file_name)) {
-				mkdir_p(file_path_parent, 0755);
-				res = pv_ctrl_process_put_file(req_fd, content_length, file_path);
-				if (res < 0)
-					goto out;
-			}
-		} else if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_file(req_fd, file_path);
-			goto out;
-		}
-	} else if (pv_str_matches(ENDPOINT_USER_META, strlen(ENDPOINT_USER_META), path, path_len)) {
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_string(req_fd, pv_metadata_get_user_meta_string());
-			goto out;
-		}
-	} else if (pv_str_matches(ENDPOINT_DEVICE_META, strlen(ENDPOINT_DEVICE_META), path, path_len)) {
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_string(req_fd, pv_metadata_get_device_meta_string());
-			goto out;
-		}
-	} else if (pv_str_matches(ENDPOINT_BUILDINFO, strlen(ENDPOINT_BUILDINFO), path, path_len)) {
-		if (!strncmp("GET", method, method_len)) {
-			pv_ctrl_process_get_string(req_fd, strdup(pv_build_manifest));
-			goto out;
-		}
-	} else if (pv_str_startswith(ENDPOINT_USER_META, strlen(ENDPOINT_USER_META), path)) {
-		metakey = pv_ctrl_get_file_name(path, sizeof(ENDPOINT_USER_META), path_len);
-
-		if (!metakey) {
-			pv_log(WARN, "HTTP request has bad meta name %s", file_name);
-			pv_ctrl_write_response(req_fd,
-				HTTP_STATUS_BAD_REQ,
-				"Request has bad metadata key name");
-			goto out;
-		}
-
-		if (!strncmp("PUT", method, method_len)) {
-			metavalue = pv_ctrl_get_body(req_fd, content_length);
-			res = pv_metadata_add_usermeta(metakey, metavalue);
-		} else if (!strncmp("DELETE", method, method_len)) {
-			res = pv_metadata_rm_usermeta(metakey);
-		}
-	} else
-		pv_log(WARN, "HTTP request received has bad endpoint");
-
-	if (res < 0) {
-		pv_ctrl_write_response(req_fd, HTTP_STATUS_ERROR, "Unknown request");
-	} else {
-		if (write(req_fd, HTTP_RES_OK, strlen(HTTP_RES_OK)) <= 0)
-			pv_log(WARN, "HTTP OK response could not be written to ctrl socket with fd %d: %s",
-				req_fd, strerror(errno));
-	}
-
+	cmd = pv_ctrl_process_endpoint_and_reply(req_fd,
+											method,
+											method_len,
+											path,
+											path_len,
+											content_length,
+											mgmt);
 out:
-	if (file_name)
-		free(file_name);
-	if (file_path_parent)
-		free(file_path_parent);
-	if (file_path)
-		free(file_path);
-	if (file_path_tmp) {
-		remove(file_path_tmp);
-		free(file_path_tmp);
-	}
-	if (metakey)
-		free(metakey);
-	if (metavalue)
-		free(metavalue);
-
 	return cmd;
 }
 

--- a/log.c
+++ b/log.c
@@ -37,7 +37,7 @@
 #include <linux/limits.h>
 
 #include "config.h"
-#include "fops.h"
+#include "file.h"
 #include "thttp.h"
 #include "utils/fs.h"
 #include "loop.h"
@@ -91,7 +91,7 @@ static void __vlog(char *module, int level, const char *fmt, va_list args)
 		int ret = 0;
 		int lock_file_errno = 0;
 		do {
-			ret = pv_fops_lock_file(log_fd);
+			ret = pv_file_lock_file(log_fd);
 		} while (ret < 0 && (errno == EAGAIN || errno == EACCES));
 
 		if (ret < 0)
@@ -139,7 +139,7 @@ static void __vlog(char *module, int level, const char *fmt, va_list args)
 				snprintf(gzip_path, sizeof(gzip_path),
 						"%s.%d.gzip", log_path, (i+1));
 				if (stat(gzip_path, &stat_gz))
-					pv_fops_gzip_file(log_path, gzip_path);
+					pv_file_gzip_file(log_path, gzip_path);
 			}
 			if (log_fd >= 0) {
 				ftruncate(log_fd, 0);
@@ -152,7 +152,7 @@ static void __vlog(char *module, int level, const char *fmt, va_list args)
 		dprintf(log_fd, "[%s]: ", module);
 		vdprintf(log_fd, fmt, args);
 		dprintf(log_fd, "\n");
-		pv_fops_unlock_file(log_fd);
+		pv_file_unlock_file(log_fd);
 		close(log_fd);
 	}
 }

--- a/metadata.c
+++ b/metadata.c
@@ -40,14 +40,15 @@
 #include "state.h"
 #include "pantahub.h"
 #include "init.h"
-#include "utils/math.h"
-#include "utils/system.h"
 #include "str.h"
 #include "json.h"
 #include "config_parser.h"
 #include "storage.h"
 #include "platforms.h"
 #include "buffer.h"
+#include "utils/math.h"
+#include "utils/system.h"
+#include "utils/file.h"
 
 #define MODULE_NAME             "metadata"
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
@@ -856,9 +857,11 @@ static void pv_metadata_load_usermeta()
 
 		len = strlen(PATH_USERMETA_KEY) + strlen(curr->path) + 1;
 		snprintf(path, len, PATH_USERMETA_KEY, curr->path);
-		value = pv_storage_load_file(path, METADATA_MAX_SIZE);
-		if (!value)
+		value = pv_file_load(path, METADATA_MAX_SIZE);
+		if (!value) {
+			pv_log(ERROR, "could not load %s: %s", path, strerror(errno));
 			continue;
+		}
 
 		pv_metadata_add_usermeta(curr->path, value);
 		free(value);

--- a/objects.c
+++ b/objects.c
@@ -28,10 +28,11 @@
 
 #include <linux/limits.h>
 
-#include "utils/math.h"
 #include "objects.h"
 #include "state.h"
 #include "storage.h"
+#include "utils/math.h"
+#include "utils/file.h"
 
 #define MODULE_NAME			"objects"
 #define pv_log(level, msg, ...)		vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
@@ -156,7 +157,7 @@ char *pv_objects_get_list_string()
 			continue;
 
 		sprintf(path, "%s/objects/%s", pv_config_get_storage_mntpoint(), curr->path);
-		size_object = pv_storage_get_file_size(path);
+		size_object = pv_file_get_size(path);
 		if (size_object <= 0)
 			continue;
 

--- a/ph_logger/ph_logger.c
+++ b/ph_logger/ph_logger.c
@@ -51,7 +51,7 @@
 #include "utils/system.h"
 #include "str.h"
 #include "json.h"
-#include "fops.h"
+#include "file.h"
 #include "buffer.h"
 #include "ph_logger.h"
 #include "ph_logger_v1.h"
@@ -514,7 +514,7 @@ static int ph_logger_push_from_file(const char *filename, char *platform, char *
 	}
 	buf = log_buff->buf;
 
-	if (pv_fops_get_file_xattr(filename, PH_LOGGER_POS_XATTR, &dst, NULL) > 0) {
+	if (pv_file_get_file_xattr(filename, PH_LOGGER_POS_XATTR, &dst, NULL) > 0) {
 		sscanf(dst, "%" PRId64, &pos);
 	} else {
 		ph_log(DEBUG, "XATTR %s not found in %s. Position set to pos %lld",
@@ -523,7 +523,7 @@ static int ph_logger_push_from_file(const char *filename, char *platform, char *
 		/*
 		 * set xattr to quiet the verbose-ness otherwise.
 		 */
-		pv_fops_set_file_xattr(filename, PH_LOGGER_POS_XATTR, dst);
+		pv_file_set_file_xattr(filename, PH_LOGGER_POS_XATTR, dst);
 	}
 #ifdef DEBUG
 	if (!dl_list_empty(&frag_list)) {
@@ -558,7 +558,7 @@ static int ph_logger_push_from_file(const char *filename, char *platform, char *
 		}
 	}
 
-	bytes_read = pv_fops_read_nointr(fd, buf, log_buff->size);
+	bytes_read = pv_file_read_nointr(fd, buf, log_buff->size);
 	/*
 	 * we've to get rid of all NULL bytes in buf
 	 * otherwise the pv_json_format won't really work as it'll
@@ -675,7 +675,7 @@ static int ph_logger_push_from_file(const char *filename, char *platform, char *
 
 			pos = read_pos + offset;
 			snprintf(value, sizeof(value), "%"PRId64, pos);
-			pv_fops_set_file_xattr(filename, PH_LOGGER_POS_XATTR, value);
+			pv_file_set_file_xattr(filename, PH_LOGGER_POS_XATTR, value);
 		}
 	}
 close_fd:
@@ -729,7 +729,7 @@ close_fd:
 				char value[20];
 
 				sprintf(value, "%"PRId64, pos);
-				pv_fops_set_file_xattr(filename, PH_LOGGER_POS_XATTR, value);
+				pv_file_set_file_xattr(filename, PH_LOGGER_POS_XATTR, value);
 			}
 			// in case of error while sending, we return -1
 			else
@@ -815,7 +815,7 @@ accept_again:
 				int nr_read = 0;
 				struct ph_logger_msg *msg = (struct ph_logger_msg*)buf;
 
-				nr_read = pv_fops_read_nointr(work_fd, buf, log_buffer->size);
+				nr_read = pv_file_read_nointr(work_fd, buf, log_buffer->size);
 				if (nr_read > 0) {
 					ph_logger_write_to_log_file(msg, revision);
 					nr_logs++;

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -200,6 +200,8 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 	} else {
 		c->set_config_item(c, "lxc.mount.entry", "/pv/pv-ctrl-log pantavisor/pv-ctrl-log"
 							" none bind,rw,create=file 0 0");
+		c->set_config_item(c, "lxc.mount.entry", "/pv/pv-ctrl pantavisor/pv-ctrl"
+							" none bind,rw,create=file 0 0");
 		sprintf(entry, "/pv/logs/%s/%s pantavisor/logs none bind,ro,create=dir 0 0",
 			rev, p->name);
 		c->set_config_item(c, "lxc.mount.entry", entry);

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -36,7 +36,7 @@
 #include "platforms.h"
 #include "pvctl_utils.h"
 #include "json.h"
-#include "fops.h"
+#include "file.h"
 
 #define MODULE_NAME             "pvlogger"
 #include "log.h"
@@ -118,7 +118,7 @@ static int set_logger_xattr(struct log *log)
 		return 0;
 	snprintf(place_holder, sizeof(place_holder), "%" PRId64, pos);
 	
-	return pv_fops_set_file_xattr(fname, PV_LOGGER_POS_XATTR, place_holder);
+	return pv_file_set_file_xattr(fname, PV_LOGGER_POS_XATTR, place_holder);
 }
 
 static int pvlogger_flush(struct log *log, char *buf, int buflen)
@@ -188,7 +188,7 @@ static int get_logger_xattr(struct log *log)
 	char *dst = buf;
 	const char *fname = pv_logger_get_logfile(pv_log_info);
 
-	if (pv_fops_get_file_xattr(fname, PV_LOGGER_POS_XATTR, &dst, NULL) < 0) {
+	if (pv_file_get_file_xattr(fname, PV_LOGGER_POS_XATTR, &dst, NULL) < 0) {
 		pv_log(DEBUG, "Attribute %s not present", PV_LOGGER_POS_XATTR);
 	}
 	else {

--- a/storage.h
+++ b/storage.h
@@ -75,8 +75,4 @@ void pv_storage_init_plat_usermeta(const char *name);
 void pv_storage_save_usermeta(const char *key, const char *value);
 void pv_storage_rm_usermeta(const char *key);
 
-char *pv_storage_load_file(const char *path, const unsigned int max_size);
-size_t pv_storage_get_file_size(const char *path);
-
-
 #endif // PV_STORAGE_H

--- a/updater.c
+++ b/updater.c
@@ -52,7 +52,7 @@
 #include "parser/parser_bundle.h"
 #include "state.h"
 #include "json.h"
-#include "fops.h"
+#include "file.h"
 #include "signature.h"
 
 #define MODULE_NAME			"updater"
@@ -1508,7 +1508,7 @@ static int trail_download_object(struct pantavisor *pv, struct pv_object *obj, c
 
 	if (use_volatile_tmp) {
 		pv_log(INFO, "copying %s to tmp path (%s)", volatile_tmp_obj_path, mmc_tmp_obj_path);
-		bytes = pv_fops_copy_and_close(volatile_tmp_fd, obj_fd);
+		bytes = pv_file_copy_and_close(volatile_tmp_fd, obj_fd);
 		fd = obj_fd;
 	}
 	pv_log(DEBUG, "downloaded object to tmp path (%s)", mmc_tmp_obj_path);
@@ -1626,7 +1626,7 @@ static int trail_link_objects(struct pantavisor *pv)
 			if ((s_fd >= 0) &&
 				(d_fd >= 0)) {
 				pv_log(INFO, "copying bind volume '%s' from '%s'", obj->relpath, obj->objpath);
-				pv_fops_copy_and_close(s_fd, d_fd);
+				pv_file_copy_and_close(s_fd, d_fd);
 			}
 			continue;
 		}
@@ -1828,7 +1828,7 @@ int pv_update_install(struct pantavisor *pv)
 		ret = -1;
 		goto out;
 	}
-	pv_fops_write_nointr(fd, pending->json, strlen(pending->json));
+	pv_file_write_nointr(fd, pending->json, strlen(pending->json));
 	close(fd);
 	rename(path_new, path);
 

--- a/utils/file.h
+++ b/utils/file.h
@@ -20,28 +20,31 @@
  * SOFTWARE.
  */
 
-#ifndef UTILS_PV_FOPS_H_
-#define UTILS_PV_FOPS_H_
+#ifndef UTILS_PV_FILE_H_
+#define UTILS_PV_FILE_H_
 
 #include <sys/types.h>
+
+char* pv_file_load(const char *path, const unsigned int max_size);
+size_t pv_file_get_size(const char *path);
 
 /*
  * Returns 0 on success.
  * For setting, value holds a null terminated string.
  * For get, the value is returned back in dst.
  */
-int pv_fops_set_file_xattr(const char *filename, char *attr, char *value);
-int pv_fops_get_file_xattr(const char *filename, char *attr, char **dst, int (*alloc)(char **, int));
-ssize_t pv_fops_write_nointr(int fd, char *buf, ssize_t len);
-ssize_t pv_fops_read_nointr(int fd, char *buf, ssize_t len);
-int pv_fops_lock_file(int fd);
+int pv_file_set_file_xattr(const char *filename, char *attr, char *value);
+int pv_file_get_file_xattr(const char *filename, char *attr, char **dst, int (*alloc)(char **, int));
+ssize_t pv_file_write_nointr(int fd, char *buf, ssize_t len);
+ssize_t pv_file_read_nointr(int fd, char *buf, ssize_t len);
+int pv_file_lock_file(int fd);
 /*
  * Returns the file descriptor on success.
  */
-int pv_fops_open_and_lock_file(const char *fname, int flags, mode_t mode);
-int pv_fops_unlock_file(int fd);
-int pv_fops_gzip_file(const char *filename, const char *target_name);
-int pv_fops_check_and_open_file(const char *fname, int flags, mode_t mode);
-int pv_fops_copy_and_close(int s_fd, int d_fd);
+int pv_file_open_and_lock_file(const char *fname, int flags, mode_t mode);
+int pv_file_unlock_file(int fd);
+int pv_file_gzip_file(const char *filename, const char *target_name);
+int pv_file_check_and_open_file(const char *fname, int flags, mode_t mode);
+int pv_file_copy_and_close(int s_fd, int d_fd);
 
-#endif /* UTILS_PV_FOPS_H_ */
+#endif /* UTILS_PV_FILE_H_ */

--- a/utils/system.c
+++ b/utils/system.c
@@ -30,7 +30,7 @@
 #include <signal.h>
 
 #include "system.h"
-#include "fops.h"
+#include "file.h"
 
 #define PREFIX_MODEL	"model name\t:"
 
@@ -45,9 +45,9 @@ int get_dt_model(char *buf, int buflen)
 	int fd = -1;
 	int ret = -1;
 
-	fd = pv_fops_check_and_open_file("/proc/device-tree/model", O_RDONLY, 0);
+	fd = pv_file_check_and_open_file("/proc/device-tree/model", O_RDONLY, 0);
 	if (fd >= 0) {
-		ret = pv_fops_read_nointr(fd, buf, buflen);
+		ret = pv_file_read_nointr(fd, buf, buflen);
 		close(fd);
 	}
 	return ret >= 0 ? 0 : ret;
@@ -63,9 +63,9 @@ int get_cpu_model(char *buf, int buflen)
 	if (!buf || buflen <= 0)
 		goto out;
 
-	fd = pv_fops_check_and_open_file("/proc/cpuinfo", O_RDONLY, 0);
+	fd = pv_file_check_and_open_file("/proc/cpuinfo", O_RDONLY, 0);
 	if (fd >= 0) {
-		bytes_read = pv_fops_read_nointr(fd, buf, buflen);
+		bytes_read = pv_file_read_nointr(fd, buf, buflen);
 		close(fd);
 	}
 	if (bytes_read > 0)


### PR DESCRIPTION
This change gets pv-ctrl socket back to non-mgmt containers. Besides that, it checks the sender container privileges to discriminate all requests coming from non-mgmt containers. In the future, some requests will be allowed to non-mgmt, such as the condition requests.

List of changes:
* ctrl: new functions to return OK and CONT
* ctrl: new functions to get the container that is sending a new request
* ctrl: check sender platform privileges (mgmt or not) when a new request arrives
* ctrl: refactor pv_ctrl_process_endpoint_and_reply to make replies easier to follow
* ctrl: forbid legacy non-HTTP commands for non-mgmt
* ctrl: forbid all existing HTTP requests for non-mgmt
* ctrl: return 403 Forbidden when the request is not available for the requesting container
* pv_lxc: bind mount pv-ctrl in non-mgmt platforms
* storage: moved functions to load files and get size of files to utils/file
* utils/fops: renamed to utils/file