### PR TITLE
Declarative kernel module loading support for BSPs

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -94,6 +94,7 @@ LOCAL_GENERATED_SRC_FILES := version.c
 
 LOCAL_COPY_FILES := scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
 	scripts/hooks_lxc-mount.d/export.sh:lib/pv/hooks_lxc-mount.d/export.sh \
+	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
 	scripts/JSON.sh:lib/pv/JSON.sh
 
 include $(BUILD_EXECUTABLE)

--- a/atom.mk
+++ b/atom.mk
@@ -87,7 +87,8 @@ LOCAL_SRC_FILES := init.c \
 			ph_logger/ph_logger_v1.c \
 			buffer.c \
 			blkid.c \
-			paths.c
+			paths.c \
+			drivers.c
 
 LOCAL_INSTALL_HEADERS := log.h
 LOCAL_GENERATED_SRC_FILES := version.c

--- a/config.c
+++ b/config.c
@@ -215,6 +215,8 @@ static int pv_config_load_config_from_file(char *path, struct pantavisor_config 
 	config->bl.type = config_get_value_bl_type(&config_list, "bootloader.type", BL_UBOOT_PLAIN);
 	config->bl.mtd_only = config_get_value_bool(&config_list, "bootloader.mtd_only", false);
 	config->bl.mtd_path = config_get_value_string(&config_list, "bootloader.mtd_env", NULL);
+	config->bl.dtb = config_get_value_string(&config_list, "bootloader.dtb", NULL);
+	config->bl.ovl = config_get_value_string(&config_list, "bootloader.ovl", NULL);
 
 	config->storage.path = config_get_value_string(&config_list, "storage.device", NULL);
 	config->storage.fstype = config_get_value_string(&config_list, "storage.fstype", NULL);
@@ -591,6 +593,8 @@ int pv_config_get_updater_revision_retries() { return pv_get_instance()->config.
 int pv_config_get_updater_revision_retry_timeout() { return pv_get_instance()->config.updater.revision_retry_timeout; }
 int pv_config_get_updater_commit_delay() { return pv_get_instance()->config.updater.commit_delay; }
 
+char* pv_config_get_bl_dtb() { return pv_get_instance()->config.bl.dtb; }
+char* pv_config_get_bl_ovl() { return pv_get_instance()->config.bl.ovl; }
 int pv_config_get_bl_type() { return pv_get_instance()->config.bl.type; }
 bool pv_config_get_bl_mtd_only() { return pv_get_instance()->config.bl.mtd_only; }
 char* pv_config_get_bl_mtd_path() { return pv_get_instance()->config.bl.mtd_path; }

--- a/config.h
+++ b/config.h
@@ -117,6 +117,8 @@ struct pantavisor_bootloader {
 	int type;
 	bool mtd_only;
 	char *mtd_path;
+	char *dtb;
+	char *ovl;
 };
 
 struct pantavisor_watchdog {
@@ -254,6 +256,8 @@ int pv_config_get_updater_revision_retries(void);
 int pv_config_get_updater_revision_retry_timeout(void);
 int pv_config_get_updater_commit_delay(void);
 
+char* pv_config_get_bl_dtb(void);
+char* pv_config_get_bl_ovl(void);
 int pv_config_get_bl_type(void);
 bool pv_config_get_bl_mtd_only(void);
 char* pv_config_get_bl_mtd_path(void);

--- a/drivers.c
+++ b/drivers.c
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <linux/limits.h>
+
+#include "utils/fs.h"
+#include "utils/tsh.h"
+#include "utils/str.h"
+#include "drivers.h"
+#include "metadata.h"
+#include "state.h"
+#include "json.h"
+
+#define MODULE_NAME			"drivers"
+#define pv_log(level, msg, ...)		vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
+#include "log.h"
+
+#define USER_META_KEY	"user-meta"
+#define DEV_META_KEY	"device-meta"
+
+static char *_sub_meta_values(char *str)
+{
+	// find key for meta from ${user-meta:KEY} component of string
+	int _start = 0, _end = 0, type;
+	char *_tok, *_t, *_at, *new;
+	char *_var, *_param, *_tstr;
+	int _nt = 0;
+
+	if (!strchr(str, '$'))
+		return strdup(str);
+
+	new = calloc(1, strlen(str));
+	if (!new)
+		return NULL;
+
+	while ((_at = strchr(str+_start, '$')) != NULL) {
+		_t = strchr(_at, '{');
+		if (!_t || ((_t-_at) != 1))
+			return NULL;
+		_t++;
+		memcpy(new+_nt, str+_start, (_at-(str+_end)));
+		_nt = _nt + (_at-(str+_end));
+		_var = strchr(_t, '}');
+		_end = _var-(str);
+		_start = _at-(str+_start);
+		_tstr = strdup(_t);
+		_tok = strtok(_tstr, "{:}");
+		if (!strcmp(_tok, USER_META_KEY))
+			type = USER_META;
+		else if (!strcmp(_tok, DEV_META_KEY))
+			type = DEVICE_META;
+		_tok = strtok(NULL, "{:}");
+		_param = pv_metadata_get_usermeta(_tok);
+		if (_param) {
+			memcpy(new+_nt, _param, strlen(_param));
+			_nt += strlen(_param);
+		}
+		free(_tstr);
+		_start = _end + 1;
+		_end++;
+	}
+
+	return new;
+}
+
+static int _pv_drivers_modprobe(char **modules, mod_action_t action)
+{
+	int ret = 0, status;
+	char cmd[PATH_MAX];
+	char **module, *tmp, *mod;
+
+	if (!modules)
+		return ret;
+
+	module = modules;
+	while (*module) {
+		tmp = _sub_meta_values(*module);
+		if (action == MOD_UNLOAD)
+			mod = strtok(tmp, " ");
+		else
+			mod = tmp;
+		pv_log(DEBUG, "%s '%s' module", action == MOD_LOAD ? "loading" : "unloading", mod);
+		sprintf(cmd, "/sbin/modprobe %s %s", action == MOD_LOAD ? "" : "-r", mod);
+		tsh_run(cmd, 1, &status);
+		if (WEXITSTATUS(status) == 0)
+			ret++;;
+		module++;
+		free(tmp);
+	}
+
+	return ret;
+}
+
+const char *pv_drivers_state_str(char *match)
+{
+	int state;
+
+	state = pv_drivers_state(match);
+	switch (state) {
+		case MOD_LOADED: return "LOADED";
+		case MOD_UNLOADED: return "UNLOADED";
+		default: return "UNKNOWN";
+	}
+}
+
+const char *pv_drivers_type_str(plat_driver_t type)
+{
+	switch (type) {
+		case DRIVER_REQUIRED: return "REQUIRED";
+		case DRIVER_OPTIONAL: return "OPTIONAL";
+		case DRIVER_MANUAL: return "MANUAL";
+		default: return "UNKNOWN";
+	}
+}
+
+char *pv_drivers_state_all(struct pv_platform *p)
+{
+	struct pv_json_ser js;
+	struct pv_platform_driver *d, *tmp;
+
+	if (dl_list_empty(&p->drivers))
+		return strdup("[]");
+
+	pv_json_ser_init(&js, 4096);
+
+	pv_json_ser_array(&js);
+
+	dl_list_for_each_safe(d, tmp, &p->drivers,
+			struct pv_platform_driver, list) {
+		const char* statechar = pv_drivers_state_str(d->match);
+		const char* typechar = pv_drivers_type_str(d->type);
+
+		pv_json_ser_object(&js);
+		{
+			pv_json_ser_key(&js, "name");
+			pv_json_ser_string(&js, d->match);
+			pv_json_ser_key(&js, "type");
+			pv_json_ser_string(&js, typechar);
+			pv_json_ser_key(&js, "status");
+			pv_json_ser_string(&js, statechar);
+
+			pv_json_ser_object_pop(&js);
+		}
+	}
+	pv_json_ser_array_pop(&js);
+
+	return pv_json_ser_str(&js);
+}
+
+int pv_drivers_state(char *match)
+{
+	struct pantavisor *pv = pv_get_instance();
+	struct pv_state *s = pv->state;
+	struct pv_driver *d, *tmp;
+
+	if (!match)
+		return -1;
+
+	if (dl_list_empty(&s->bsp.drivers))
+		return -1;
+
+	dl_list_for_each_safe(d, tmp, &s->bsp.drivers,
+			struct pv_driver, list) {
+		if (strcmp(d->alias, match))
+			continue;
+		return d->loaded;
+	}
+
+	return -1;
+}
+
+static int _pv_drivers_set(char *match, mod_action_t action)
+{
+	int changed = 0;
+	struct pantavisor *pv = pv_get_instance();
+	struct pv_state *s = pv->state;
+	struct pv_driver *d, *tmp;
+
+	if (!match)
+		return 0;
+
+	if (!strlen(match))
+		return 0;
+
+	if (dl_list_empty(&s->bsp.drivers))
+		return 0;
+
+	dl_list_for_each_safe(d, tmp, &s->bsp.drivers,
+			struct pv_driver, list) {
+		if (strcmp(d->alias, match))
+			continue;
+		changed += _pv_drivers_modprobe(d->modules, action);
+		int len = pv_str_count_list(d->modules);
+		pv_log(DEBUG, "changed=%d, len=%d", changed, len);
+		if (changed != len) {
+			pv_log(WARN, "not all modules were loaded/unloaded correctly");
+			changed = false;
+		}
+		if (!changed)
+			continue;
+		if (action == MOD_LOAD)
+			d->loaded = true;
+		else
+			d->loaded = false;
+	}
+
+	return changed;
+}
+
+int pv_drivers_load(char *match)
+{
+	return _pv_drivers_set(match, MOD_LOAD);
+}
+
+int pv_drivers_unload(char *match)
+{
+	return _pv_drivers_set(match, MOD_UNLOAD);
+}
+
+struct pv_driver* pv_drivers_add(struct pv_state *s, char *alias,
+					int len, char **modules)
+{
+	int i = 0;
+	struct pv_driver *this = calloc(1, sizeof(struct pv_driver));
+
+	if (this) {
+		this->alias = strdup(alias);
+		this->modules = calloc(1, sizeof(char*) * len+1);
+		while (i < len) {
+			this->modules[i] = strdup(modules[i]);
+			i++;
+		}
+		modules[i] = 0;
+
+		dl_list_init(&this->list);
+		dl_list_add(&s->bsp.drivers, &this->list);
+		return this;
+	}
+	return NULL;
+}
+
+void pv_drivers_empty(struct pv_state *s)
+{
+	int num_obj = 0;
+	struct pv_driver *curr, *tmp;
+	struct dl_list *head = &s->bsp.drivers;
+
+	dl_list_for_each_safe(curr, tmp, head,
+			struct pv_driver, list) {
+		dl_list_del(&curr->list);
+		pv_driver_free(curr);
+		num_obj++;
+	}
+
+	pv_log(DEBUG, "cleared %d drivers", num_obj);
+}

--- a/drivers.h
+++ b/drivers.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef PV_DRIVERS_H
+#define PV_DRIVERS_H
+
+#include <stdlib.h>
+#include <limits.h>
+
+#include "platforms.h"
+#include "pantavisor.h"
+
+typedef enum {
+	MOD_LOAD = 0,
+	MOD_UNLOAD
+} mod_action_t;
+
+typedef enum {
+	MOD_UNKNOWN = -1,
+	MOD_UNLOADED,
+	MOD_LOADED
+} mod_state_t;
+
+struct pv_driver {
+	char *alias;
+	char **modules;
+	bool loaded;
+	struct dl_list list;
+};
+
+const char *pv_drivers_state_str(char *match);
+const char *pv_drivers_type_str(plat_driver_t type);
+int pv_drivers_state(char *match);
+char *pv_drivers_state_all(struct pv_platform *p);
+int pv_drivers_load(char *match);
+int pv_drivers_unload(char *match);
+
+struct pv_driver* pv_drivers_add(struct pv_state *s, char *alias, int len, char **modules);
+void pv_drivers_empty(struct pv_state *s);
+
+static inline void pv_driver_free(struct pv_driver *driver)
+{
+	char **modules = driver->modules;
+
+	if (driver->alias)
+		free(driver->alias);
+	if (!driver->modules)
+		return;
+	while (*modules != 0) {
+		free(*modules);
+		modules++;
+	}
+
+	free(driver);
+}
+
+#define pv_drivers_iter_begin(state, item) 	\
+{\
+	struct pv_driver *item##__tmp;\
+	struct dl_list *item##__head = &(state)->bsp.drivers;\
+	dl_list_for_each_safe(item, item##__tmp, item##__head,\
+			struct pv_driver, list)
+
+#define pv_drivers_iter_end	}
+#endif // PV_DRIVERS_H

--- a/metadata.c
+++ b/metadata.c
@@ -824,18 +824,16 @@ void pv_metadata_parse_usermeta(char *buf)
 	usermeta_clear(pv);
 }
 
-static struct pv_meta* pv_metadata_get_usermeta(struct pantavisor *pv, char *key)
+char *pv_metadata_get_usermeta(char *key)
 {
-	if (!pv || !pv->metadata)
-		return NULL;
-
-	struct pv_meta *curr, *tmp;
+	struct pantavisor *pv = pv_get_instance();
 	struct dl_list *head = &pv->metadata->usermeta;
+	struct pv_meta *curr, *tmp;
 
 	dl_list_for_each_safe(curr, tmp, head,
 			struct pv_meta, list) {
 		if (!strcmp(curr->key, key))
-			return curr;
+			return curr->value;
 	}
 	return NULL;
 }

--- a/metadata.h
+++ b/metadata.h
@@ -39,6 +39,11 @@
 #define DEVMETA_KEY_PV_VERSION "pantavisor.version"
 #define DEVMETA_KEY_PH_ADDRESS "pantahub.address"
 
+typedef enum {
+	USER_META,
+	DEVICE_META
+} pv_metadata_t;
+
 struct pv_metadata {
 	struct dl_list usermeta; // pv_meta
 	struct dl_list devmeta; // pv_meta
@@ -51,6 +56,7 @@ bool pv_metadata_factory_meta_done(struct pantavisor *pv);
 void pv_metadata_init_usermeta(struct pv_state *s);
 int pv_metadata_add_usermeta(const char *key, const char *value);
 int pv_metadata_rm_usermeta(const char *key);
+char *pv_metadata_get_usermeta(char *key);
 void pv_metadata_parse_usermeta(char *buf);
 
 int pv_metadata_init_devmeta(struct pantavisor *pv);

--- a/platforms.h
+++ b/platforms.h
@@ -41,6 +41,19 @@ typedef enum {
 	PLAT_STOPPED
 } plat_status_t;
 
+typedef enum {
+	DRIVER_REQUIRED = (1 << 0),
+	DRIVER_OPTIONAL = (1 << 1),
+	DRIVER_MANUAL   = (1 << 2)
+} plat_driver_t;
+
+struct pv_platform_driver {
+	plat_driver_t type;
+	bool loaded;
+	char *match;
+	struct dl_list list;
+};
+
 struct pv_platform {
 	char *name;
 	char *type;
@@ -54,6 +67,7 @@ struct pv_platform {
 	struct pv_state *state;
 	bool mgmt;
 	bool updated;
+	struct dl_list drivers;
 	struct dl_list condition_refs; // pv_condition_ref
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
@@ -65,7 +79,11 @@ struct pv_platform {
 
 void pv_platform_free(struct pv_platform *p);
 
+void pv_platform_add_driver(struct pv_platform *g, plat_driver_t type, char *value);
 void pv_platform_add_condition(struct pv_platform *g, struct pv_condition *c);
+
+int pv_platform_load_drivers(struct pv_platform *p, char *namematch, plat_driver_t typematch);
+void pv_platform_unload_drivers(struct pv_platform *p, char *namematch, plat_driver_t typematch);
 
 int pv_platform_start(struct pv_platform *p);
 int pv_platform_stop(struct pv_platform *p);

--- a/scripts/hooks_lxc-mount.d/mdev.sh
+++ b/scripts/hooks_lxc-mount.d/mdev.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+/bin/cat /proc/self/environ | tr '\0' '\n'
+
+container_mdev=/storage/trails/current/$LXC_NAME/mdev.json
+
+if ! [ -f $container_mdev ]; then
+	exit 0
+fi
+
+tmpf=`mktemp -t mdev.conf.XXXXXXX`
+
+echo "CONTAINER_DEV: $container_mdev"
+
+cat $container_mdev \
+	| /lib/pv/JSON.sh -l \
+	| grep '\["rules",' \
+	| sed 's/[^[:space:]]*[[:space:]]"//;s/"$//' \
+	> $tmpf
+
+FOLLOW_X_ROOT=$LXC_ROOTFS_MOUNT MDEV_CONF=$tmpf mdev -vvv -S -d >/dev/null 2>&1 </dev/null
+

--- a/state.h
+++ b/state.h
@@ -45,6 +45,7 @@ struct pv_bsp {
 	} img;
 	char *firmware;
 	char *modules;
+	struct dl_list drivers; // pv_driver
 };
 
 struct pv_state {

--- a/utils/str.c
+++ b/utils/str.c
@@ -75,6 +75,18 @@ char *pv_str_unescape_to_ascii(char *buf, char *code, char c)
 	return new;
 }
 
+int pv_str_count_list(char **list)
+{
+	int len = 0;
+
+	while (*list) {
+		len++;
+		list++;
+	}
+
+	return len;
+}
+
 char *pv_str_skip_prefix(char *str, const char *key)
 {
 	if (!str || !key)

--- a/utils/str.h
+++ b/utils/str.h
@@ -66,6 +66,7 @@ char *pv_str_replace_str(const char *s1, const char *s2, const char *s3);
 char *pv_str_unescape_to_ascii(char *buf, char *code, char c);
 char *pv_str_replace_char(char *str, int len, char which, char what);
 char *pv_str_skip_prefix(char *str, const char *key);
+int pv_str_count_list(char **list);
 
 /* prints seconds since beginning of epoch in buf */
 size_t epochsecstring(char *buf, size_t len, time_t t);


### PR DESCRIPTION
This adds support to a declarative interface in the BSP JSON
for kernel modules that are provided by the BSP and that expose
the said modules to the application containers depending on the
presence of a named dtb or dtbo object as passed by the bootloader.