### PR TITLE
rollback if any condition is not met when rollback timer times out

### DIFF
--- a/config.c
+++ b/config.c
@@ -202,6 +202,7 @@ static int pv_config_load_config_from_file(char *path, struct pantavisor_config 
 	config->net.braddress4 = config_get_value_string(&config_list, "net.braddress4", "10.0.3.1");
 	config->net.brmask4 = config_get_value_string(&config_list, "net.brmask4", "255.255.255.0");
 
+	config->updater.conditions_timeout = config_get_value_int(&config_list, "updater.conditions.timeout", 2 * 60);
 	config->updater.use_tmp_objects = config_get_value_bool(&config_list, "updater.use_tmp_objects", false);
 
 	config->updater.revision_retries = config_get_value_int(&config_list, "revision.retries", 10);
@@ -285,6 +286,7 @@ static int pv_config_override_config_from_file(char *path, struct pantavisor_con
 	config_override_value_int(&config_list, "revision.retries.timeout", &config->updater.revision_retry_timeout);
 	config_override_value_bool(&config_list, "updater.keep_factory", &config->storage.gc.keep_factory);
 	config_override_value_int(&config_list, "updater.interval", &config->updater.interval);
+	config_override_value_int(&config_list, "updater.conditions.timeout", &config->updater.conditions_timeout);
 	config_override_value_int(&config_list, "updater.network_timeout", &config->updater.network_timeout);
 	config_override_value_int(&config_list, "updater.commit.delay", &config->updater.commit_delay);
 
@@ -528,6 +530,7 @@ int pv_config_get_storage_gc_threshold() { return pv_get_instance()->config.stor
 int pv_config_get_storage_gc_threshold_defertime() { return pv_get_instance()->config.storage.gc.threshold_defertime; }
 
 int pv_config_get_updater_interval() { return pv_get_instance()->config.updater.interval; }
+int pv_config_get_updater_conditions_timeout() { return pv_get_instance()->config.updater.conditions_timeout; }
 int pv_config_get_updater_network_timeout() { return pv_get_instance()->config.updater.network_timeout; }
 bool pv_config_get_updater_network_use_tmp_objects() { return pv_get_instance()->config.updater.use_tmp_objects; }
 int pv_config_get_updater_revision_retries() { return pv_get_instance()->config.updater.revision_retries; }

--- a/config.h
+++ b/config.h
@@ -81,6 +81,7 @@ struct pantavisor_storage {
 
 struct pantavisor_updater {
 	int interval;
+	int conditions_timeout;
 	int network_timeout;
 	bool use_tmp_objects;
 	int revision_retries;
@@ -194,6 +195,7 @@ int pv_config_get_storage_gc_threshold(void);
 int pv_config_get_storage_gc_threshold_defertime(void);
 
 int pv_config_get_updater_interval(void);
+int pv_config_get_updater_conditions_timeout(void);
 int pv_config_get_updater_network_timeout(void);
 bool pv_config_get_updater_network_use_tmp_objects(void);
 int pv_config_get_updater_revision_retries(void);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -77,7 +77,8 @@ struct pantavisor* pv_get_instance()
 	return global_pv;
 }
 
-static struct timer rollback_timer;
+static struct timer timer_rollback_remote;
+static struct timer timer_rollback_conditions;
 static struct timer timer_wait_delay;
 static struct timer timer_commit;
 
@@ -262,7 +263,8 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	}
 
 	timer_start(&timer_commit, 0, 0, RELATIV_TIMER);
-	timer_start(&rollback_timer, pv_config_get_updater_network_timeout(), 0, RELATIV_TIMER);
+	timer_start(&timer_rollback_remote, pv_config_get_updater_network_timeout(), 0, RELATIV_TIMER);
+	timer_start(&timer_rollback_conditions, pv_config_get_updater_conditions_timeout(), 0, RELATIV_TIMER);
 
 	next_state = PV_STATE_WAIT;
 out:
@@ -346,7 +348,7 @@ static pv_state_t pv_wait_update()
 		if (pv_update_is_trying(pv->update)) {
 			// rollback if timed out and any condition has not been met
 			if (!pv_state_check_conditions(pv->state))	{
-				tstate = timer_current_state(&rollback_timer);
+				tstate = timer_current_state(&timer_rollback_conditions);
 				if (tstate.fin) {
 					pv_log(ERROR, "timed out before all conditions are met. Rolling back...");
 					return PV_STATE_ROLLBACK;
@@ -387,7 +389,7 @@ static pv_state_t pv_wait_network(struct pantavisor *pv)
 		!pv_trail_is_auth(pv)) {
 		// this could mean the trying update cannot connect to ph
 		if (pv_update_is_trying(pv->update)) {
-			tstate = timer_current_state(&rollback_timer);
+			tstate = timer_current_state(&timer_rollback_remote);
 			if (tstate.fin) {
 				pv_log(ERROR, "timed out before getting any response from cloud. Rolling back...");
 				return PV_STATE_ROLLBACK;

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -439,7 +439,7 @@ static pv_state_t _pv_wait(struct pantavisor *pv)
 
 	// check if any platform has exited and we need to tear down
 	if (pv_state_run(pv->state)) {
-		pv_log(ERROR, "one or more platforms exited. Tearing down...");
+		pv_log(ERROR, "a platform did not work as expected. Tearing down...");
 		if (pv_update_is_trying(pv->update) || pv_update_is_testing(pv->update))
 			next_state = PV_STATE_ROLLBACK;
 		else

--- a/platforms.c
+++ b/platforms.c
@@ -116,6 +116,9 @@ static const char* pv_platform_status_string(plat_status_t status)
 
 static void pv_platform_set_status(struct pv_platform *p, plat_status_t status)
 {
+	if (p->status == status)
+		return;
+
 	p->status = status;
 	pv_state_report_condition(p->state, p->name, "status", pv_platform_status_string(status));
 }

--- a/state.c
+++ b/state.c
@@ -1080,6 +1080,26 @@ int pv_state_report_condition(struct pv_state *s, const char *plat, const char *
 	return 0;
 }
 
+bool pv_state_check_conditions(struct pv_state *s)
+{
+	struct pv_condition *c, *tmp;
+
+	if (!s)
+		return false;
+
+	if (dl_list_empty(&s->conditions))
+		goto out;
+
+	dl_list_for_each_safe(c, tmp, &s->conditions,
+			struct pv_condition, list) {
+		if (!pv_condition_check(c))
+			return false;
+	}
+
+out:
+	return true;
+}
+
 char* pv_state_get_containers_json(struct pv_state *s)
 {
 	int len = 1, line_len;

--- a/state.c
+++ b/state.c
@@ -473,8 +473,10 @@ static int pv_state_start_platform(struct pv_state *s, struct pv_platform *p)
 	dl_list_for_each_safe(v, tmp, &s->volumes,
 			struct pv_volume, list) {
 		if (v->plat == p)
-			if (pv_volume_mount(v))
+			if (pv_volume_mount(v)) {
+				pv_log(ERROR, "volume %s could not be mounted", v->name);
 				return -1;
+			}
 	}
 
 	pv_platform_set_mounted(p);
@@ -482,8 +484,10 @@ static int pv_state_start_platform(struct pv_state *s, struct pv_platform *p)
 	if (pv_str_matches(p->group->name, strlen(p->group->name), "data", strlen("data")))
 		return 0;
 
-	if (pv_platform_start(p))
+	if (pv_platform_start(p)) {
+		pv_log(ERROR, "platform %s could not be started", p->name);
 		return -1;
+	}
 
 	return 0;
 }
@@ -505,7 +509,7 @@ int pv_state_run(struct pv_state *s)
 				pv_log(DEBUG, "platform %s still not running", p->name);
 		} else if (pv_platform_is_started(p)) {
 			if (!pv_platform_check_running(p)) {
-				pv_log(DEBUG, "platform %s suddenly stopped", p->name);
+				pv_log(ERROR, "platform %s suddenly stopped", p->name);
 				ret = -1;
 			}
 		}

--- a/state.h
+++ b/state.h
@@ -91,7 +91,9 @@ int pv_state_stop(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
-int pv_state_report_condition(struct pv_state *s, const char *plat, const char *key, const char *value); 
+int pv_state_report_condition(struct pv_state *s, const char *plat, const char *key, const char *value);
+bool pv_state_check_conditions(struct pv_state *s);
+
 void pv_state_print(struct pv_state *s);
 char* pv_state_get_containers_json(struct pv_state *s);
 char* pv_state_get_conditions_json(struct pv_state *s);


### PR DESCRIPTION
This PR adds rollback to the local experience

List of changes:
* config: new updater.conditions.timeout int configuration key
* pantavisor: add timer for conditions timeout
* pantavisor: rollback if conditions timeout timer times out before all current state conditions are satisfied
* platforms: only report status condition when a change in the status has occured
* state: new function to check if all state conditions are met
* general: improve logs when starting and mounting plats and vols