### PR TITLE
add signature and format validation during step put

### DIFF
--- a/signature.c
+++ b/signature.c
@@ -739,7 +739,7 @@ static void pv_signature_parse_json(const char *json, struct dl_list *json_pairs
 	k = keys;
 
 	// platform head is pv->state->platforms
-	while (*k) {
+	while (k && *k) {
 		n = (*k)->end - (*k)->start;
 
 		pair = calloc(1, sizeof(struct pv_signature_pair));

--- a/storage.h
+++ b/storage.h
@@ -42,12 +42,14 @@ struct pv_path {
 	struct dl_list list;
 };
 
-char* pv_storage_get_rev_path(const char *rev);
 char* pv_storage_get_state_json_path(const char *rev);
 char* pv_storage_get_state_json(const char *rev);
+bool pv_storage_verify_state_json(const char *rev);
+
+char* pv_storage_get_rev_path(const char *rev);
 void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev);
 void pv_storage_set_rev_progress(const char *rev, const char *progress);
-void pv_storage_rm_rev(struct pantavisor *pv, const char *rev);
+void pv_storage_rm_rev(const char *rev);
 void pv_storage_set_active(struct pantavisor *pv);
 int pv_storage_update_factory(const char* rev);
 int pv_storage_make_config(struct pantavisor *pv);

--- a/updater.c
+++ b/updater.c
@@ -1852,7 +1852,7 @@ int pv_update_install(struct pantavisor *pv)
 	pv_update_set_status(pv, UPDATE_INSTALLED);
 out:
 	if (pending && (ret < 0))
-		pv_storage_rm_rev(pv, pending->rev);
+		pv_storage_rm_rev(pending->rev);
 
 	return ret;
 }


### PR DESCRIPTION
This MR makes pv-ctrl steps put to return an error if signature or format validation of the json goes wrong.

List of changes:
* ctrl: objects put wrong checksum returns now a 422 error
* ctrl: steps put wrong signature or format returns now a 422 error
* storate: new function to check signature and format of a stored revision