### PR TITLE
introduce platform groups and conditions

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -48,6 +48,8 @@ LOCAL_SRC_FILES := init.c \
 			config.c \
 			pantavisor.c \
 			state.c \
+			group.c \
+			condition.c \
 			platforms.c \
 			addons.c \
 			volumes.c \

--- a/condition.c
+++ b/condition.c
@@ -74,7 +74,7 @@ int pv_condition_report(struct pv_condition *c, char *plat, char *key, char *cur
 	return -1;
 }
 
-bool pv_condition_evaluate(struct pv_condition *c)
+bool pv_condition_check(struct pv_condition *c)
 {
 	return pv_str_matches(c->eval_value,
 		strlen(c->eval_value),

--- a/condition.c
+++ b/condition.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <string.h>
+
+#include "condition.h"
+
+#define MODULE_NAME             "condition"
+#define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
+#include "log.h"
+
+struct pv_condition* pv_condition_new(char *plat, char *key, char *value)
+{
+	struct pv_condition *c;
+
+	c = calloc(1, sizeof(struct pv_condition));
+
+	c->plat = strdup(plat);
+	c->key = strdup(key);
+	c->value = strdup(value);
+
+	return c;
+}
+
+void pv_condition_free(struct pv_condition *c)
+{
+	pv_log(DEBUG, "removing condition %s", c->key);
+
+	if (c->plat)
+		free(c->plat);
+	if (c->key)
+		free(c->key);
+	if (c->value)
+		free(c->value);
+	free(c);
+}

--- a/condition.h
+++ b/condition.h
@@ -38,7 +38,7 @@ struct pv_condition* pv_condition_new(char *plat, char *key, char *eval_value);
 void pv_condition_free(struct pv_condition *c);
 
 int pv_condition_report(struct pv_condition *c, char *plat, char *key, char *curr_value);
-bool pv_condition_evaluate(struct pv_condition *c);
+bool pv_condition_check(struct pv_condition *c);
 
 char *pv_condition_get_json(struct pv_condition *c);
 

--- a/condition.h
+++ b/condition.h
@@ -22,16 +22,24 @@
 #ifndef PV_CONDITION_H
 #define PV_CONDITION_H
 
+#include <stdbool.h>
+
 #include "utils/list.h"
 
 struct pv_condition {
 	char *plat;
 	char *key;
-	char *value;
+	char *eval_value;
+	char *curr_value;
 	struct dl_list list; // pv_condition
 };
 
-struct pv_condition* pv_condition_new(char *plat, char *key, char *value);
-void pv_condition_free(struct pv_condition *g);
+struct pv_condition* pv_condition_new(char *plat, char *key, char *eval_value);
+void pv_condition_free(struct pv_condition *c);
+
+int pv_condition_report(struct pv_condition *c, char *plat, char *key, char *curr_value);
+bool pv_condition_evaluate(struct pv_condition *c);
+
+char *pv_condition_get_json(struct pv_condition *c);
 
 #endif // PV_CONDITION_H

--- a/condition.h
+++ b/condition.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef PV_CONDITION_H
+#define PV_CONDITION_H
+
+#include "utils/list.h"
+
+struct pv_condition {
+	char *plat;
+	char *key;
+	char *value;
+	struct dl_list list; // pv_condition
+};
+
+struct pv_condition* pv_condition_new(char *plat, char *key, char *value);
+void pv_condition_free(struct pv_condition *g);
+
+#endif // PV_CONDITION_H

--- a/condition.h
+++ b/condition.h
@@ -27,19 +27,28 @@
 #include "utils/list.h"
 
 struct pv_condition {
-	char *plat;
 	char *key;
 	char *eval_value;
 	char *curr_value;
 	struct dl_list list; // pv_condition
 };
 
-struct pv_condition* pv_condition_new(char *plat, char *key, char *eval_value);
+struct pv_condition* pv_condition_new(char *key, char *eval_value);
 void pv_condition_free(struct pv_condition *c);
 
-int pv_condition_report(struct pv_condition *c, char *plat, char *key, char *curr_value);
+void pv_condition_set_value(struct pv_condition *c, char *curr_value);
 bool pv_condition_check(struct pv_condition *c);
 
 char *pv_condition_get_json(struct pv_condition *c);
+
+struct pv_condition_ref {
+	struct pv_condition *ref;
+	struct dl_list list; // pv_condition_ref
+};
+
+struct pv_condition_ref* pv_condition_ref_new(struct pv_condition *c);
+void pv_condition_ref_free(struct pv_condition_ref *cr);
+
+struct pv_condition* pv_condition_get_ref(struct pv_condition_ref *cr);
 
 #endif // PV_CONDITION_H

--- a/ctrl.c
+++ b/ctrl.c
@@ -615,7 +615,7 @@ static bool pv_ctrl_check_sender_privileged(const char *pname)
 	struct pantavisor *pv = pv_get_instance();
 	struct pv_platform *plat;
 
-	plat = pv_platform_get_by_name(pv->state, pname);
+	plat = pv_state_fetch_platform(pv->state, pname);
 	if (!plat) {
 		pv_log(WARN, "could not find platform %s in current state", pname);
 		goto out;

--- a/group.c
+++ b/group.c
@@ -89,6 +89,20 @@ int pv_group_report_condition(struct pv_group *g, char *plat, char *key, char *v
 	return ret;
 }
 
+bool pv_group_check_conditions(struct pv_group *g)
+{
+	bool ret = true;
+	struct pv_condition *c, *tmp;
+
+	dl_list_for_each_safe(c, tmp, &g->conditions,
+			struct pv_condition, list) {
+		if (!pv_condition_check(c))
+			ret = false;
+	}
+
+	return ret;
+}
+
 char* pv_group_get_json(struct pv_group *g)
 {
 	int len, line_len;

--- a/group.c
+++ b/group.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <string.h>
+
+#include "group.h"
+
+#define MODULE_NAME             "group"
+#define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
+#include "log.h"
+
+struct pv_group* pv_group_new(char *name)
+{
+	struct pv_group *g;
+
+	g = calloc(1, sizeof(struct pv_group));
+
+	g->name = strdup(name);
+	dl_list_init(&g->conditions);
+
+	return g;
+}
+
+static void pv_group_empty_conditions(struct pv_group *g)
+{
+	int num_conditions = 0;
+	struct pv_condition *c, *tmp;
+	struct dl_list *conditions = &g->conditions;
+
+	// Iterate over all conditions from group
+	dl_list_for_each_safe(c, tmp, conditions,
+		struct pv_condition, list) {
+		dl_list_del(&c->list);
+		pv_condition_free(c);
+		num_conditions++;
+	}
+
+	pv_log(INFO, "removed %g conditions", num_conditions);
+}
+
+void pv_group_free(struct pv_group *g)
+{
+	pv_log(DEBUG, "removing group %s", g->name);
+
+	if (g->name)
+		free(g->name);
+	pv_group_empty_conditions(g);
+	free(g);
+}
+
+void pv_group_add_condition(struct pv_group *g, struct pv_condition *c)
+{
+	pv_log(DEBUG, "adding condition %s to group", c->key);
+
+	dl_list_init(&c->list);
+	dl_list_add_tail(&g->conditions, &c->list);
+}

--- a/group.h
+++ b/group.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef PV_GROUP_H
+#define PV_GROUP_H
+
+#include "condition.h"
+#include "utils/list.h"
+
+struct pv_group {
+	char *name;
+	struct dl_list conditions; // pv_condition
+	struct dl_list list; // pv_group
+};
+
+struct pv_group* pv_group_new(char *name);
+void pv_group_free(struct pv_group *g);
+
+void pv_group_add_condition(struct pv_group *g, struct pv_condition *c);
+
+#endif // PV_GROUP_H

--- a/group.h
+++ b/group.h
@@ -27,17 +27,13 @@
 
 struct pv_group {
 	char *name;
-	struct dl_list conditions; // pv_condition
+	struct dl_list condition_refs; // pv_condition_ref
 	struct dl_list list; // pv_group
 };
 
 struct pv_group* pv_group_new(char *name);
 void pv_group_free(struct pv_group *g);
 
-void pv_group_add_condition(struct pv_group *g, struct pv_condition *c);
-int pv_group_report_condition(struct pv_group *g, char *plat, char *key, char *value);
-bool pv_group_check_conditions(struct pv_group *g);
-
-char* pv_group_get_json(struct pv_group *g);
+void pv_group_add_condition_ref(struct pv_group *g, struct pv_condition *c);
 
 #endif // PV_GROUP_H

--- a/group.h
+++ b/group.h
@@ -36,6 +36,7 @@ void pv_group_free(struct pv_group *g);
 
 void pv_group_add_condition(struct pv_group *g, struct pv_condition *c);
 int pv_group_report_condition(struct pv_group *g, char *plat, char *key, char *value);
+bool pv_group_check_conditions(struct pv_group *g);
 
 char* pv_group_get_json(struct pv_group *g);
 

--- a/group.h
+++ b/group.h
@@ -35,5 +35,8 @@ struct pv_group* pv_group_new(char *name);
 void pv_group_free(struct pv_group *g);
 
 void pv_group_add_condition(struct pv_group *g, struct pv_condition *c);
+int pv_group_report_condition(struct pv_group *g, char *plat, char *key, char *value);
+
+char* pv_group_get_json(struct pv_group *g);
 
 #endif // PV_GROUP_H

--- a/init.c
+++ b/init.c
@@ -44,6 +44,7 @@
 #include "version.h"
 #include "pvlogger.h"
 #include "platforms.h"
+#include "volumes.h"
 #include "state.h"
 #include "utils/tsh.h"
 #include "utils/math.h"
@@ -372,6 +373,7 @@ struct pv_init *pv_init_tbl [] = {
 	&pv_init_metadata,
 	&pv_init_ctrl,
 	&pv_init_network,
+	&pv_init_volume,
 	&pv_init_platform,
 	&pv_init_pantavisor,
 };

--- a/init.h
+++ b/init.h
@@ -81,6 +81,7 @@ extern struct pv_init pv_init_mount;
 extern struct pv_init ph_init_mount;
 extern struct pv_init pv_init_network;
 extern struct pv_init pv_init_pantavisor;
+extern struct pv_init pv_init_volume;
 extern struct pv_init pv_init_platform;
 extern struct pv_init pv_init_update;
 

--- a/jsons.c
+++ b/jsons.c
@@ -53,19 +53,6 @@ void pv_jsons_remove(struct pv_json *j)
 	pv_jsons_free(j);
 }
 
-struct pv_json* pv_jsons_get_by_name(struct pv_state *s, char *name)
-{
-	struct pv_json *curr, *tmp;
-	struct dl_list *head = &s->jsons;
-
-	dl_list_for_each_safe(curr, tmp, head,
-			struct pv_json, list) {
-		if (!strcmp(curr->name, name))
-			return curr;
-	}
-	return NULL;
-}
-
 void pv_jsons_free(struct pv_json *json)
 {
 	if (json->name)

--- a/jsons.h
+++ b/jsons.h
@@ -35,7 +35,6 @@ struct pv_json {
 
 struct pv_json* pv_jsons_add(struct pv_state *s, char *name, char *value);
 void pv_jsons_remove(struct pv_json *j);
-struct pv_json* pv_jsons_get_by_name(struct pv_state *s, char *name);
 void pv_jsons_empty(struct pv_state *s);
 
 void pv_jsons_free(struct pv_json *json);

--- a/loop.c
+++ b/loop.c
@@ -171,8 +171,6 @@ int unmount_loop(char *dest, int loop_fd, int file_fd)
 	if (ret < 0)
 		goto out;
 
-	pv_log(DEBUG, "umounted '%s' volume", dest);
-
 out:
 	return ret;
 }

--- a/metadata.c
+++ b/metadata.c
@@ -408,20 +408,18 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 		n = (*key_i)->end - (*key_i)->start + 1;
 
 		// copy key
-		key = malloc(n+1);
+		key = calloc(1, n+1);
 		if (!key)
 			break;
 
-		key[n] = 0;
 		SNPRINTF_WTRUNC(key, n, "%s", um+(*key_i)->start);
 
 		// copy value
 		n = (*key_i+1)->end - (*key_i+1)->start + 1;
-		value = malloc(n+1);
+		value = calloc(1, n+1);
 		if (!value)
 			break;
 
-		value[n] = 0;
 		SNPRINTF_WTRUNC(value, n, "%s", um+(*key_i+1)->start);
 
 		// add or update metadata

--- a/objects.c
+++ b/objects.c
@@ -85,19 +85,6 @@ void pv_objects_remove(struct pv_object *o)
 	pv_object_free(o);
 }
 
-struct pv_object* pv_objects_get_by_name(struct pv_state *s, char *name)
-{
-	struct pv_object *curr, *tmp;
-	struct dl_list *head = &s->objects;
-
-	dl_list_for_each_safe(curr, tmp, head,
-			struct pv_object, list) {
-		if (!strcmp(curr->name, name))
-			return curr;
-	}
-	return NULL;
-}
-
 void pv_objects_empty(struct pv_state *s)
 {
 	int num_obj = 0;

--- a/objects.h
+++ b/objects.h
@@ -45,7 +45,6 @@ struct pv_object {
 int pv_objects_id_in_step(struct pv_state *s, char *id);
 struct pv_object* pv_objects_add(struct pv_state *s, char *filename, char *id, char *mntpoint);
 void pv_objects_remove(struct pv_object *o);
-struct pv_object* pv_objects_get_by_name(struct pv_state *s, char *name);
 void pv_objects_empty(struct pv_state *s);
 
 char *pv_objects_get_list_string(void);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -173,7 +173,8 @@ static pv_state_t _pv_init(struct pantavisor *pv)
 
 	if (pv_do_execute_init())
 		return PV_STATE_EXIT;
-        return PV_STATE_RUN;
+
+    return PV_STATE_RUN;
 }
 
 static pv_state_t _pv_run(struct pantavisor *pv)
@@ -453,9 +454,8 @@ static pv_state_t _pv_wait(struct pantavisor *pv)
 			}
 		}
 		tstate = timer_current_state(&t);
-		if (tstate.fin) {
+		if (tstate.fin)
 			pv_log(DEBUG, "network operations are taking %d seconds!",  5 + tstate.sec);
-		}
 	} else {
 		// process ongoing updates, if any
 		next_state = pv_wait_update();

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -238,8 +238,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		tokv = 0;
 	}
 
-	this->status = PLAT_INSTALLED;
-
+	pv_platform_set_ready(this);
 out:
 	if (name)
 		free(name);

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -177,7 +177,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
 	name = pv_json_get_value(buf, "name", tokv, tokc);
 
-	this = pv_platform_get_by_name(s, name);
+	this = pv_state_fetch_platform(s, name);
 	if (!this)
 		goto out;
 

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -216,69 +216,81 @@ out:
 	return ret;
 }
 
-static int parse_conditions(struct pv_state *s, struct pv_group *g, char *value)
+static struct pv_condition* parse_condition(struct pv_state *s, char *value)
 {
-	char *str = NULL, *plat = NULL, *key = NULL, *val = NULL;
+	char *key = NULL, *val = NULL;
+	struct pv_condition *c = NULL;
+	jsmntok_t *condv;
+	int condc;
+
+	pv_log(DEBUG, "condition %s", value);
+
+	if (jsmnutil_parse_json(value, &condv, &condc) <= 0) {
+		pv_log(ERROR, "wrong format condition");
+		goto out;
+	}
+
+	key = pv_json_get_value(value, "key", condv, condc);
+	if (!key) {
+		pv_log(ERROR, "key not found in condition");
+		goto out;
+	}
+
+	val = pv_json_get_value(value, "value", condv, condc);
+	if (!val) {
+		pv_log(ERROR, "value not found in condition");
+		goto out;
+	}
+
+	c = pv_state_fetch_condition_value(s, key, value);
+	if (c) {
+		pv_log(DEBUG, "condition found in state");
+		goto out;
+	}
+
+	c = pv_condition_new(key, val);
+	if (!c) {
+		pv_log(ERROR, "could not create a new condition");
+		goto out;
+	}
+
+	pv_state_add_condition(s, c);
+
+out:
+	if (key)
+		free(key);
+	if (val)
+		free(val);
+	return c;
+}
+
+static int parse_group_conditions(struct pv_state *s, struct pv_group *g, char *value)
+{
+	struct pv_condition *c;
+	char *str = NULL;
 	int ret = 0, tokc;
 	jsmntok_t *tokv = NULL, **t = NULL, **i = NULL;
 
-	pv_log(DEBUG, "conditions %s", value);
+	pv_log(DEBUG, "group conditions %s", value);
 
 	if (jsmnutil_parse_json(value, &tokv, &tokc) < 0) {
-		pv_log(ERROR, "wrong format conditions");
+		pv_log(ERROR, "wrong format group conditions");
 		goto out;
 	}
 
 	t = jsmnutil_get_array_toks(value, tokv);
 	i = t;
 	while (*i) {
-		struct pv_condition *c;
-		jsmntok_t *condv;
-		int condc;
-
 		str = pv_json_get_one_str(value, i);
 		if (!str)
 			break;
 
-		pv_log(DEBUG, "condition %s", str);
-
-		if (jsmnutil_parse_json(str, &condv, &condc) <= 0) {
-			pv_log(ERROR, "wrong format condition");
+		c = parse_condition(s, str);
+		if (!c)
 			goto out;
-		}
 
-		plat = pv_json_get_value(str, "platform", condv, condc);
-		if (!plat) {
-			pv_log(ERROR, "platform not found in condition");
-			goto out;
-		}
+		pv_group_add_condition_ref(g, c);
 
-		key = pv_json_get_value(str, "key", condv, condc);
-		if (!key) {
-			pv_log(ERROR, "key not found in condition");
-			goto out;
-		}
-
-		val = pv_json_get_value(str, "value", condv, condc);
-		if (!val) {
-			pv_log(ERROR, "value not found in condition");
-			goto out;
-		}
-
-		c = pv_condition_new(plat, key, val);
-		if (!c) {
-			pv_log(ERROR, "could not create a new condition");
-			goto out;
-		}
-
-		pv_group_add_condition(g, c);
-
-		free(plat);
-		plat = NULL;
-		free(key);
-		key = NULL;
-		free(val);
-		val = NULL;
 		free(str);
 		str = NULL;
 
@@ -288,12 +300,52 @@ static int parse_conditions(struct pv_state *s, struct pv_group *g, char *value)
 	ret = 1;
 
 out:
-	if (plat)
-		free(plat);
-	if (key)
-		free(key);
-	if (val)
-		free(val);
+	if (str)
+		free(str);
+	if (t)
+		jsmnutil_tokv_free(t);
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
+static int parse_platform_conditions(struct pv_state *s, struct pv_platform *p, char *value)
+{
+	struct pv_condition *c;
+	char *str = NULL;
+	int ret = 0, tokc;
+	jsmntok_t *tokv = NULL, **t = NULL, **i = NULL;
+
+	pv_log(DEBUG, "platform conditions %s", value);
+
+	if (jsmnutil_parse_json(value, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "wrong format platform conditions");
+		goto out;
+	}
+
+	t = jsmnutil_get_array_toks(value, tokv);
+	i = t;
+	while (*i) {
+		str = pv_json_get_one_str(value, i);
+		if (!str)
+			break;
+
+		c = parse_condition(s, str);
+		if (!c)
+			goto out;
+
+		pv_platform_add_condition(p, c);
+
+		free(str);
+		str = NULL;
+
+		i++;
+	}
+
+	ret = 1;
+
+out:
 	if (str)
 		free(str);
 	if (t)
@@ -353,8 +405,8 @@ static int parse_groups(struct pv_state *s, char *value)
 			goto out;
 		}
 
-		if (!parse_conditions(s, g, conditions)) {
-			pv_log(ERROR, "could not parse conditions");
+		if (!parse_group_conditions(s, g, conditions)) {
+			pv_log(ERROR, "could not parse group conditions");
 			pv_group_free(g);
 			goto out;
 		}
@@ -960,6 +1012,21 @@ static int do_action_for_storage(struct json_key_action *jka, char *value)
 	return 0;
 }
 
+static int do_action_for_conditions(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle*) jka->opaque;
+
+	if (!(*bundle->platform) || !value)
+		return -1;
+
+	if (!parse_platform_conditions(bundle->s, *bundle->platform, value)) {
+		pv_log(ERROR, "could not parse platform conditions");
+		return -1;
+	}
+
+	return 0;
+}
+
 static int parse_platform(struct pv_state *s, char *buf, int n)
 {
 	char *config = NULL, *shares = NULL;
@@ -983,6 +1050,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		ADD_JKA_ENTRY("volumes", JSMN_ARRAY, &bundle, do_action_for_one_volume, false),
 		ADD_JKA_ENTRY("logs", JSMN_ARRAY, &bundle, do_action_for_one_log, false),
 		ADD_JKA_ENTRY("storage", JSMN_OBJECT, &bundle, do_action_for_storage, false),
+		ADD_JKA_ENTRY("conditions", JSMN_STRING, &bundle, do_action_for_conditions, false),
 		ADD_JKA_NULL_ENTRY()
 	};
 
@@ -1192,10 +1260,7 @@ struct pv_state* system1_parse(struct pv_state *this, const char *buf)
 
 	system1_link_object_json_platforms(this);
 
-	if (pv_state_validate(this)) {
-		this = NULL;
-		goto out;
-	}
+	pv_state_validate(this);
 
 	pv_state_print(this);
 

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -1000,7 +1000,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		config = 0;
 	}
 
-	this->status = PLAT_INSTALLED;
+	pv_platform_set_ready(this);
 out:
 	if (config)
 		free(config);

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -747,8 +747,7 @@ static int do_action_for_runlevel(struct json_key_action *jka,
 	if (!(*bundle->platform) || !value)
 		return -1;
 
-	(*bundle->platform)->runlevel = RUNLEVEL_ROOT;
-
+	// runlevel is still valid in the state json to keep backwards compatibility, but internally it is substituted by groups
 	if (!strcmp(value, "data") ||
 		!strcmp(value, "root") ||
 		!strcmp(value, "app") ||
@@ -1024,13 +1023,13 @@ static void system1_link_object_json_platforms(struct pv_state *s)
 		dir = strtok(name, "/");
 		if (!strcmp(dir, "_config")) {
 			dir = strtok(NULL, "/");
-			o->plat = pv_platform_get_by_name(s, dir);
+			o->plat = pv_state_fetch_platform(s, dir);
 			if (!o->plat) {
 				pv_log(WARN, "discarding unassociated object '%s'", o->name);
 				pv_objects_remove(o);
 			}
 		} else
-			o->plat = pv_platform_get_by_name(s, dir);
+			o->plat = pv_state_fetch_platform(s, dir);
 		free(name);
 	}
 
@@ -1043,13 +1042,13 @@ link_jsons:
 		dir = strtok(name, "/");
 		if (!strcmp(dir, "_config")) {
 			dir = strtok(NULL, "/");
-			j->plat = pv_platform_get_by_name(s, dir);
+			j->plat = pv_state_fetch_platform(s, dir);
 			if (!j->plat) {
 				pv_log(WARN, "discarding unassociated json '%s'", j->name);
 				pv_jsons_remove(j);
 			}
 		} else
-			j->plat = pv_platform_get_by_name(s, dir);
+			j->plat = pv_state_fetch_platform(s, dir);
 		free(name);
 	}
 }

--- a/platforms.c
+++ b/platforms.c
@@ -225,41 +225,6 @@ void pv_platforms_remove_not_installed(struct pv_state *s)
 	}
 }
 
-void pv_platforms_default_runlevel(struct pv_state *s)
-{
-	bool root_configured = false;
-	struct pv_platform *p, *tmp, *first_p = NULL;
-	struct dl_list *platforms = &s->platforms;
-
-	if (dl_list_empty(platforms))
-		return;
-
-	dl_list_for_each_safe(p, tmp, platforms,
-			struct pv_platform, list) {
-		// check if any platform has been configured as ROOT
-		if (p->runlevel == RUNLEVEL_ROOT)
-			root_configured = true;
-		// get first unconfigured platform
-		if (!first_p && (p->runlevel == -1))
-			first_p = p;
-	}
-
-	// if not, set first platform as runlevel ROOT
-	if (!root_configured && first_p) {
-		pv_log(WARN, "no platform was found with root runlevel, "
-				"so the first unconfigured one in alphabetical order will be set");
-		first_p->runlevel = RUNLEVEL_ROOT;
-	}
-
-	// set rest of the non configured platforms with runlevel PLATFORM, reserved for non-explicilty configured ones
-	platforms = &s->platforms;
-	dl_list_for_each_safe(p, tmp, platforms,
-            struct pv_platform, list) {
-		if (p->runlevel < RUNLEVEL_DATA)
-			p->runlevel = RUNLEVEL_PLATFORM;
-    }
-}
-
 static struct pv_cont_ctrl* _pv_platforms_get_ctrl(char *type)
 {
 	int i;

--- a/platforms.c
+++ b/platforms.c
@@ -193,6 +193,39 @@ void pv_platform_free(struct pv_platform *p)
 	free(p);
 }
 
+static const char* pv_platform_status_string(plat_status_t status)
+{
+	switch(status) {
+		case PLAT_NONE: return "NONE";
+		case PLAT_INSTALLED: return "INSTALLED";
+		case PLAT_STARTED: return "STARTED";
+		case PLAT_STOPPED: return "STOPPED";
+		default: return "UNKNOWN";
+	}
+
+	return "UNKNOWN";
+}
+
+char* pv_platform_get_json(struct pv_platform *p)
+{
+	int len;
+	char *json, *group = NULL;
+	const char *status = pv_platform_status_string(p->status);
+
+	if (p->group)
+		group = p->group->name;
+
+	len = strlen(p->name) +
+		strlen(group) +
+		strlen(status) +
+		strlen("{\"name\":\"\",\"group\":\"\",\"status\":\"\"}");
+	json = calloc(1, (len + 1) * sizeof(char*));
+	snprintf(json, len + 1, "{\"name\":\"%s\",\"group\":\"%s\",\"status\":\"%s\"}",
+		p->name, group, status);
+
+	return json;
+}
+
 void pv_platforms_empty(struct pv_state *s)
 {
 	int num_plats = 0;

--- a/platforms.h
+++ b/platforms.h
@@ -48,6 +48,7 @@ struct pv_platform {
 	pid_t init_pid;
 	plat_status_t status;
 	int runlevel;
+	struct pv_group *group;
 	bool mgmt;
 	bool updated;
 	struct dl_list list; // pv_platform
@@ -66,7 +67,6 @@ struct pv_platform* pv_platform_add(struct pv_state *s, char *name);
 struct pv_platform* pv_platform_get_by_name(struct pv_state *s, const char *name);
 
 void pv_platforms_remove_not_installed(struct pv_state *s);
-void pv_platforms_default_runlevel(struct pv_state *s);
 void pv_platforms_add_all_loggers(struct pv_state *s);
 
 int pv_platforms_start(struct pantavisor *pv, int runlevel);

--- a/platforms.h
+++ b/platforms.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 
 #include "pantavisor.h"
+#include "condition.h"
 #include "utils/list.h"
 
 typedef enum {
@@ -52,6 +53,7 @@ struct pv_platform {
 	struct pv_group *group;
 	bool mgmt;
 	bool updated;
+	struct dl_list condition_refs; // pv_condition_ref
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
 	/*
@@ -62,11 +64,14 @@ struct pv_platform {
 
 void pv_platform_free(struct pv_platform *p);
 
+void pv_platform_add_condition(struct pv_platform *g, struct pv_condition *c);
+
 int pv_platform_start(struct pv_platform *p);
 int pv_platform_stop(struct pv_platform *p);
 void pv_platform_force_stop(struct pv_platform *p);
 
 int pv_platform_check_running(struct pv_platform *p);
+bool pv_platform_check_conditions(struct pv_platform *p);
 
 void pv_platform_set_ready(struct pv_platform *p);
 void pv_platform_set_blocked(struct pv_platform *p);

--- a/platforms.h
+++ b/platforms.h
@@ -29,8 +29,6 @@
 #include "pantavisor.h"
 #include "utils/list.h"
 
-extern const int MAX_RUNLEVEL;
-
 typedef enum {
 	PLAT_NONE,
 	PLAT_DATA,
@@ -38,6 +36,7 @@ typedef enum {
 	PLAT_BLOCKED,
 	PLAT_STARTING,
 	PLAT_STARTED,
+	PLAT_STOPPING,
 	PLAT_STOPPED
 } plat_status_t;
 
@@ -50,7 +49,6 @@ struct pv_platform {
 	void *data;
 	pid_t init_pid;
 	plat_status_t status;
-	int runlevel;
 	struct pv_group *group;
 	bool mgmt;
 	bool updated;
@@ -64,19 +62,29 @@ struct pv_platform {
 
 void pv_platform_free(struct pv_platform *p);
 
-void pv_platform_set_ready(struct pv_platform *p);
-
 int pv_platform_start(struct pv_platform *p);
 int pv_platform_stop(struct pv_platform *p);
+void pv_platform_force_stop(struct pv_platform *p);
 
 int pv_platform_check_running(struct pv_platform *p);
+
+void pv_platform_set_ready(struct pv_platform *p);
+void pv_platform_set_blocked(struct pv_platform *p);
+void pv_platform_set_updated(struct pv_platform *p);
+
+bool pv_platform_is_ready(struct pv_platform *p);
+bool pv_platform_is_blocked(struct pv_platform *p);
+bool pv_platform_is_starting(struct pv_platform *p);
+bool pv_platform_is_started(struct pv_platform *p);
+bool pv_platform_is_stopping(struct pv_platform *p);
+bool pv_platform_is_stopped(struct pv_platform *p);
+bool pv_platform_is_updated(struct pv_platform *p);
 
 char* pv_platform_get_json(struct pv_platform *p);
 
 int pv_platforms_init_ctrl(struct pantavisor *pv);
 
 struct pv_platform* pv_platform_add(struct pv_state *s, char *name);
-struct pv_platform* pv_platform_get_by_name(struct pv_state *s, const char *name);
 
 void pv_platforms_remove_not_installed(struct pv_state *s);
 void pv_platforms_add_all_loggers(struct pv_state *s);

--- a/platforms.h
+++ b/platforms.h
@@ -61,6 +61,8 @@ struct pv_platform {
 
 void pv_platform_free(struct pv_platform *p);
 
+char* pv_platform_get_json(struct pv_platform *p);
+
 int pv_platforms_init_ctrl(struct pantavisor *pv);
 
 struct pv_platform* pv_platform_add(struct pv_state *s, char *name);

--- a/platforms.h
+++ b/platforms.h
@@ -33,7 +33,10 @@ extern const int MAX_RUNLEVEL;
 
 typedef enum {
 	PLAT_NONE,
-	PLAT_INSTALLED,
+	PLAT_DATA,
+	PLAT_READY,
+	PLAT_BLOCKED,
+	PLAT_STARTING,
 	PLAT_STARTED,
 	PLAT_STOPPED
 } plat_status_t;
@@ -61,6 +64,13 @@ struct pv_platform {
 
 void pv_platform_free(struct pv_platform *p);
 
+void pv_platform_set_ready(struct pv_platform *p);
+
+int pv_platform_start(struct pv_platform *p);
+int pv_platform_stop(struct pv_platform *p);
+
+int pv_platform_check_running(struct pv_platform *p);
+
 char* pv_platform_get_json(struct pv_platform *p);
 
 int pv_platforms_init_ctrl(struct pantavisor *pv);
@@ -71,9 +81,6 @@ struct pv_platform* pv_platform_get_by_name(struct pv_state *s, const char *name
 void pv_platforms_remove_not_installed(struct pv_state *s);
 void pv_platforms_add_all_loggers(struct pv_state *s);
 
-int pv_platforms_start(struct pantavisor *pv, int runlevel);
-int pv_platforms_check_exited(struct pantavisor *pv, int runlevel);
-int pv_platforms_stop(struct pantavisor *pv, int runlevel);
 void pv_platforms_empty(struct pv_state *s);
 
 #endif

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -251,16 +251,11 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 		free(buf);
 	}
 	// override container=lxc environment of pid 1
-	if (p->runlevel == RUNLEVEL_DATA)
-		c->set_container_type(c, "pv-data");
-	else if (p->runlevel == RUNLEVEL_ROOT)
-		c->set_container_type(c, "pv-root");
-	else if (p->runlevel == RUNLEVEL_PLATFORM)
-		c->set_container_type(c, "pv-platform");
-	else if (p->runlevel == RUNLEVEL_APP)
-		c->set_container_type(c, "pv-app");
+	if (p->group)
+		sprintf(entry, "pv-%s", p->group->name);
 	else
-		c->set_container_type(c, "pv-unknown");
+		sprintf(entry, "pv-unknown");
+	c->set_container_type(c, entry);
 
 	/*
 	 * Set console filename if not provided.

--- a/state.h
+++ b/state.h
@@ -67,7 +67,11 @@ struct pv_state* pv_state_new(const char *rev, state_spec_t spec);
 void pv_state_free(struct pv_state *s);
 
 void pv_state_add_group(struct pv_state *s, struct pv_group *g);
+
 struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name);
+struct pv_platform* pv_state_fetch_platform(struct pv_state *s, const char *name);
+struct pv_object* pv_state_fetch_object(struct pv_state *s, const char *name);
+struct pv_json* pv_state_fetch_json(struct pv_state *s, const char *name);
 
 state_spec_t pv_state_spec(struct pv_state *s);
 
@@ -78,9 +82,8 @@ int pv_state_start(struct pv_state *s);
 int pv_state_run(struct pv_state *s);
 int pv_state_stop(struct pv_state *s);
 
-//void pv_state_transition(struct pv_state *in, struct pv_state *out);
-void pv_state_transfer(struct pv_state *in, struct pv_state *out);
-int pv_state_compare_states(struct pv_state *pending, struct pv_state *current);
+int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
+void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
 int pv_state_report_condition(struct pv_state *s, char *plat, char *key, char *value);
 

--- a/state.h
+++ b/state.h
@@ -24,6 +24,7 @@
 #define PV_STATE_H
 
 #include "pantavisor.h"
+#include "group.h"
 
 typedef enum {
 	SPEC_MULTI1,
@@ -56,6 +57,7 @@ struct pv_state {
 	struct dl_list addons; // pv_addon
 	struct dl_list objects; //pv_object
 	struct dl_list jsons; //pv_json
+	struct dl_list groups; //pv_group
 	char *json;
 	int tryonce;
 	bool local;
@@ -64,8 +66,11 @@ struct pv_state {
 struct pv_state* pv_state_new(const char *rev, state_spec_t spec);
 void pv_state_free(struct pv_state *s);
 
+void pv_state_add_group(struct pv_state *s, struct pv_group *g);
+struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name);
+
 void pv_state_print(struct pv_state *s);
-void pv_state_validate(struct pv_state *s);
+int pv_state_validate(struct pv_state *s);
 
 void pv_state_transfer(struct pv_state *in, struct pv_state *out);
 int pv_state_compare_states(struct pv_state *pending, struct pv_state *current);

--- a/state.h
+++ b/state.h
@@ -58,6 +58,7 @@ struct pv_state {
 	struct dl_list objects; //pv_object
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
+	struct dl_list conditions; // pv_condition
 	char *json;
 	int tryonce;
 	bool local;
@@ -67,15 +68,18 @@ struct pv_state* pv_state_new(const char *rev, state_spec_t spec);
 void pv_state_free(struct pv_state *s);
 
 void pv_state_add_group(struct pv_state *s, struct pv_group *g);
+void pv_state_add_condition(struct pv_state *s, struct pv_condition *c);
 
 struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name);
 struct pv_platform* pv_state_fetch_platform(struct pv_state *s, const char *name);
 struct pv_object* pv_state_fetch_object(struct pv_state *s, const char *name);
 struct pv_json* pv_state_fetch_json(struct pv_state *s, const char *name);
+struct pv_condition* pv_state_fetch_condition(struct pv_state *s, const char *key);
+struct pv_condition* pv_state_fetch_condition_value(struct pv_state *s, const char *key, const char *eval_value);
 
 state_spec_t pv_state_spec(struct pv_state *s);
 
-int pv_state_validate(struct pv_state *s);
+void pv_state_validate(struct pv_state *s);
 bool pv_state_validate_checksum(struct pv_state *s);
 
 int pv_state_start(struct pv_state *s);

--- a/state.h
+++ b/state.h
@@ -79,4 +79,9 @@ state_spec_t pv_state_spec(struct pv_state *s);
 
 bool pv_state_validate_checksum(struct pv_state *s);
 
+int pv_state_report_condition(struct pv_state *s, char *plat, char *key, char *value);
+
+char* pv_state_get_containers_json(struct pv_state *s);
+char* pv_state_get_conditions_json(struct pv_state *s);
+
 #endif

--- a/state.h
+++ b/state.h
@@ -69,18 +69,22 @@ void pv_state_free(struct pv_state *s);
 void pv_state_add_group(struct pv_state *s, struct pv_group *g);
 struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name);
 
-void pv_state_print(struct pv_state *s);
-int pv_state_validate(struct pv_state *s);
+state_spec_t pv_state_spec(struct pv_state *s);
 
+int pv_state_validate(struct pv_state *s);
+bool pv_state_validate_checksum(struct pv_state *s);
+
+int pv_state_start(struct pv_state *s);
+int pv_state_run(struct pv_state *s);
+int pv_state_stop(struct pv_state *s);
+
+//void pv_state_transition(struct pv_state *in, struct pv_state *out);
 void pv_state_transfer(struct pv_state *in, struct pv_state *out);
 int pv_state_compare_states(struct pv_state *pending, struct pv_state *current);
 
-state_spec_t pv_state_spec(struct pv_state *s);
-
-bool pv_state_validate_checksum(struct pv_state *s);
-
 int pv_state_report_condition(struct pv_state *s, char *plat, char *key, char *value);
 
+void pv_state_print(struct pv_state *s);
 char* pv_state_get_containers_json(struct pv_state *s);
 char* pv_state_get_conditions_json(struct pv_state *s);
 

--- a/storage.c
+++ b/storage.c
@@ -81,7 +81,6 @@ static int pv_storage_gc_objects(struct pantavisor *pv)
 		goto out;
 
 	dl_list_for_each_safe(o, tmp, &objects, struct pv_path, list) {
-		pv_log(DEBUG, "path %s", o->path);
 		if (!strncmp(o->path, "..", len) ||
 			!strncmp(o->path, ".", len))
 			continue;

--- a/updater.h
+++ b/updater.h
@@ -87,7 +87,6 @@ struct object_update {
 struct pv_update {
 	enum update_state status;
 	char *endpoint;
-	int runlevel;
 	int progress_size;
 	struct timer retry_timer;
 	struct pv_state *pending;
@@ -119,8 +118,6 @@ int pv_update_install(struct pantavisor *pv);
 int pv_update_resume(struct pantavisor *pv);
 void pv_update_test(struct pantavisor *pv);
 int pv_update_finish(struct pantavisor *pv);
-
-bool pv_update_requires_reboot(struct pantavisor *pv);
 
 bool pv_update_is_transitioning(struct pv_update *u);
 bool pv_update_is_trying(struct pv_update *u);

--- a/volumes.h
+++ b/volumes.h
@@ -70,8 +70,11 @@ void pv_disks_empty(struct pv_state *s);
 struct pv_volume* pv_volume_add_with_disk(struct pv_state *s, char *name, char *disk);
 struct pv_volume* pv_volume_add(struct pv_state *s, char *name);
 
-int pv_volumes_mount(struct pantavisor *pv, int runlevel);
-int pv_volumes_unmount(struct pantavisor *pv, int runlevel);
+int pv_volume_mount(struct pv_volume *v);
+int pv_volume_unmount(struct pv_volume *v);
+
 void pv_volumes_empty(struct pv_state *s);
+
+int pv_volumes_mount_firmware_modules(void);
 
 #endif // PV_VOLUMES_H


### PR DESCRIPTION
This change is about substituting runlevel by platform groups with conditions. Groups will allow to group platforms together, while conditions will affect the start order of plaforms. Instead of starting all of them in a row, Pantavisor will now check if the platform group conditions are met before that, and will block any platform until conditions are validated. To do so, Pantavisor will start platforms and mount their related volumes during WAIT state.

In this PR:
* condition: new module to define a structure that represent a condition
* condition: functions to alloc and free struct
* condition: functions to set value, check and get json
* condition: functions to allo and free references of the condition struct
* ctrl: new endpoints for containers and conditions
* ctrl: refactor privileges to return 403 depending on the request and allow requests depending on platform name
* ctrl: new requests to report and list conditions
* ctrl: new request to list platforms
* group: new module to define a structure that represent a group of platforms
* group: functions to alloc and free group struct
* group: functions to add condition references
* init: new volume early init
* json: move search by name to state
* object: move search by name to state
* pantavisor: move start and stop volumes and platforms to module state
* pantavisor: firmware and modules volumes are still mounted during the initialization of a new revision
* pantavisor: rest of volumes and platforms are initialized during WAIT state loop now
* parser: parse optional groups.json and group field in run.json of each platform
* parser: add conditions to platforms and groups
* parser: set default groups to platforms configured with runlevel
* platforms: add new platforms status (DATA, READY, BLOCKED, STARTING, STOPPING)
* platforms: new pv_group pointer to associate platforms and groups
* platforms: new list of condition references to associate platforms and conditions
* platforms: move search by name to state
* platforms: function to add and check conditions, check status and get json
* platforms: move code responsible of starting, stopping and checking list of platforms to state while keeping code to start, check and stop single platforms
* platforms: remove all runlevel code
* lxc plugin: use group name for container type setting
* state: store list of conditions and groups of platforms
* state: create data, root, platform and app default groups
* state: functions to add and fetch groups, platforms, objects, jsons and conditions
* state: set default group to platforms with neither group nor runlevel
* state: check platforms conditions are possible after parsing
* state: functions to start, run and stop state
* state: functions to report condition and get containers and conditions json
* state: modified non-reboot updates to adapt to the removal of runlevel
* updater: remove all runlevel code
* volumes: make function to mount bsp volumes public to be used by state
* volumes: move code responsible of mounting and unmounting list of volumes to state while keeping code to mount and unmount single volumes