### PR TITLE
return 507 insufficient space error when trying to put an object

### DIFF
--- a/storage.h
+++ b/storage.h
@@ -59,6 +59,7 @@ int pv_storage_validate_file_checksum(char* path, char* checksum);
 bool pv_storage_validate_trails_object_checksum(const char *rev, const char *name, char *checksum);
 bool pv_storage_validate_trails_json_value(const char *rev, const char *name, char *val);
 
+off_t pv_storage_get_free(void);
 int pv_storage_gc_run(void);
 off_t pv_storage_gc_run_needed(off_t needed);
 void pv_storage_gc_defer_run_threshold(void);


### PR DESCRIPTION
List of changes:
* ctrl: return 507 when trying to PUT an object that is bigger than the free space available
* ctrl: fix one error that was making any PUT or POST method to get a content-length from HTTP headers bigger than what was actually in the headers
* storage: improve disk usage info in logs and add real and reserved disk space to devmeta