### PR TITLE
refactor all file writing except bootloader ones to use tmp files and sync

### DIFF
--- a/config.c
+++ b/config.c
@@ -40,6 +40,7 @@
 #include "paths.h"
 #include "parser/parser.h"
 #include "utils/fs.h"
+#include "utils/file.h"
 #include "utils/str.h"
 #include "utils/math.h"
 #include "utils/json.h"
@@ -343,8 +344,7 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config, char *
 	int fd;
 	char tmp_path[PATH_MAX];
 
-	SNPRINTF_WTRUNC(tmp_path, sizeof (tmp_path), "%s-XXXXXX", path);
-	mkstemp(tmp_path);
+	pv_paths_tmp(tmp_path, PATH_MAX, path);
 	fd = open(tmp_path, O_RDWR | O_SYNC | O_CREAT | O_TRUNC, 644);
 	if (fd < 0) {
 		pv_log(ERROR, "unable to open temporary credentials config: %s", strerror(errno));
@@ -377,7 +377,10 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config, char *
 	write_config_tuple_int(fd, "libthttp.log.level", config->libthttp.loglevel);
 
 	close(fd);
-	rename(tmp_path, path);
+	if (pv_file_rename(tmp_path, path) < 0) {
+		pv_log(ERROR, "could not rename");
+		return -1;
+	}
 
 	return 0;
 }

--- a/pantahub.c
+++ b/pantahub.c
@@ -53,6 +53,7 @@
 #include "utils/tsh.h"
 #include "utils/str.h"
 #include "utils/fs.h"
+#include "utils/file.h"
 
 #define MODULE_NAME             "pantahub-api"
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
@@ -496,31 +497,20 @@ out:
 
 void pv_ph_update_hint_file(struct pantavisor *pv, char *c)
 {
-	int fd;
 	char buf[256], path[PATH_MAX];
 
 	pv_paths_pv_file(path, PATH_MAX, DEVICE_ID_FNAME);
-	fd = open(path, O_TRUNC | O_SYNC | O_RDWR);
-	if (fd < 0) {
-		pv_log(INFO, "unable to open device-id hint file: %s", strerror(errno));
-		return;
-	}
 	SNPRINTF_WTRUNC (buf, sizeof (buf), "%s\n", pv_config_get_creds_id());
-	write(fd, buf, strlen(buf));
-	close(fd);
+	if (pv_file_save(path, buf, 044))
+		pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
 
 	if (!c)
 		return;
 
 	pv_paths_pv_file(path, PATH_MAX, CHALLENGE_FNAME);
-	fd = open(path, O_TRUNC | O_SYNC | O_RDWR);
-	if (fd < 0) {
-		pv_log(INFO, "unable to open challenge hint file: %s", strerror(errno));
-		return;
-	}
 	SNPRINTF_WTRUNC(buf, sizeof (buf), "%s\n", c);
-	write(fd, buf, strlen(buf));
-	close(fd);
+	if (pv_file_save(path, buf, 044))
+		pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
 }
 
 int pv_ph_upload_metadata(struct pantavisor *pv, char *metadata)

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -61,6 +61,7 @@
 #include "parser/parser.h"
 #include "utils/timer.h"
 #include "utils/fs.h"
+#include "utils/file.h"
 #include "utils/str.h"
 
 #define MODULE_NAME             "controller"
@@ -249,7 +250,6 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	ph_logger_toggle(pv, pv->state->rev);
 
 	// meta data initialization, also to be uploaded as soon as possible when connected
-	pv_storage_meta_set_objdir(pv);
 	pv_metadata_init_devmeta(pv);
 	pv_metadata_init_usermeta(pv->state);
 
@@ -318,7 +318,8 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 		pv_config_save_creds();
 		pv_ph_release_client(pv);
 		pv_paths_pv_file(path, PATH_MAX, CHALLENGE_FNAME);
-		open(path, O_TRUNC | O_WRONLY);
+		if (pv_file_save(path, "", 0444) < 0)
+			pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
 		pv_metadata_add_devmeta("pantahub.claimed", "1");
 	}
 

--- a/paths.c
+++ b/paths.c
@@ -93,16 +93,10 @@ void pv_paths_storage_dropbear(char *buf, size_t size)
 }
 
 #define PV_OBJECT_PATHF     "%s/objects/%s"
-#define PV_OBJECT_TMP_PATHF PV_OBJECT_PATHF".tmp"
 
 void pv_paths_storage_object(char *buf, size_t size, const char *sha)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_OBJECT_PATHF, pv_config_get_storage_mntpoint(), sha);
-}
-
-void pv_paths_storage_object_tmp(char *buf, size_t size, const char *sha)
-{
-	SNPRINTF_WTRUNC(buf, size, PV_OBJECT_TMP_PATHF, pv_config_get_storage_mntpoint(), sha);
 }
 
 #define PV_TRAILS_PATHF           "%s/trails/%s"
@@ -257,4 +251,11 @@ void pv_paths_configs(char *buf, size_t size)
 void pv_paths_cert(char *buf, size_t size, const char* name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CERT_PATHF, name);
+}
+
+#define PV_TMP_PATHF "%s.tmp"
+
+void pv_paths_tmp(char *buf, size_t size, const char *path)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_TMP_PATHF, path);
 }

--- a/paths.h
+++ b/paths.h
@@ -55,15 +55,12 @@ void pv_paths_storage_meta(char *buf, size_t size);
 void pv_paths_storage_dropbear(char *buf, size_t size);
 
 void pv_paths_storage_object(char *buf, size_t size, const char *sha);
-void pv_paths_storage_object_tmp(char *buf, size_t size, const char *sha);
 
 #define DONE_FNAME      "done"
-#define TRYONCE_FNAME   ".tryonce"
 #define PROGRESS_FNAME  "progress"
 #define COMMITMSG_FNAME "commitmsg"
 #define METADONE_FNAME  "factory-meta.done"
 #define JSON_FNAME      "json"
-#define CONFIG_FNAME    "config"
 
 void pv_paths_storage_trail(char *buf, size_t size, const char *rev);
 void pv_paths_storage_trail_file(char *buf, size_t size, const char *rev, const char *name);
@@ -110,6 +107,8 @@ void pv_paths_etc_file(char *buf, size_t size, const char *name);
 void pv_paths_configs(char *buf, size_t size);
 
 void pv_paths_cert(char *buf, size_t size, const char* name);
+
+void pv_paths_tmp(char *buf, size_t size, const char *path);
 
 #define PLATFORM_PV_PATH            "/pantavisor"
 #define PLATFORM_LOGS_PATH          PLATFORM_PV_PATH"/"LOGS_DNAME

--- a/ph_logger/ph_logger_v1.c
+++ b/ph_logger/ph_logger_v1.c
@@ -169,7 +169,7 @@ int ph_logger_write_to_file_handler_v1(struct ph_logger_msg *ph_logger_msg, cons
 	if (log_fd >= 0) {
 		if (!fstat(log_fd, &st)) {
 			/* Do we need to make a zip out of it?*/
-			if (st.st_size >= MAX_SIZE) 
+			if (st.st_size >= MAX_SIZE)
 				ftruncate(log_fd, 0);
 		}
 		dprintf(log_fd, "%s -- %.*s\n", level_names[level].name, ph_logger_msg->len, data);

--- a/storage.h
+++ b/storage.h
@@ -55,10 +55,8 @@ off_t pv_storage_gc_run_needed(off_t needed);
 void pv_storage_gc_defer_run_threshold(void);
 void pv_storage_gc_run_threshold(void);
 
-void pv_storage_meta_set_objdir(struct pantavisor *pv);
 int pv_storage_meta_expand_jsons(struct pantavisor *pv, struct pv_state *s);
 int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s);
-void pv_storage_meta_set_tryonce(struct pantavisor *pv, int value);
 
 void pv_storage_init_plat_usermeta(const char *name);
 void pv_storage_save_usermeta(const char *key, const char *value);

--- a/utils/file.h
+++ b/utils/file.h
@@ -26,6 +26,12 @@
 #include <sys/types.h>
 
 char* pv_file_load(const char *path, const unsigned int max_size);
+int pv_file_rename(const char *src_path, const char *dst_path);
+int pv_file_save(const char *path, const char *content, mode_t mode);
+int pv_file_copy(const char *src_path, const char *dst_path, mode_t mode);
+int pv_file_rename(const char *src_path, const char *dst_path);
+int pv_file_remove(const char *path);
+
 size_t pv_file_get_size(const char *path);
 
 /*

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -85,7 +85,7 @@ int mkbasedir_p(char *dir, mode_t mode)
 	return ret;
 }
 
-void syncdir(char *file)
+void syncdir(const char *file)
 {
 	int fd;
 	char *dir;

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -31,7 +31,7 @@
 bool dir_exist(const char *dir);
 int mkdir_p(char *dir, mode_t mode);
 int mkbasedir_p(char *dir, mode_t mode);
-void syncdir(char *dir);
+void syncdir(const char *dir);
 int remove_in(char *path, const char *dirname);
 int remove_at(char *path, const char *filename);
 

--- a/volumes.c
+++ b/volumes.c
@@ -43,6 +43,7 @@
 #include "tsh.h"
 #include "init.h"
 #include "utils/fs.h"
+#include "utils/file.h"
 #include "utils/str.h"
 #include "utils/tsh.h"
 
@@ -291,9 +292,8 @@ int pv_volume_mount(struct pv_volume *v)
 		fstype++;
 		if (strcmp(fstype, "bind") == 0) {
 			if (stat(mntpoint, &buf) != 0) {
-				int fd = open(mntpoint, O_CREAT | O_EXCL | O_RDWR | O_SYNC, 0644);
-				if (fd >= 0)
-					close(fd);
+				if (pv_file_save(mntpoint, "", 0644) < 0)
+					pv_log(WARN, "could not save file %s: %s", mntpoint, strerror(errno));
 			}
 			ret = mount(path, mntpoint, NULL, MS_BIND, NULL);
 		} else if (strcmp(fstype, "data") == 0) {


### PR DESCRIPTION
The idea is to use temporary files and sync when writing anything in disk. That way we want to avoid problems that could appear, specially with low disk throughput.

List of changes:
* config: use new pv_paths_tmp and pv_file_rename for saving pantahub.config
* crtl: use new pv_paths_tmp and pv_file_rename for putting files
* pantahub: use new pv_file_save for saving device-id and challenge
* pantavisor: use new pv_file_save for creating challenge
* paths: new function for tmp paths
* storage: use new pv_file_save and pv_file_copy for saving various storage files
* storage: remove unused tryonce and objdir functions
* updater: se new pv_paths_tmp and pv_file_rename for saving objects and state json
* utils/file: new functions to save and copy files. Using tmp files and sync
* volumes: use new pv_file_save for creating mount point