### PR TITLE
Status conditions

### DIFF
--- a/condition.c
+++ b/condition.c
@@ -29,12 +29,18 @@
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
-struct pv_condition* pv_condition_new(char *key, char *eval_value)
+struct pv_condition* pv_condition_new(const char *plat,
+	const char *key,
+	const char *eval_value)
 {
 	struct pv_condition *c;
 
+	if (!key || !eval_value)
+		return NULL;
+
 	c = calloc(1, sizeof(struct pv_condition));
 	if (c) {
+		c->plat = strdup(plat);
 		c->key = strdup(key);
 		c->eval_value = strdup(eval_value);
 		c->curr_value = strdup("");
@@ -47,6 +53,8 @@ void pv_condition_free(struct pv_condition *c)
 {
 	pv_log(DEBUG, "removing condition %s", c->key);
 
+	if (c->plat)
+		free(c->plat);
 	if (c->key)
 		free(c->key);
 	if (c->eval_value)
@@ -56,7 +64,7 @@ void pv_condition_free(struct pv_condition *c)
 	free(c);
 }
 
-void pv_condition_set_value(struct pv_condition *c, char *curr_value)
+void pv_condition_set_value(struct pv_condition *c, const char *curr_value)
 {
 	if (c->curr_value)
 		free(c->curr_value);
@@ -76,13 +84,14 @@ char *pv_condition_get_json(struct pv_condition *c)
 	int len;
 	char *json;
 
-	len = strlen(c->key) +
+	len = strlen(c->plat) +
+		strlen(c->key) +
 		strlen(c->eval_value) +
 		strlen(c->curr_value) +
-		strlen("{\"key\":\"\",\"eval_value\":\"\",\"curr_value\":\"\"}");
+		strlen("{\"platform\":\"\",\"key\":\"\",\"eval_value\":\"\",\"curr_value\":\"\"}");
 	json = calloc(1, (len + 1) * sizeof(char*));
-	snprintf(json, len + 1, "{\"key\":\"%s\",\"eval_value\":\"%s\",\"curr_value\":\"%s\"}",
-		c->key, c->eval_value, c->curr_value);
+	SNPRINTF_WTRUNC(json, len + 1, "{\"platform\":\"%s\",\"key\":\"%s\",\"eval_value\":\"%s\",\"curr_value\":\"%s\"}",
+		c->plat, c->key, c->eval_value, c->curr_value);
 
 	return json;
 }

--- a/condition.c
+++ b/condition.c
@@ -29,9 +29,7 @@
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
-struct pv_condition* pv_condition_new(const char *plat,
-	const char *key,
-	const char *eval_value)
+struct pv_condition* pv_condition_new(const char *plat, const char *key, const char *eval_value)
 {
 	struct pv_condition *c;
 
@@ -88,9 +86,9 @@ char *pv_condition_get_json(struct pv_condition *c)
 		strlen(c->key) +
 		strlen(c->eval_value) +
 		strlen(c->curr_value) +
-		strlen("{\"platform\":\"\",\"key\":\"\",\"eval_value\":\"\",\"curr_value\":\"\"}");
+		strlen("{\"container\":\"\",\"key\":\"\",\"eval_value\":\"\",\"curr_value\":\"\"}");
 	json = calloc(1, (len + 1) * sizeof(char*));
-	SNPRINTF_WTRUNC(json, len + 1, "{\"platform\":\"%s\",\"key\":\"%s\",\"eval_value\":\"%s\",\"curr_value\":\"%s\"}",
+	SNPRINTF_WTRUNC(json, len + 1, "{\"container\":\"%s\",\"key\":\"%s\",\"eval_value\":\"%s\",\"curr_value\":\"%s\"}",
 		c->plat, c->key, c->eval_value, c->curr_value);
 
 	return json;

--- a/condition.h
+++ b/condition.h
@@ -27,16 +27,19 @@
 #include "utils/list.h"
 
 struct pv_condition {
+	char *plat;
 	char *key;
 	char *eval_value;
 	char *curr_value;
 	struct dl_list list; // pv_condition
 };
 
-struct pv_condition* pv_condition_new(char *key, char *eval_value);
+struct pv_condition* pv_condition_new(const char *plat,
+	const char *key,
+	const char *eval_value);
 void pv_condition_free(struct pv_condition *c);
 
-void pv_condition_set_value(struct pv_condition *c, char *curr_value);
+void pv_condition_set_value(struct pv_condition *c, const char *curr_value);
 bool pv_condition_check(struct pv_condition *c);
 
 char *pv_condition_get_json(struct pv_condition *c);

--- a/condition.h
+++ b/condition.h
@@ -34,9 +34,7 @@ struct pv_condition {
 	struct dl_list list; // pv_condition
 };
 
-struct pv_condition* pv_condition_new(const char *plat,
-	const char *key,
-	const char *eval_value);
+struct pv_condition* pv_condition_new(const char *plat, const char *key, const char *eval_value);
 void pv_condition_free(struct pv_condition *c);
 
 void pv_condition_set_value(struct pv_condition *c, const char *curr_value);

--- a/group.c
+++ b/group.c
@@ -35,27 +35,9 @@ struct pv_group* pv_group_new(char *name)
 	g = calloc(1, sizeof(struct pv_group));
 	if (g) {
 		g->name = strdup(name);
-		dl_list_init(&g->condition_refs);
 	}
 
 	return g;
-}
-
-static void pv_group_empty_condition_refs(struct pv_group *g)
-{
-	int num_conditions = 0;
-	struct pv_condition_ref *cr, *tmp;
-	struct dl_list *condition_refs = &g->condition_refs;
-
-	// Iterate over all condition references from group
-	dl_list_for_each_safe(cr, tmp, condition_refs,
-			struct pv_condition_ref, list) {
-		dl_list_del(&cr->list);
-		pv_condition_ref_free(cr);
-		num_conditions++;
-	}
-
-	pv_log(INFO, "removed %d condition references", num_conditions);
 }
 
 void pv_group_free(struct pv_group *g)
@@ -64,19 +46,5 @@ void pv_group_free(struct pv_group *g)
 
 	if (g->name)
 		free(g->name);
-	pv_group_empty_condition_refs(g);
 	free(g);
-}
-
-void pv_group_add_condition_ref(struct pv_group *g, struct pv_condition *c)
-{
-	struct pv_condition_ref *cr;
-
-	pv_log(DEBUG, "adding condition reference %s to group", c->key);
-
-	cr = pv_condition_ref_new(c);
-	if (cr) {
-		dl_list_init(&cr->list);
-		dl_list_add_tail(&g->condition_refs, &cr->list);
-	}
 }

--- a/group.h
+++ b/group.h
@@ -27,13 +27,10 @@
 
 struct pv_group {
 	char *name;
-	struct dl_list condition_refs; // pv_condition_ref
 	struct dl_list list; // pv_group
 };
 
 struct pv_group* pv_group_new(char *name);
 void pv_group_free(struct pv_group *g);
-
-void pv_group_add_condition_ref(struct pv_group *g, struct pv_condition *c);
 
 #endif // PV_GROUP_H

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -242,8 +242,8 @@ static struct pv_condition* parse_condition(struct pv_state *s, char *value)
 		goto out;
 	}
 
-	plat = pv_json_get_value(value, "platform", condv, condc);
-	// accept all platforms by default
+	plat = pv_json_get_value(value, "container", condv, condc);
+	// accept all containers by default
 	if (!plat)
 		plat = strdup("*");
 

--- a/platforms.c
+++ b/platforms.c
@@ -97,16 +97,28 @@ struct pv_cont_ctrl cont_ctrl[PV_CONT_MAX] = {
 //	{ "docker", start_docker_platform, stop_docker_platform }
 };
 
-typedef enum {
-	PLAT_NONE,
-	PLAT_DATA,
-	PLAT_READY,
-	PLAT_BLOCKED,
-	PLAT_STARTING,
-	PLAT_STARTED,
-	PLAT_STOPPING,
-	PLAT_STOPPED
-} plat_status_t;
+static const char* pv_platform_status_string(plat_status_t status)
+{
+	switch(status) {
+		case PLAT_NONE: return "NONE";
+		case PLAT_MOUNTED: return "MOUNTED";
+		case PLAT_READY: return "READY";
+		case PLAT_BLOCKED: return "BLOCKED";
+		case PLAT_STARTING: return "STARTING";
+		case PLAT_STARTED: return "STARTED";
+		case PLAT_STOPPING: return "STOPPING";
+		case PLAT_STOPPED: return "STOPPED";
+		default: return "UNKNOWN";
+	}
+
+	return "UNKNOWN";
+}
+
+static void pv_platform_set_status(struct pv_platform *p, plat_status_t status)
+{
+	p->status = status;
+	pv_state_report_condition(p->state, p->name, "status", pv_platform_status_string(status));
+}
 
 struct pv_platform* pv_platform_add(struct pv_state *s, char *name)
 {
@@ -117,6 +129,7 @@ struct pv_platform* pv_platform_add(struct pv_state *s, char *name)
 		p->status = PLAT_NONE;
 		p->mgmt = true;
 		p->updated = false;
+		p->state = s;
 		dl_list_init(&p->condition_refs);
 		dl_list_init(&p->logger_list);
 		dl_list_init(&p->logger_configs);
@@ -219,23 +232,6 @@ void pv_platform_add_condition(struct pv_platform *p, struct pv_condition *c)
 	}
 }
 
-static const char* pv_platform_status_string(plat_status_t status)
-{
-	switch(status) {
-		case PLAT_NONE: return "NONE";
-		case PLAT_DATA: return "DATA";
-		case PLAT_READY: return "READY";
-		case PLAT_BLOCKED: return "BLOCKED";
-		case PLAT_STARTING: return "STARTING";
-		case PLAT_STARTED: return "STARTED";
-		case PLAT_STOPPING: return "STOPPING";
-		case PLAT_STOPPED: return "STOPPED";
-		default: return "UNKNOWN";
-	}
-
-	return "UNKNOWN";
-}
-
 char* pv_platform_get_json(struct pv_platform *p)
 {
 	int len, line_len;
@@ -263,11 +259,9 @@ char* pv_platform_get_json(struct pv_platform *p)
 			continue;
 
 		line = pv_condition_get_json(cr->ref);
-		pv_log(DEBUG, "line %s", line);
 		line_len = strlen(line) + 1;
 		json = realloc(json, len + line_len + 1);
 		SNPRINTF_WTRUNC(&json[len], line_len + 1, "%s,", line);
-		pv_log(DEBUG, "json %s", json);
 		len += line_len;
 		free(line);
 	}
@@ -574,7 +568,7 @@ int pv_platform_start(struct pv_platform *p)
 	if (pid <= 0)
 		return -1;
 
-	p->status = PLAT_STARTING;
+	pv_platform_set_status(p, PLAT_STARTING);
 
 	if (pv_config_get_log_loggers())
 		if (start_pvlogger_for_platform(p) < 0)
@@ -643,7 +637,7 @@ int pv_platform_stop(struct pv_platform *p)
 	ctrl = _pv_platforms_get_ctrl(p->type);
 	ctrl->stop(p, NULL, p->data);
 	p->data = NULL;
-	p->status = PLAT_STOPPING;
+	pv_platform_set_status(p, PLAT_STOPPING);
 
 	return 0;
 }
@@ -652,21 +646,21 @@ void pv_platform_force_stop(struct pv_platform *p)
 {
 	pv_log(DEBUG, "force stopping platform '%s'", p->name);
 	kill(p->init_pid, SIGKILL);
-	p->status = PLAT_STOPPED;
+	pv_platform_set_status(p, PLAT_STOPPED);
 }
 
 void pv_platform_set_ready(struct pv_platform *p)
 {
-	p->status = PLAT_READY;
+	pv_platform_set_status(p, PLAT_READY);
 
 	if (p->group &&
 		pv_str_matches(p->group->name, strlen(p->group->name), "data", strlen("data")))
-		p->status = PLAT_DATA;
+		pv_platform_set_status(p, PLAT_MOUNTED);
 }
 
 void pv_platform_set_blocked(struct pv_platform *p)
 {
-	p->status = PLAT_BLOCKED;
+	pv_platform_set_status(p, PLAT_BLOCKED);
 }
 
 void pv_platform_set_updated(struct pv_platform *p)
@@ -682,12 +676,12 @@ int pv_platform_check_running(struct pv_platform *p)
 	if (running) {
 		if ((p->status != PLAT_STARTED) && (p->status != PLAT_STOPPING)) {
 			pv_log(DEBUG, "platform %s started", p->name);
-			p->status = PLAT_STARTED;
+			pv_platform_set_status(p, PLAT_STARTED);
 		}
 	} else {
 		if ((p->status != PLAT_STOPPED) && (p->status != PLAT_STARTING)) {
 			pv_log(DEBUG, "platform %s stopped", p->name);
-			p->status = PLAT_STOPPED;
+			pv_platform_set_status(p, PLAT_STOPPED);
 		}
 	}
 

--- a/platforms.h
+++ b/platforms.h
@@ -30,6 +30,17 @@
 #include "condition.h"
 #include "utils/list.h"
 
+typedef enum {
+	PLAT_NONE,
+	PLAT_MOUNTED,
+	PLAT_READY,
+	PLAT_BLOCKED,
+	PLAT_STARTING,
+	PLAT_STARTED,
+	PLAT_STOPPING,
+	PLAT_STOPPED
+} plat_status_t;
+
 struct pv_platform {
 	char *name;
 	char *type;
@@ -40,6 +51,7 @@ struct pv_platform {
 	pid_t init_pid;
 	plat_status_t status;
 	struct pv_group *group;
+	struct pv_state *state;
 	bool mgmt;
 	bool updated;
 	struct dl_list condition_refs; // pv_condition_ref

--- a/platforms.h
+++ b/platforms.h
@@ -30,17 +30,6 @@
 #include "condition.h"
 #include "utils/list.h"
 
-typedef enum {
-	PLAT_NONE,
-	PLAT_DATA,
-	PLAT_READY,
-	PLAT_BLOCKED,
-	PLAT_STARTING,
-	PLAT_STARTED,
-	PLAT_STOPPING,
-	PLAT_STOPPED
-} plat_status_t;
-
 struct pv_platform {
 	char *name;
 	char *type;

--- a/state.h
+++ b/state.h
@@ -74,8 +74,10 @@ struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name);
 struct pv_platform* pv_state_fetch_platform(struct pv_state *s, const char *name);
 struct pv_object* pv_state_fetch_object(struct pv_state *s, const char *name);
 struct pv_json* pv_state_fetch_json(struct pv_state *s, const char *name);
-struct pv_condition* pv_state_fetch_condition(struct pv_state *s, const char *key);
-struct pv_condition* pv_state_fetch_condition_value(struct pv_state *s, const char *key, const char *eval_value);
+struct pv_condition* pv_state_fetch_condition_value(struct pv_state *s,
+	const char *plat,
+	const char *key,
+	const char *eval_value);
 
 state_spec_t pv_state_spec(struct pv_state *s);
 
@@ -89,7 +91,10 @@ int pv_state_stop(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
-int pv_state_report_condition(struct pv_state *s, char *plat, char *key, char *value);
+int pv_state_report_condition(struct pv_state *s,
+	const char *plat,
+	const char *key,
+	const char *value);
 
 void pv_state_print(struct pv_state *s);
 char* pv_state_get_containers_json(struct pv_state *s);

--- a/state.h
+++ b/state.h
@@ -91,11 +91,7 @@ int pv_state_stop(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
-int pv_state_report_condition(struct pv_state *s,
-	const char *plat,
-	const char *key,
-	const char *value);
-
+int pv_state_report_condition(struct pv_state *s, const char *plat, const char *key, const char *value); 
 void pv_state_print(struct pv_state *s);
 char* pv_state_get_containers_json(struct pv_state *s);
 char* pv_state_get_conditions_json(struct pv_state *s);


### PR DESCRIPTION
This PR allows for platforms to report their status changes as conditions. It also introduces default conditions between groups (old runlevels) so they are started in order depending on conditions

List of changes:
* condition: add platform field to struct
* group: remove condition refs as conditions are no longer attached to groups
* parser: parse container field in conditions and set * as default when not explicitly defined
* parser: remove unused function to parse group conditions
* platforms: status in now modified in one function that reports changes as conditions
* platforms: fix platform json regression introduced with the deletion of group.json
* platform: remove checking of group condition references
* state: fetch conditions with platform
* state: remove transfer of group conditions ref
* state: iterate over all conditions when reporting to allow several conditions with same key but different plats or values
* state: fix containers and conditions json when returning empty arrays