### PR TITLE
ignore _sigs when considering if reboot is necessary during update

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -47,6 +47,7 @@
 #include "condition.h"
 #include "state.h"
 #include "pvlogger.h"
+#include "utils/str.h"
 
 #define PV_NS_NETWORK	0x1
 #define PV_NS_UTS	0x2
@@ -966,15 +967,9 @@ static void system1_link_object_json_platforms(struct pv_state *s)
 		struct pv_object, list) {
 		name = strdup(o->name);
 		dir = strtok(name, "/");
-		if (!strcmp(dir, "_config")) {
+		if (!strcmp(dir, "_config"))
 			dir = strtok(NULL, "/");
-			o->plat = pv_state_fetch_platform(s, dir);
-			if (!o->plat) {
-				pv_log(WARN, "discarding unassociated object '%s'", o->name);
-				pv_objects_remove(o);
-			}
-		} else
-			o->plat = pv_state_fetch_platform(s, dir);
+		o->plat = pv_state_fetch_platform(s, dir);
 		free(name);
 	}
 
@@ -985,15 +980,9 @@ link_jsons:
 		struct pv_json, list) {
 		name = strdup(j->name);
 		dir = strtok(name, "/");
-		if (!strcmp(dir, "_config")) {
+		if (!strcmp(dir, "_config"))
 			dir = strtok(NULL, "/");
-			j->plat = pv_state_fetch_platform(s, dir);
-			if (!j->plat) {
-				pv_log(WARN, "discarding unassociated json '%s'", j->name);
-				pv_jsons_remove(j);
-			}
-		} else
-			j->plat = pv_state_fetch_platform(s, dir);
+		j->plat = pv_state_fetch_platform(s, dir);
 		free(name);
 	}
 }
@@ -1094,7 +1083,8 @@ struct pv_state* system1_parse(struct pv_state *this, const char *buf)
 			pv_jsons_add(this, key, value);
 		// if the extension is either src.json or build.json, we ignore it
 		} else if (ext && (!strcmp(ext, "/src.json") ||
-					!strcmp(ext, "/build.json"))) {
+					!strcmp(ext, "/build.json") ||
+					pv_str_startswith("_sigs/", strlen("_sigs/"), key))) {
 			pv_log(DEBUG, "skipping '%s'", key);
 		// if the extension is other .json, we add it to the list of jsons
 		} else if ((ext = strrchr(key, '.')) && !strcmp(ext, ".json")) {

--- a/signature.c
+++ b/signature.c
@@ -711,11 +711,11 @@ static bool pv_signature_verify_sha(const char *payload, struct dl_list *certs_r
 
 	res = mbedtls_pk_verify(pk, mdtype, hash, 0, (unsigned char*)sig_decoded, olen);
 	if (res) {
-		pv_log(ERROR, "verification returned error code %d sig: %s", res, sig_decoded);
+		pv_log(ERROR, "verification returned error code %d", res);
 		goto out;
 	}
 
-	pv_log(ERROR, "signature OK");
+	pv_log(DEBUG, "signature OK");
 	ret = true;
 
 out:
@@ -891,6 +891,9 @@ bool pv_signature_verify(const char *json)
 {
 	bool ret = false;
 	struct dl_list json_pairs; // pv_signature_pair
+
+	if (!json)
+		return false;
 
 	if (pv_config_get_secureboot_mode() == SB_DISABLED)
 		return true;

--- a/state.c
+++ b/state.c
@@ -199,6 +199,9 @@ struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name)
 {
 	struct pv_group *g, *tmp;
 
+	if (!name)
+		return NULL;
+
 	// Iterate over all groups from state
 	dl_list_for_each_safe(g, tmp, &s->groups,
             struct pv_group, list) {
@@ -212,6 +215,9 @@ struct pv_group* pv_state_fetch_group(struct pv_state *s, const char *name)
 struct pv_platform* pv_state_fetch_platform(struct pv_state *s, const char *name)
 {
 	struct pv_platform *p, *tmp;
+
+	if (!name)
+		return NULL;
 
 	// Iterate over all platforms from state
 	dl_list_for_each_safe(p, tmp, &s->platforms,
@@ -227,6 +233,9 @@ struct pv_object* pv_state_fetch_object(struct pv_state *s, const char *name)
 {
 	struct pv_object *o, *tmp;
 
+	if (!name)
+		return NULL;
+
 	// Iterate over all objects from state
 	dl_list_for_each_safe(o, tmp, &s->objects,
             struct pv_object, list) {
@@ -240,6 +249,9 @@ struct pv_object* pv_state_fetch_object(struct pv_state *s, const char *name)
 struct pv_json* pv_state_fetch_json(struct pv_state *s, const char *name)
 {
 	struct pv_json *j, *tmp;
+
+	if (!name)
+		return NULL;
 
 	// Iterate over all groups from state
 	dl_list_for_each_safe(j, tmp, &s->jsons,
@@ -257,6 +269,9 @@ struct pv_condition* pv_state_fetch_condition_value(struct pv_state *s,
 	const char *eval_value)
 {
 	struct pv_condition *c, *tmp;
+
+	if (!plat || !key || !eval_value)
+		return NULL;
 
 	// Iterate over all conditions from state
 	dl_list_for_each_safe(c, tmp, &s->conditions,

--- a/updater.c
+++ b/updater.c
@@ -1733,6 +1733,11 @@ struct pv_update* pv_update_get_step_local(char *rev)
 		goto err;
 
 	json = pv_storage_get_state_json(rev);
+	if (!json) {
+		pv_log(ERROR, "Could not read state json");
+		goto err;
+	}
+
 	if (!pv_signature_verify(json)) {
 		trail_remote_set_status(pv, update, UPDATE_NO_SIGNATURE, NULL);
 		pv_log(WARN, "state signature verification went wrong");


### PR DESCRIPTION
This change removes the files under _sigs/ to be considered in the reboot during an update transition. From now on, files in _sigs/ will only be considered for the signature verification, which is done independently in these places:
* after a reboot and before the current JSON state is parsed
* after downloading a new JSON state from remote and before is parsed
* before installing a new revision using pv-ctrl
* before running a revision using pv-ctrl
* before running the factory revision using pv-ctrl

List of detailed changes:
* parser: ignore _sigs/ files when parsing a JSON state
* signature: fix some log traces
* state: avoid crashes when fetching for objects, jsons, conditions, etc with NULL names
* updater: fix crash when json was not present after a pvcontrol commands run