### PR TITLE
prefix paths and init mode in config

### DIFF
--- a/config.h
+++ b/config.h
@@ -27,10 +27,24 @@
 
 #include "utils/list.h"
 
-enum {
-	BL_UBOOT_PLAIN = 0,
-	BL_UBOOT_PVK,
-	BL_GRUB
+typedef enum {
+	IM_EMBEDDED,
+	IM_STANDALONE,
+	IM_APPENGINE
+} init_mode_t;
+
+struct pantavisor_system {
+	init_mode_t init_mode;
+	char *libdir;
+	char *etcdir;
+	char *rundir;
+	char *mediadir;
+	char *confdir;
+};
+
+struct pantavisor_debug {
+	bool shell;
+	bool ssh;
 };
 
 struct pantavisor_cache {
@@ -79,6 +93,10 @@ struct pantavisor_storage {
 	struct pantavisor_gc gc;
 };
 
+struct pantavisor_disk {
+	char *voldir;
+};
+
 struct pantavisor_updater {
 	int interval;
 	int conditions_timeout;
@@ -87,6 +105,12 @@ struct pantavisor_updater {
 	int revision_retries;
 	int revision_retry_timeout;
 	int commit_delay;
+};
+
+enum {
+	BL_UBOOT_PLAIN = 0,
+	BL_UBOOT_PVK,
+	BL_GRUB
 };
 
 struct pantavisor_bootloader {
@@ -138,14 +162,18 @@ typedef enum {
 
 struct pantavisor_secureboot {
 	secureboot_mode_t mode;
+	char *certdir;
 };
 
 struct pantavisor_config {
+	struct pantavisor_system sys;
+	struct pantavisor_debug debug;
 	struct pantavisor_cache cache;
 	struct pantavisor_bootloader bl;
 	struct pantavisor_creds creds;
 	struct pantavisor_factory factory;
 	struct pantavisor_storage storage;
+	struct pantavisor_disk disk;
 	struct pantavisor_updater updater;
 	struct pantavisor_watchdog wdt;
 	struct pantavisor_network net;
@@ -156,6 +184,8 @@ struct pantavisor_config {
 	struct pantavisor_secureboot secureboot;
 };
 
+int pv_config_init(char *path);
+
 int pv_config_load_creds(void);
 int pv_config_save_creds(void);
 
@@ -163,9 +193,24 @@ void pv_config_override_value(const char* key, const char* value);
 
 void pv_config_free(void);
 
+void pv_config_set_system_init_mode(init_mode_t mode);
+
+void pv_config_set_debug_shell(bool shell);
+void pv_config_set_debug_ssh(bool ssh);
+
 void pv_config_set_creds_id(char *id);
 void pv_config_set_creds_prn(char *prn);
 void pv_config_set_creds_secret(char *secret);
+
+init_mode_t pv_config_get_system_init_mode(void);
+char* pv_config_get_system_libdir(void);
+char* pv_config_get_system_etcdir(void);
+char* pv_config_get_system_rundir(void);
+char* pv_config_get_system_mediadir(void);
+char* pv_config_get_system_confdir(void);
+
+bool pv_config_get_debug_shell(void);
+bool pv_config_get_debug_ssh(void);
 
 char* pv_config_get_cache_metacachedir(void);
 char* pv_config_get_cache_dropbearcachedir(void);
@@ -199,6 +244,8 @@ bool pv_config_get_storage_gc_keep_factory(void);
 int pv_config_get_storage_gc_threshold(void);
 int pv_config_get_storage_gc_threshold_defertime(void);
 
+char* pv_config_get_disk_voldir(void);
+
 int pv_config_get_updater_interval(void);
 int pv_config_get_updater_conditions_timeout(void);
 int pv_config_get_updater_network_timeout(void);
@@ -230,7 +277,9 @@ int pv_config_get_libthttp_loglevel(void);
 
 int pv_config_get_lxc_loglevel(void);
 bool pv_config_get_control_remote(void);
+
 secureboot_mode_t pv_config_get_secureboot_mode(void);
+char* pv_config_get_secureboot_certdir(void);
 
 char* pv_config_get_json(void);
 

--- a/init.h
+++ b/init.h
@@ -70,7 +70,6 @@ struct pv_init {
 
 extern struct pv_init *pv_init_tbl[];
 extern struct pv_init pv_init_bl;
-extern struct pv_init pv_init_config;
 extern struct pv_init pv_init_creds;
 extern struct pv_init pv_init_config_trail;
 extern struct pv_init pv_init_storage;

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -729,9 +729,29 @@ static pv_state_t _pv_run_state(pv_state_t state, struct pantavisor *pv)
 
 int pv_start()
 {
+	char path[PATH_MAX];
 	struct pantavisor *pv = pv_get_instance();
 	if (!pv)
 		return 1;
+
+	printf("Pantavisor (TM) (%s) - www.pantahub.com\n", pv_build_version);
+	SNPRINTF_WTRUNC(pv_user_agent, sizeof (pv_user_agent), PV_USER_AGENT_FMT,
+			pv_build_arch, pv_build_version, pv_build_date);
+
+	prctl(PR_SET_NAME, "pantavisor");
+
+	struct rlimit core_limit;
+	core_limit.rlim_cur = RLIM_INFINITY;
+	core_limit.rlim_max = RLIM_INFINITY;
+
+	setrlimit(RLIMIT_CORE, &core_limit);
+
+	pv_paths_storage_file(path, PATH_MAX, COREPV_FNAME);
+	int fd = open("/proc/sys/kernel/core_pattern", O_WRONLY | O_SYNC);
+	if (fd < 0)
+		printf("open failed for /proc/sys/kernel/core_pattern: %s", strerror(errno));
+	else
+		write(fd, path, strlen(path));
 
 	pv_state_t state = PV_STATE_INIT;
 
@@ -779,36 +799,11 @@ void pv_stop()
 
 void pv_init()
 {
-	int ret;
 	struct pantavisor *pv;
 
-	printf("Pantavisor (TM) (%s) - www.pantahub.com\n", pv_build_version);
-	SNPRINTF_WTRUNC(pv_user_agent, sizeof (pv_user_agent), PV_USER_AGENT_FMT,
-			pv_build_arch, pv_build_version, pv_build_date);
-
-	prctl(PR_SET_NAME, "pantavisor");
 	pv = calloc(1, sizeof(struct pantavisor));
 	if (pv)
 		global_pv = pv;
-
-	struct rlimit core_limit;
-	core_limit.rlim_cur = RLIM_INFINITY;
-	core_limit.rlim_max = RLIM_INFINITY;
-
-	setrlimit(RLIMIT_CORE, &core_limit);
-
-	char *core = "/storage/corepv";
-	int fd = open("/proc/sys/kernel/core_pattern", O_WRONLY | O_SYNC);
-	if (fd < 0)
-		printf("open failed for /proc/sys/kernel/core_pattern: %s", strerror(errno));
-	else
-		write(fd, core, strlen(core));
-
-	// Enter state machine
-	ret = pv_start();
-
-	// Clean exit -> reboot
-	exit(ret);
 }
 
 static int pv_pantavisor_init(struct pv_init *this)

--- a/paths.c
+++ b/paths.c
@@ -30,12 +30,12 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
-#define PV_PATH  "/pv"
+#define PV_PATH  "%s"
 #define PV_PATHF PV_PATH"/%s"
 
 void pv_paths_pv_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_PATHF, pv_config_get_system_rundir(), name);
 }
 
 #define PV_USRMETA_PATHF      PV_PATH"/"USRMETA_DNAME"/%s"
@@ -43,12 +43,12 @@ void pv_paths_pv_file(char *buf, size_t size, const char *name)
 
 void pv_paths_pv_usrmeta_key(char *buf, size_t size, const char *key)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PATHF, key);
+	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PATHF, pv_config_get_system_rundir(), key);
 }
 
 void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, const char *key)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PLAT_PATHF, plat, key);
+	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PLAT_PATHF, pv_config_get_system_rundir(), plat, key);
 }
 
 #define PV_LOGS_PATHF      PV_PATH"/"LOGS_DNAME"/%s"
@@ -57,17 +57,17 @@ void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, cons
 
 void pv_paths_pv_log(char *buf, size_t size, const char *rev)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PATHF, rev);
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PATHF, pv_config_get_system_rundir(), rev);
 }
 
 void pv_paths_pv_log_plat(char *buf, size_t size, const char *rev, const char *plat)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PLAT_PATHF, rev, plat);
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PLAT_PATHF, pv_config_get_system_rundir(), rev, plat);
 }
 
 void pv_paths_pv_log_file(char *buf, size_t size, const char *rev, const char *plat, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LOGS_FILE_PATHF, rev, plat, name);
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_FILE_PATHF, pv_config_get_system_rundir(), rev, plat, name);
 }
 
 #define PV_STORAGE_PATHF "%s"
@@ -90,6 +90,13 @@ void pv_paths_storage_meta(char *buf, size_t size)
 void pv_paths_storage_dropbear(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_dropbearcachedir());
+}
+
+#define PV_STORAGE_FILE_PATHF "%s/%s"
+
+void pv_paths_storage_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_FILE_PATHF, pv_config_get_storage_mntpoint(), name);
 }
 
 #define PV_OBJECT_PATHF     "%s/objects/%s"
@@ -161,10 +168,6 @@ void pv_paths_storage_factory_meta_key(char *buf, size_t size, const char *key)
 #define PV_STORAGE_DISKS_REV_PATHF       "%s/disks/rev"
 #define PV_STORAGE_DISKS_PERM_FILE_PATHF "%s/disks/perm/%s/%s"
 #define PV_STORAGE_DISKS_REV_FILE_PATHF  "%s/disks/rev/%s/%s/%s"
-#define PV_STORAGE_CRYPT_PATHF           "/media/pv/%s/%s"
-#define PV_CRYPT_DISKS_PERM_FILE_PATHF   PV_STORAGE_CRYPT_PATHF"/perm/%s/%s"
-#define PV_CRYPT_DISKS_REV_FILE_PATHF    PV_STORAGE_CRYPT_PATHF"/rev/%s/%s/%s"
-#define PV_CRYPT_DISKS_BOOT_FILE_PATHF   PV_STORAGE_CRYPT_PATHF"/boot/%s/%s"
 
 void pv_paths_storage_disks(char *buf, size_t size)
 {
@@ -186,31 +189,36 @@ void pv_paths_storage_disks_perm_file(char *buf, size_t size, const char *plat, 
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_PERM_FILE_PATHF, pv_config_get_storage_mntpoint(), plat, name);
 }
 
+#define PV_STORAGE_CRYPT_PATHF           "%s/pv/%s/%s"
+#define PV_CRYPT_DISKS_PERM_FILE_PATHF   PV_STORAGE_CRYPT_PATHF"/perm/%s/%s"
+#define PV_CRYPT_DISKS_REV_FILE_PATHF    PV_STORAGE_CRYPT_PATHF"/rev/%s/%s/%s"
+#define PV_CRYPT_DISKS_BOOT_FILE_PATHF   PV_STORAGE_CRYPT_PATHF"/boot/%s/%s"
+
 void pv_paths_storage_mounted_disk_path(char *buf, size_t size, const char *type, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_CRYPT_PATHF, type, name);
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_CRYPT_PATHF, pv_config_get_system_mediadir(), type, name);
 }
 
 void pv_paths_crypt_disks_rev_file(char *buf, size_t size, const char *type, const char *dname,
 				   const char *rev, const char *plat, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_REV_FILE_PATHF, type, dname ,rev, plat, name);
+	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_REV_FILE_PATHF, pv_config_get_system_mediadir(), type, dname ,rev, plat, name);
 }
 
 void pv_paths_crypt_disks_perm_file(char *buf, size_t size, const char *type, const char *dname,
 				    const char *plat, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_PERM_FILE_PATHF, type, dname, plat, name);
+	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_PERM_FILE_PATHF, pv_config_get_system_mediadir(), type, dname, plat, name);
 }
 
 void pv_paths_crypt_disks_boot_file(char *buf, size_t size, const char *type, const char *dname,
 				    const char *plat, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_BOOT_FILE_PATHF, type, dname, plat, name);
+	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_BOOT_FILE_PATHF, pv_config_get_system_mediadir(), type, dname, plat, name);
 }
 
 #define PV_ROOT_PATHF         "%s"
-#define PV_VOLUMES_PATHF      "/volumes/%s"
+#define PV_VOLUMES_PATHF      "%s/%s"
 #define PV_VOLUMES_PLAT_PATHF PV_VOLUMES_PATHF"/%s"
 
 void pv_paths_root_file(char *buf, size_t size, const char *path)
@@ -220,64 +228,63 @@ void pv_paths_root_file(char *buf, size_t size, const char *path)
 
 void pv_paths_volumes_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PATHF, pv_config_get_disk_voldir(), name);
 }
 
 void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const char *name){
-	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PLAT_PATHF, plat, name);
+	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PLAT_PATHF, pv_config_get_disk_voldir(), plat, name);
 }
 
-#define PV_LIB_PLUGIN_PATHF   "/lib/pv_%s.so"
-#define PV_LIB_MODULES_PATHF  "/lib/modules/%s"
-#define PV_LIB_VOLMOUNT_PATHF "/lib/pv/volmount/%s/%s"
-#define PV_LIB_HOOK_PATHF     "/lib/pv/hooks_lxc-mount.d/%s"
+#define PV_LIB_PLUGIN_PATHF      "%s/pv_%s.so"
+#define PV_LIB_MODULES_PATHF     "%s/modules/%s"
+#define PV_LIB_VOLMOUNT_PATHF    "%s/pv/volmount/%s/%s"
+#define PV_LIB_HOOK_PATHF        "%s/pv/hooks_lxc-mount.d/%s"
+#define PV_LIB_HOOKS_EARLY_SPAWN "%s/pv/hooks_early.spawn/%s"
 
 void pv_paths_lib_plugin(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LIB_PLUGIN_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_PLUGIN_PATHF, pv_config_get_system_libdir(), name);
 }
 
 void pv_paths_lib_modules(char *buf, size_t size, const char *release)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LIB_MODULES_PATHF, release);
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_MODULES_PATHF, pv_config_get_system_libdir(), release);
 }
 
 void pv_paths_lib_volmount(char *buf, size_t size, const char *type, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LIB_VOLMOUNT_PATHF, type, name);
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_VOLMOUNT_PATHF, pv_config_get_system_libdir(), type, name);
 }
 
 void pv_paths_lib_hook(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_PATHF, pv_config_get_system_libdir(), name);
 }
 
-#define PV_CONFIG_PANTAVISOR_PATHF "/etc/pantavisor.config"
-
-void pv_paths_etc_pantavisor(char *buf, size_t size)
+void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CONFIG_PANTAVISOR_PATHF);
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOKS_EARLY_SPAWN, pv_config_get_system_libdir(), name);
 }
 
-#define PV_ETC_PATHF "/etc/%s"
+#define PV_ETC_PATHF "%s/%s"
 
 void pv_paths_etc_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, pv_config_get_system_etcdir(), name);
 }
 
-#define PV_CONFIGS_PATHF "/configs/"
+#define PV_CONFIGS_PATHF "%s/"
 
 void pv_paths_configs(char *buf, size_t size)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF);
+	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF, pv_config_get_system_confdir());
 }
 
-#define PV_CERT_PATHF "/certs/%s"
+#define PV_CERT_PATHF "%s/%s"
 
 void pv_paths_cert(char *buf, size_t size, const char* name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CERT_PATHF, name);
+	SNPRINTF_WTRUNC(buf, size, PV_CERT_PATHF, pv_config_get_secureboot_certdir(), name);
 }
 
 #define PV_TMP_PATHF "%s.tmp"

--- a/paths.h
+++ b/paths.h
@@ -54,6 +54,9 @@ void pv_paths_storage_log(char *buf, size_t size);
 void pv_paths_storage_meta(char *buf, size_t size);
 void pv_paths_storage_dropbear(char *buf, size_t size);
 
+#define COREPV_FNAME "corepv"
+
+void pv_paths_storage_file(char *buf, size_t size, const char *name);
 void pv_paths_storage_object(char *buf, size_t size, const char *sha);
 
 #define DONE_FNAME      "done"
@@ -97,12 +100,13 @@ void pv_paths_lib_plugin(char *buf, size_t size, const char *name);
 void pv_paths_lib_modules(char *buf, size_t size, const char *release);
 void pv_paths_lib_volmount(char *buf, size_t size, const char *type, const char *name);
 void pv_paths_lib_hook(char *buf, size_t size, const char *name);
-
-void pv_paths_etc_pantavisor(char *buf, size_t size);
+void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name);
 
 void pv_paths_root_file(char *buf, size_t size, const char *path);
 void pv_paths_volumes_file(char *buf, size_t size, const char *name);
 void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const char *name);
+
+#define PV_PANTAVISOR_CONFIG_PATH "/etc/pantavisor.config"
 
 #define DROPBEAR_DNAME "dropbear"
 #define PVS_DNAME      "pantavisor/pvs"

--- a/utils/json.c
+++ b/utils/json.c
@@ -331,7 +331,7 @@ static int pv_json_ser_null(struct pv_json_ser *js)
 
 	ret = jsonb_null(&js->b, js->buf, js->size);
 	if (ret == JSONB_ERROR_NOMEM) {
-		pv_json_ser_null(js);
+		pv_json_ser_resize(js);
 		ret = jsonb_null(&js->b, js->buf, js->size);
 	}
 


### PR DESCRIPTION
List of changes:
* config: new config keys for paths taking /storage as example (/lib, /etc, /pv, /media, /configs)
* config: new config keys for debug (shell, ssh)
* config: new config keys for init mode (embedded, standalone and appengine)
* init: get config out of rest of early init so we can do it separatedly and use the init mode, paths and debug from it
* init: add --help with usage info of command
* paths: integrate new configurable paths