### PR TITLE
fix usrmeta_plat_key path function in callback set of pv_lxc

### DIFF
--- a/platforms.c
+++ b/platforms.c
@@ -362,13 +362,14 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_instance_fn");
 
-	void (*__pv_paths)(void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
+	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
 	if (__pv_paths)
 		__pv_paths(pv_paths_pv_file,
 			pv_paths_pv_log,
 			pv_paths_pv_log_plat,
 			pv_paths_pv_log_file,
 			pv_paths_pv_usrmeta_key,
+			pv_paths_pv_usrmeta_plat_key,
 			pv_paths_lib_hook);
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_paths_fn");

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -78,6 +78,7 @@ void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
 	void *fn_pv_paths_pv_log_plat,
 	void *fn_pv_paths_pv_log_file,
 	void *fn_pv_paths_pv_usrmeta_key,
+	void *fn_pv_paths_pv_usrmeta_plat_key,
 	void *fn_pv_paths_lib_hook)
 {
 	__pv_paths_pv_file = fn_pv_paths_pv_file;
@@ -85,6 +86,7 @@ void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
 	__pv_paths_pv_log_plat = fn_pv_paths_pv_log_plat;
 	__pv_paths_pv_log_file = fn_pv_paths_pv_log_file;
 	__pv_paths_pv_usrmeta_key = fn_pv_paths_pv_usrmeta_key;
+	__pv_paths_pv_usrmeta_plat_key = fn_pv_paths_pv_usrmeta_plat_key;
 	__pv_paths_lib_hook = fn_pv_paths_lib_hook;
 }
 

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -33,6 +33,7 @@ void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
 	void *fn_pv_paths_pv_log_plat,
 	void *fn_pv_paths_pv_log_file,
 	void *fn_pv_paths_pv_usrmeta_key,
+	void *fn_pv_paths_pv_usrmeta_plat_key,
 	void *fn_pv_paths_lib_hook);
 
 void* pv_start_container(struct pv_platform *p, const char *rev, char *conf_file, void *data);


### PR DESCRIPTION
add usermeta_plat_key path function to callback set function to avoid undefined behaviour in non-mgmt platforms