### PR TITLE
refactor: centralize all non /dev or /proc path formatting in paths.h

### DIFF
--- a/addons.c
+++ b/addons.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantacor Ltd.
+ * Copyright (c) 2018-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,8 +39,6 @@
 #define MODULE_NAME             "addon"
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
-
-#define FW_PATH		"/lib/firmware"
 
 static void pv_addon_free(struct pv_addon *a)
 {

--- a/atom.mk
+++ b/atom.mk
@@ -86,7 +86,8 @@ LOCAL_SRC_FILES := init.c \
 			ph_logger/ph_logger.c \
 			ph_logger/ph_logger_v1.c \
 			buffer.c \
-			blkid.c
+			blkid.c \
+			paths.c
 
 LOCAL_INSTALL_HEADERS := log.h
 LOCAL_GENERATED_SRC_FILES := version.c

--- a/grub.c
+++ b/grub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantacor Ltd.
+ * Copyright (c) 2018-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,9 +26,10 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-
+#include <linux/limits.h>
 #include <sys/stat.h>
 
+#include "paths.h"
 #include "bootloader.h"
 #include "utils/str.h"
 
@@ -36,7 +37,6 @@
 #define pv_log(level, msg, ...)		vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
-#define GRUB_FMT		"%s/boot/grubenv"
 #define GRUB_HDR		"# GRUB Environment Block\n"
 #define HDR_SIZE		sizeof(GRUB_HDR)-1
 
@@ -45,13 +45,13 @@ static char *grub_env = 0;
 static int grub_init()
 {
 	int fd, ret;
-	char buf[1024];
+	char buf[PATH_MAX];
 	struct stat st;
 
 	if (grub_env)
 		return 0;
 
-	SNPRINTF_WTRUNC(buf, sizeof (buf), GRUB_FMT, pv_config_get_storage_mntpoint());
+	pv_paths_storage_boot_file(buf, PATH_MAX, GRUBENV_FNAME);
 	grub_env  = strdup(buf);
 
 	if (stat(grub_env, &st))

--- a/init.c
+++ b/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -159,10 +159,21 @@ static int early_mounts()
 }
 
 #ifdef PANTAVISOR_DEBUG
+#define DBCMD "dropbear -p 0.0.0.0:8222 -n %s -R -c /usr/bin/fallbear-cmd"
+
 static void debug_telnet()
 {
+	char *dbcmd;
+	char path[PATH_MAX];
+
+	pv_paths_pv_usrmeta_key(path, PATH_MAX, SSH_KEY_FNAME);
+	dbcmd = calloc(1, sizeof(DBCMD) + strlen(path) + 1);
+	sprintf(dbcmd, DBCMD, path);
+
 	tsh_run("ifconfig lo up", 0, NULL);
-	tsh_run("dropbear -p 0.0.0.0:8222 -n "PV_USER_META_PATH"/pvr-sdk.authorized_keys -R -c /usr/bin/fallbear-cmd", 0, NULL);
+	tsh_run(dbcmd, 0, NULL);
+
+	free(dbcmd);
 }
 #else
 static void debug_telnet()

--- a/log.h
+++ b/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,10 +39,6 @@ enum log_level {
 	DEBUG,	// 4
 	ALL	// 5
 };
-
-#define LOG_NAME		"pantavisor.log"
-#define ERROR_DIR		"error"
-
 
 #define JSON_FORMAT	"{ \"tsec\": %"PRId64", \"tnano\": %"PRId32", \"lvl\": \"%s\", \"src\": \"%s\", \"msg\": \"%s\" }"
 

--- a/objects.h
+++ b/objects.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,8 +34,8 @@ struct pv_object {
 	char *name;
 	char *id;
 	char *geturl;
-	char objpath[PATH_MAX];
-	char relpath[PATH_MAX];
+	char *objpath;
+	char *relpath;
 	off_t size;
 	char *sha256;
 	struct pv_platform *plat;
@@ -57,6 +57,10 @@ static inline void pv_object_free(struct pv_object *obj)
 		free(obj->id);
 	if (obj->geturl)
 		free(obj->geturl);
+	if (obj->objpath)
+		free(obj->objpath);
+	if (obj->relpath)
+		free(obj->relpath);
 	if (obj->sha256)
 		free(obj->sha256);
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -281,6 +281,7 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 {
 	int need_register = 1;
 	char *c;
+	char path[PATH_MAX];
 
 	c = calloc(1, sizeof(char) * 128);
 
@@ -316,7 +317,8 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 		pv->unclaimed = false;
 		pv_config_save_creds();
 		pv_ph_release_client(pv);
-		open(PV_CHALLENGE_PATH, O_TRUNC | O_WRONLY);
+		pv_paths_pv_file(path, PATH_MAX, CHALLENGE_FNAME);
+		open(path, O_TRUNC | O_WRONLY);
 		pv_metadata_add_devmeta("pantahub.claimed", "1");
 	}
 
@@ -658,6 +660,8 @@ static int shutdown_type_reboot_cmd(shutdown_type_t t) {
 
 static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 {
+	char path[PATH_MAX];
+
 	pv_log(INFO, "prepare %s...", shutdown_type_string(t));
 	wait_shell();
 
@@ -669,7 +673,8 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 		pv_wdt_start(pv);
 
 	// unmount storage
-	umount(pv_config_get_storage_mntpoint());
+	pv_paths_storage(path, PATH_MAX);
+	umount(path);
 	sync();
 
 	sleep(5);

--- a/paths.c
+++ b/paths.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+
+#include "paths.h"
+#include "utils/str.h"
+
+#define MODULE_NAME             "paths"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
+#include "log.h"
+
+#define PV_PATH  "/pv"
+#define PV_PATHF PV_PATH"/%s"
+
+void pv_paths_pv_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_PATHF, name);
+}
+
+#define PV_USRMETA_PATHF      PV_PATH"/"USRMETA_DNAME"/%s"
+#define PV_USRMETA_PLAT_PATHF PV_PATH"/user-meta.%s/%s"
+
+void pv_paths_pv_usrmeta_key(char *buf, size_t size, const char *key)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PATHF, key);
+}
+
+void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, const char *key)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PLAT_PATHF, plat, key);
+}
+
+#define PV_LOGS_PATHF      PV_PATH"/"LOGS_DNAME"/%s"
+#define PV_LOGS_PLAT_PATHF PV_LOGS_PATHF"/%s"
+#define PV_LOGS_FILE_PATHF PV_LOGS_PLAT_PATHF"/%s"
+
+void pv_paths_pv_log(char *buf, size_t size, const char *rev)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PATHF, rev);
+}
+
+void pv_paths_pv_log_plat(char *buf, size_t size, const char *rev, const char *plat)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PLAT_PATHF, rev, plat);
+}
+
+void pv_paths_pv_log_file(char *buf, size_t size, const char *rev, const char *plat, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_FILE_PATHF, rev, plat, name);
+}
+
+#define PV_STORAGE_PATHF "%s"
+
+void pv_paths_storage(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_storage_mntpoint());
+}
+
+void pv_paths_storage_log(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_log_logdir());
+}
+
+void pv_paths_storage_meta(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_metacachedir());
+}
+
+void pv_paths_storage_dropbear(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_dropbearcachedir());
+}
+
+#define PV_OBJECT_PATHF     "%s/objects/%s"
+#define PV_OBJECT_TMP_PATHF PV_OBJECT_PATHF".tmp"
+
+void pv_paths_storage_object(char *buf, size_t size, const char *sha)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_OBJECT_PATHF, pv_config_get_storage_mntpoint(), sha);
+}
+
+void pv_paths_storage_object_tmp(char *buf, size_t size, const char *sha)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_OBJECT_TMP_PATHF, pv_config_get_storage_mntpoint(), sha);
+}
+
+#define PV_TRAILS_PATHF           "%s/trails/%s/"
+#define PV_TRAILS_FILE_PATHF      PV_TRAILS_PATHF"%s"
+#define PV_TRAILS_PLAT_FILE_PATHF PV_TRAILS_PATHF"%s/%s"
+#define PV_TRAILS_CONFIG_PATHF    PV_TRAILS_PATHF"_config/"
+#define PV_TRAILS_PV_PATHF        PV_TRAILS_PATHF".pv/%s"
+#define PV_TRAILS_PVR_PATHF       PV_TRAILS_PATHF".pvr/%s"
+
+void pv_paths_storage_trail(char *buf, size_t size, const char *rev)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PATHF, pv_config_get_storage_mntpoint(), rev);
+}
+
+void pv_paths_storage_trail_file(char *buf, size_t size, const char *rev, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_FILE_PATHF, pv_config_get_storage_mntpoint(), rev, name);
+}
+
+void pv_paths_storage_trail_plat_file(char *buf, size_t size, const char *rev, const char *plat, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PLAT_FILE_PATHF, pv_config_get_storage_mntpoint(), rev, plat, name);
+}
+
+void pv_paths_storage_trail_config(char *buf, size_t size, const char *rev)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_CONFIG_PATHF, pv_config_get_storage_mntpoint(), rev);
+}
+
+void pv_paths_storage_trail_pv_file(char *buf, size_t size, const char *rev, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PV_PATHF, pv_config_get_storage_mntpoint(), rev, name);
+}
+
+void pv_paths_storage_trail_pvr_file(char *buf, size_t size, const char *rev, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PVR_PATHF, pv_config_get_storage_mntpoint(), rev, name);
+}
+
+#define PV_CONFIG_PATHF "%s/config/%s"
+
+void pv_paths_storage_config_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_CONFIG_PATHF, pv_config_get_storage_mntpoint(), name);
+}
+
+#define PV_BOOT_PATHF "%s/boot/%s"
+
+void pv_paths_storage_boot_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_BOOT_PATHF, pv_config_get_storage_mntpoint(), name);
+}
+
+#define PV_STORAGE_FACTORY_META_PATHF "%s/factory/meta/%s"
+
+void pv_paths_storage_factory_meta_key(char *buf, size_t size, const char *key)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_FACTORY_META_PATHF, pv_config_get_storage_mntpoint(), key);
+}
+
+#define PV_STORAGE_DISKS_PATHF           "%s/disks/"
+#define PV_STORAGE_DISKS_REV_PATHF       "%s/disks/rev"
+#define PV_STORAGE_DISKS_PERM_FILE_PATHF "%s/disks/perm/%s/%s"
+#define PV_STORAGE_DISKS_REV_FILE_PATHF  "%s/disks/rev/%s/%s/%s"
+
+void pv_paths_storage_disks(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_PATHF, pv_config_get_storage_mntpoint());
+}
+
+void pv_paths_storage_disks_rev(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_REV_PATHF, pv_config_get_storage_mntpoint());
+}
+
+void pv_paths_storage_disks_rev_file(char *buf, size_t size, const char *rev, const char *plat, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_REV_FILE_PATHF, pv_config_get_storage_mntpoint(), rev, plat, name);
+}
+
+void pv_paths_storage_disks_perm_file(char *buf, size_t size, const char *plat, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_PERM_FILE_PATHF, pv_config_get_storage_mntpoint(), plat, name);
+}
+
+#define PV_ROOT_PATHF         "%s"
+#define PV_VOLUMES_PATHF      "/volumes/%s"
+#define PV_VOLUMES_PLAT_PATHF PV_VOLUMES_PATHF"/%s"
+
+void pv_paths_root_file(char *buf, size_t size, const char *path)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_ROOT_PATHF, path);
+}
+
+void pv_paths_volumes_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PATHF, name);
+}
+
+void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const char *name){
+	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PLAT_PATHF, plat, name);
+}
+
+#define PV_LIB_PLUGIN_PATHF   "/lib/pv_%s.so"
+#define PV_LIB_MODULES_PATHF  "/lib/modules/%s"
+#define PV_LIB_VOLMOUNT_PATHF "/lib/pv/volmount/%s"
+#define PV_LIB_HOOK_PATHF     "/lib/pv/hooks_lxc-mount.d/%s"
+
+void pv_paths_lib_plugin(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_PLUGIN_PATHF, name);
+}
+
+void pv_paths_lib_modules(char *buf, size_t size, const char *release)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_MODULES_PATHF, release);
+}
+
+void pv_paths_lib_volmount(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_VOLMOUNT_PATHF, name);
+}
+
+void pv_paths_lib_hook(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_PATHF, name);
+}
+
+#define PV_CONFIG_PANTAVISOR_PATHF "/etc/pantavisor.config"
+
+void pv_paths_etc_pantavisor(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_CONFIG_PANTAVISOR_PATHF);
+}
+
+#define PV_ETC_PATHF "/etc/%s"
+
+void pv_paths_etc_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, name);
+}
+
+#define PV_CONFIGS_PATHF "/configs/"
+
+void pv_paths_configs(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF);
+}
+
+#define PV_CERT_PATHF "/certs/%s"
+
+void pv_paths_cert(char *buf, size_t size, const char* name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_CERT_PATHF, name);
+}

--- a/paths.h
+++ b/paths.h
@@ -1,39 +1,120 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #ifndef PV_PATHS_H
 #define PV_PATHS_H
 
-#define PV_PATH					"/pv"
-#define PLATFORM_PV_PATH			"/pantavisor"
+#define ONLINE_FNAME    "online"
+#define DEVICE_ID_FNAME "device-id"
+#define CHALLENGE_FNAME "challenge"
+#define PHHOST_FNAME    "pantahub-host"
+#define PVCTRL_FNAME    "pv-ctrl"
+#define LOGCTRL_FNAME   "pv-ctrl-log"
 
-#define LOG_CTRL_FNAME 				"pv-ctrl-log"
-#define PV_LOG_CTRL_PATH 			PV_PATH"/"LOG_CTRL_FNAME
-#define PLATFORM_LOG_CTRL_PATH 			PLATFORM_PV_PATH"/"LOG_CTRL_FNAME
+void pv_paths_pv_file(char *buf, size_t size, const char *name);
 
-#define LOG_DNAME				"logs"
-#define PV_LOGS_PATH				PV_PATH"/"LOG_DNAME
-#define PLATFORM_LOGS_PATH			PLATFORM_PV_PATH"/"LOG_DNAME
+#define USRMETA_DNAME "user-meta"
+#define SSH_KEY_FNAME "pvr-sdk.authorized_keys"
 
-#define CTRL_SOCKET_FNAME			"pv-ctrl"
-#define PV_CTRL_SOCKET_PATH			PV_PATH"/"CTRL_SOCKET_FNAME
-#define PLATFORM_CTRL_SOCKET_PATH		PLATFORM_PV_PATH"/"CTRL_SOCKET_FNAME
+void pv_paths_pv_usrmeta_key(char *buf, size_t size, const char *key);
+void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, const char *key);
 
-#define USER_META_DNAME				"user-meta"
-#define PV_USER_META_PATH			PV_PATH"/"USER_META_DNAME
-#define PLATFORM_USER_META_PATH			PLATFORM_PV_PATH"/"USER_META_DNAME
+#define LOGS_DNAME            "logs"
+#define LOGS_ERROR_DNAME      "error"
+#define LXC_LOG_SUBDIR        "lxc"
+#define LOGS_PV_DNAME         "pantavisor"
+#define LOGS_PV_FNAME         "pantavisor.log"
+#define LXC_LOG_FNAME         LXC_LOG_SUBDIR"/lxc.log"
+#define LXC_CONSOLE_LOG_FNAME LXC_LOG_SUBDIR"/console.log"
 
-#define CHALLENGE_FNAME				"challenge"
-#define PV_CHALLENGE_PATH			PV_PATH"/"CHALLENGE_FNAME
-#define PLATFORM_CHALLENGE_PATH			PLATFORM_PV_PATH"/"CHALLENGE_FNAME
+void pv_paths_pv_log(char *buf, size_t size, const char *rev);
+void pv_paths_pv_log_plat(char *buf, size_t size, const char *rev, const char *plat);
+void pv_paths_pv_log_file(char *buf, size_t size, const char *rev, const char *plat, const char *name);
 
-#define DEVICE_ID_FNAME				"device-id"
-#define PV_DEVICE_ID_PATH			PV_PATH"/"DEVICE_ID_FNAME
-#define PLATFORM_DEVICE_ID_PATH			PLATFORM_PV_PATH"/"DEVICE_ID_FNAME
+void pv_paths_storage(char *buf, size_t size);
+void pv_paths_storage_log(char *buf, size_t size);
+void pv_paths_storage_meta(char *buf, size_t size);
+void pv_paths_storage_dropbear(char *buf, size_t size);
 
-#define ONLINE_FNAME				"online"
-#define PV_ONLINE_PATH				PV_PATH"/"ONLINE_FNAME
-#define PLATFORM_ONLINE_PATH			PLATFORM_PV_PATH"/"ONLINE_FNAME
+void pv_paths_storage_object(char *buf, size_t size, const char *sha);
+void pv_paths_storage_object_tmp(char *buf, size_t size, const char *sha);
 
-#define PV_USER_META_KEY_PATHF			PV_USER_META_PATH"/%s"
-#define PV_USER_META_PLAT_PATHF			PV_USER_META_PATH".%s"
-#define PV_USER_META_PLAT_KEY_PATHF		PV_USER_META_PATH".%s/%s"
+#define DONE_FNAME      "done"
+#define TRYONCE_FNAME   ".tryonce"
+#define PROGRESS_FNAME  "progress"
+#define COMMITMSG_FNAME "commitmsg"
+#define METADONE_FNAME  "factory-meta.done"
+#define JSON_FNAME      "json"
+#define CONFIG_FNAME    "config"
+
+void pv_paths_storage_trail(char *buf, size_t size, const char *rev);
+void pv_paths_storage_trail_file(char *buf, size_t size, const char *rev, const char *name);
+void pv_paths_storage_trail_plat_file(char *buf, size_t size, const char *rev, const char *plat, const char *name);
+void pv_paths_storage_trail_config(char *buf, size_t size, const char *rev);
+void pv_paths_storage_trail_pv_file(char *buf, size_t size, const char *rev, const char *name);
+void pv_paths_storage_trail_pvr_file(char *buf, size_t size, const char *rev, const char *name);
+
+#define UNCLAIMED_FNAME "unclaimed.config"
+#define PANTAHUB_FNAME  "pantahub.config"
+
+void pv_paths_storage_config_file(char *buf, size_t size, const char *name);
+
+#define GRUBENV_FNAME  "grubenv"
+#define UBOOTTXT_FNAME "uboot.txt"
+
+void pv_paths_storage_boot_file(char *buf, size_t size, const char *name);
+
+void pv_paths_storage_factory_meta_key(char *buf, size_t size, const char *key);
+
+void pv_paths_storage_disks(char *buf, size_t size);
+void pv_paths_storage_disks_rev(char *buf, size_t size);
+void pv_paths_storage_disks_rev_file(char *buf, size_t size, const char *rev, const char *plat, const char *name);
+void pv_paths_storage_disks_perm_file(char *buf, size_t size, const char *plat, const char *name);
+
+void pv_paths_lib_plugin(char *buf, size_t size, const char *name);
+void pv_paths_lib_modules(char *buf, size_t size, const char *release);
+void pv_paths_lib_volmount(char *buf, size_t size, const char *name);
+void pv_paths_lib_hook(char *buf, size_t size, const char *name);
+
+void pv_paths_etc_pantavisor(char *buf, size_t size);
+
+void pv_paths_root_file(char *buf, size_t size, const char *path);
+void pv_paths_volumes_file(char *buf, size_t size, const char *name);
+void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const char *name);
+
+#define DROPBEAR_DNAME "dropbear"
+#define PVS_DNAME      "pvs"
+#define PVS_PK_FNAME   PVS_DNAME"/pub.pem"
+#define PVS_CERT_FNAME PVS_DNAME"/certs/ca.pem"
+
+void pv_paths_etc_file(char *buf, size_t size, const char *name);
+
+void pv_paths_configs(char *buf, size_t size);
+
+void pv_paths_cert(char *buf, size_t size, const char* name);
+
+#define PLATFORM_PV_PATH            "/pantavisor"
+#define PLATFORM_LOGS_PATH          PLATFORM_PV_PATH"/"LOGS_DNAME
+#define PLATFORM_PVCTRL_SOCKET_PATH PLATFORM_PV_PATH"/"PVCTRL_FNAME
+#define PLATFORM_LOG_CTRL_PATH      PLATFORM_PV_PATH"/"LOGCTRL_FNAME
+#define PLATFORM_USER_META_PATH     PLATFORM_PV_PATH"/"USRMETA_DNAME
 
 #endif /* PATHS_H */

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,11 +26,15 @@
 #include "../config.h"
 #include "../platforms.h"
 
-#define LXC_LOG_FNAME 		"lxc"
-#define LXC_CONSOLE_LOG_FNAME 	"console"
+void pv_set_new_log_fn(void *fn_pv_new_log);
+void pv_set_pv_instance_fn(void *fn_pv_get_instance);
+void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
+	void *fn_pv_paths_pv_log,
+	void *fn_pv_paths_pv_log_plat,
+	void *fn_pv_paths_pv_log_file,
+	void *fn_pv_paths_pv_usrmeta_key,
+	void *fn_pv_paths_lib_hook);
 
-void pv_set_new_log_fn( void *fn_pv_new_log);
-void pv_set_pv_instance_fn( void *fn_pv_get_instance);
 void* pv_start_container(struct pv_platform *p, const char *rev, char *conf_file, void *data);
 void* pv_stop_container(struct pv_platform *p, char *conf_file, void *data);
 

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Pantacor Ltd.
+ * Copyright (c) 2018-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -68,6 +68,7 @@ static void pv_log(int level, char *msg, ...)
 {
 	char __buffer[PV_LOG_BUF_SIZE + (PV_LOG_BUF_SIZE / 2 )];
 	char __formatted[PV_LOG_BUF_SIZE + (PV_LOG_BUF_SIZE / 2 )];
+	char path[PATH_MAX];
 	int to_write = 0;
 	int written = 0;
 	int offset = 0;
@@ -96,7 +97,8 @@ static void pv_log(int level, char *msg, ...)
 			}
 
 		} else {
-			int ret = pvctl_write_to_path(PV_LOG_CTRL_PATH,
+			pv_paths_pv_file(path, PATH_MAX, LOGCTRL_FNAME);
+			int ret = pvctl_write_to_path(path,
 					__buffer,
 					ph_logger_msg->len + sizeof(struct ph_logger_msg));
 			if (ret < 0) {

--- a/signature.h
+++ b/signature.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Pantacor Ltd.
+ * Copyright (c) 2021-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,9 +23,6 @@
 #define PV_SIGNATURE_H
 
 #include "state.h"
-
-#define PATH_PVS_CERTS "/etc/pantavisor/pvs/certs/ca.pem"
-#define PATH_PVS_PK "/etc/pantavisor/pvs/pub.pem"
 
 bool pv_signature_verify(const char *json);
 

--- a/storage.h
+++ b/storage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,14 +22,6 @@
 #ifndef PV_STORAGE_H
 #define PV_STORAGE_H
 
-#define PATH_OBJECTS_TMP "%s/objects/%s.new"
-#define PATH_OBJECTS "%s/objects/%s"
-#define PATH_TRAILS_PVR_PARENT "%s/trails/%s/.pvr"
-#define PATH_TRAILS_PV_PARENT "%s/trails/%s/.pv"
-#define PATH_TRAILS "%s/trails/%s/.pvr/json"
-#define PATH_TRAILS_PROGRESS "%s/trails/%s/.pv/progress"
-#define PATH_TRAILS_COMMITMSG "%s/trails/%s/.pv/commitmsg"
-
 #define PREFIX_LOCAL_REV "locals/"
 #define SIZE_LOCAL_REV 64
 
@@ -38,11 +30,9 @@ struct pv_path {
 	struct dl_list list;
 };
 
-char* pv_storage_get_state_json_path(const char *rev);
 char* pv_storage_get_state_json(const char *rev);
 bool pv_storage_verify_state_json(const char *rev);
 
-char* pv_storage_get_rev_path(const char *rev);
 void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev);
 void pv_storage_set_rev_progress(const char *rev, const char *progress);
 void pv_storage_rm_rev(const char *rev);

--- a/uboot.c
+++ b/uboot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantacor Ltd.
+ * Copyright (c) 2018-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include <mtd/mtd-user.h>
 
 #include "bootloader.h"
+#include "paths.h"
 #include "utils/str.h"
 #include "utils/fs.h"
 
@@ -63,7 +64,7 @@ static int uboot_init()
 		return 0;
 
 	// setup uboot.txt location
-	SNPRINTF_WTRUNC(buf, sizeof (buf), "%s/boot/uboot.txt", pv_config_get_storage_mntpoint());
+	pv_paths_storage_boot_file(buf, PATH_MAX, UBOOTTXT_FNAME);
 	uboot_txt = strdup(buf);
 
 	pv_log(DEBUG, "uboot.txt@%s", uboot_txt);

--- a/updater.h
+++ b/updater.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,6 @@
 #define DEVICE_TRAIL_ENDPOINT_DOWNLOADING "?progress.status=DOWNLOADING"
 #define DEVICE_TRAIL_ENDPOINT_INPROGRESS "?progress.status=INPROGRESS"
 
-#define VOLATILE_TMP_OBJ_PATH "/tmp/object-XXXXXX"
 #define MMC_TMP_OBJ_FMT "%s.tmp"
 
 #define UPDATE_PROGRESS_FREQ 	(3) /*3 seconds for update*/

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Pantacor Ltd.
+ * Copyright (c) 2021-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -106,7 +106,7 @@ void syncdir(char *file)
 		free(dir);
 }
 
-int remove_at(char *path, char *filename)
+int remove_at(char *path, const char *filename)
 {
 	char full_path[PATH_MAX];
 
@@ -114,7 +114,7 @@ int remove_at(char *path, char *filename)
 	return remove(full_path);
 }
 
-int remove_in(char *path, char *dirname)
+int remove_in(char *path, const char *dirname)
 {
 	int n = 0;
 	struct dirent **d;

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Pantacor Ltd.
+ * Copyright (c) 2021-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ bool dir_exist(const char *dir);
 int mkdir_p(char *dir, mode_t mode);
 int mkbasedir_p(char *dir, mode_t mode);
 void syncdir(char *dir);
-int remove_in(char *path, char *dirname);
-int remove_at(char *path, char *filename);
+int remove_in(char *path, const char *dirname);
+int remove_at(char *path, const char *filename);
 
 #endif // UTILS_FS_H


### PR DESCRIPTION
This PR tries to centralize all path formatting into the paths module. This prepares the way for the app engine feature, as that is going to need prefixes before most of the paths, and it is easier to do these changes if all snprintfs are located in one .c. Also, having a standardized way to format paths will make it easier to debug.

This patch is a refactor and does not intend to change functionality.

List of changes:
* paths: new multiple functions that allow to retrieve a path into a char array
* general: use of new paths functions