### PR TITLE
appengine init mode

### DIFF
--- a/config_parser.c
+++ b/config_parser.c
@@ -134,28 +134,12 @@ static struct config_item* _config_replace_item(struct dl_list *list,
 
 int config_parse_cmdline(struct dl_list *list, char *hint)
 {
-	int fd, bytes;
+	struct pantavisor *pv = pv_get_instance();
 	char *buf = NULL, *k = NULL, *nl = NULL;
 	char *ptr_out = NULL, *ptr_in = NULL;
 	char *token = NULL, *key = NULL, *value = NULL;
 
-	// Get current step revision from cmdline
-	fd = open("/proc/cmdline", O_RDONLY);
-	if (fd < 0)
-		return -1;
-
-	buf = calloc(1, sizeof(char) * (1024 + 1));
-	if (!buf) {
-		close(fd);
-		return -1;
-	}
-
-	bytes = pv_file_read_nointr(fd, buf, sizeof(char)*1024);
-	if (!bytes) {
-		close(fd);
-		return -1;
-	}
-	close(fd);
+	buf = strdup(pv->cmdline);
 	token = strtok_r(buf, " ", &ptr_out);
 	while (token) {
 		if (strncmp(hint, token, strlen(hint)) == 0) {

--- a/ctrl.c
+++ b/ctrl.c
@@ -140,10 +140,15 @@ out:
 
 void pv_ctrl_socket_close(int ctrl_fd)
 {
+	char path[PATH_MAX];
+
 	if (ctrl_fd >= 0) {
-		pv_log(DEBUG, "closing ctrl socket with fd %d", ctrl_fd);
+		pv_paths_pv_file(path, PATH_MAX, PVCTRL_FNAME);
+		pv_log(DEBUG, "closing %s with fd %d", path, ctrl_fd);
 		close(ctrl_fd);
+		unlink(path);
 	}
+
 }
 
 static struct pv_cmd* pv_ctrl_parse_command(char *buf)

--- a/metadata.c
+++ b/metadata.c
@@ -251,6 +251,9 @@ static void pv_usermeta_remove(struct pv_metadata *metadata)
 	struct pv_meta *curr, *tmp;
 	struct dl_list *head = &metadata->usermeta;
 
+	if (dl_list_empty(&metadata->usermeta))
+		return;
+
 	pv_log(DEBUG, "removing user meta list");
 
 	dl_list_for_each_safe(curr, tmp, head,
@@ -264,6 +267,9 @@ static void pv_devmeta_remove(struct pv_metadata *metadata)
 {
 	struct pv_meta *curr, *tmp;
 	struct dl_list *head = &metadata->devmeta;
+
+	if (dl_list_empty(&metadata->devmeta))
+		return;
 
 	pv_log(DEBUG, "removing devmeta list");
 
@@ -967,6 +973,9 @@ char* pv_metadata_get_device_meta_string()
 void pv_metadata_remove()
 {
 	struct pantavisor *pv = pv_get_instance();
+
+	if(!pv->metadata)
+		return;
 
 	pv_log(DEBUG, "removing metadata");
 

--- a/mount.c
+++ b/mount.c
@@ -81,6 +81,9 @@ static int pv_mount_init(struct pv_init *this)
 	char path[PATH_MAX];
 	int ret = -1;
 
+	if (pv_config_get_system_init_mode() == IM_APPENGINE)
+		return 0;
+
 	// Create storage mountpoint and mount device
 	pv_paths_storage(path, PATH_MAX);
 	mkdir_p(path, 0755);
@@ -106,8 +109,9 @@ static int pv_mount_init(struct pv_init *this)
 
 	printf("INFO: trail storage found: %s.\n", dev_info.device);
 
-	// attempt auto resize only if we have ext4
-	if (!strcmp(pv_config_get_storage_fstype(), "ext4")) {
+	// attempt auto resize only if we have ext4 and in embedded init mode
+	if ((pv_config_get_system_init_mode() == IM_EMBEDDED) &&
+		!strcmp(pv_config_get_storage_fstype(), "ext4")) {
 		size_t run_size = strlen("/lib/pv/pv_e2fsgrow") + strlen(dev_info.device) + 3;
 		char *run = malloc(sizeof(char) * run_size);
 		SNPRINTF_WTRUNC(run, run_size, "/lib/pv/pv_e2fsgrow %s", dev_info.device);

--- a/pantavisor.h
+++ b/pantavisor.h
@@ -38,7 +38,6 @@ extern char pv_user_agent[4096];
 #define PV_USER_AGENT_FMT "Pantavisor/2 (Linux; %s) PV/%s Date/%s"
 
 struct pantavisor {
-	struct pv_device *dev;
 	struct pv_update *update;
 	struct pv_state *state;
 	struct pv_cmd *cmd;
@@ -46,6 +45,7 @@ struct pantavisor {
 	struct trail_remote *remote;
 	struct pv_metadata *metadata;
 	struct pv_connection *conn;
+	char *cmdline;
 	bool remote_mode;
 	bool online;
 	bool unclaimed;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,9 +34,11 @@
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
+#include "parser.h"
+#include "parser_multi1.h"
+#include "parser_system1.h"
 #include "pantavisor.h"
 #include "json.h"
-#include "parser.h"
 #include "state.h"
 
 struct pv_state_parser {
@@ -60,15 +62,9 @@ struct pv_state_parser parsers[SPEC_UNKNOWN] = {
 	}
 };
 
-static struct pv_state_parser* _get_parser(char *spec)
+static struct pv_state_parser* _get_parser(state_spec_t spec)
 {
-	int i;
-
-	for (i = 0; i < SPEC_UNKNOWN; i++)
-		if (strcmp(parsers[i].spec, spec) == 0)
-			return &parsers[i];
-
-	return NULL;
+	return &parsers[spec];
 }
 
 static state_spec_t pv_parser_convert_spec(char *spec)
@@ -82,10 +78,21 @@ static state_spec_t pv_parser_convert_spec(char *spec)
 	return SPEC_UNKNOWN;
 }
 
+static bool pv_parser_is_compatible(state_spec_t spec)
+{
+	// embedded and standalone init modes are compatible with multi1 and system1
+	// appengine init mode is only compatible with system1
+	return ((pv_config_get_system_init_mode() == IM_EMBEDDED) ||
+			(pv_config_get_system_init_mode() == IM_STANDALONE) ||
+			((pv_config_get_system_init_mode() == IM_APPENGINE) &&
+			(spec == SPEC_SYSTEM1)));
+}
+
 struct pv_state* pv_parser_get_state(const char *buf, const char *rev)
 {
 	int tokc, ret;
-	char *spec = 0;
+	char *value = 0;
+	state_spec_t spec;
 	struct pv_state *state = 0;
 	struct pv_state_parser *p;
 	jsmntok_t *tokv;
@@ -97,19 +104,27 @@ struct pv_state* pv_parser_get_state(const char *buf, const char *rev)
 		goto out;
 	}
 
-	spec = pv_json_get_value(buf, "#spec", tokv, tokc);
-	if (!spec) {
+	value = pv_json_get_value(buf, "#spec", tokv, tokc);
+	if (!value) {
 		pv_log(WARN, "step JSON has no valid #spec key");
+		goto out;
+	}
+
+	spec = pv_parser_convert_spec(value);
+	if (!pv_parser_is_compatible(spec)) {
+		pv_log(WARN, "spec '%s' not compatible with init mode %d",
+			value,
+			pv_config_get_system_init_mode());
 		goto out;
 	}
 
 	p = _get_parser(spec);
 	if (!p) {
-		pv_log(WARN, "no parser plugin available for '%s' spec", spec);
+		pv_log(WARN, "no parser plugin available for '%s' spec", value);
 		goto out;
 	}
 
-	state = pv_state_new(rev, pv_parser_convert_spec(spec));
+	state = pv_state_new(rev, spec);
 	if (state) {
 		if (!p->parse(state, buf)) {
 			pv_state_free(state);
@@ -119,8 +134,8 @@ struct pv_state* pv_parser_get_state(const char *buf, const char *rev)
 out:
 	if (tokv)
 		free(tokv);
-	if (spec)
-		free(spec);
+	if (value)
+		free(value);
 
 	return state;
 }
@@ -128,30 +143,45 @@ out:
 char* pv_parser_get_initrd_config_name(const char *buf)
 {
 	int tokc;
-	char *spec = 0;
+	char *value = 0;
+	state_spec_t spec;
 	struct pv_state_parser *p;
 	jsmntok_t *tokv;
 	char* config_name = NULL;
 
 	// Parse full state json
-	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0)
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(WARN, "unable to parse state JSON");
 		goto out;
+	}
 
-	spec = pv_json_get_value(buf, "#spec", tokv, tokc);
-	if (!spec)
+	value = pv_json_get_value(buf, "#spec", tokv, tokc);
+	if (!value) {
+		pv_log(WARN, "step JSON has no valid #spec key");
 		goto out;
+	}
+
+	spec = pv_parser_convert_spec(value);
+	if (!pv_parser_is_compatible(spec)) {
+		pv_log(WARN, "spec '%s' not compatible with init mode %d",
+			value,
+			pv_config_get_system_init_mode());
+		goto out;
+	}
 
 	p = _get_parser(spec);
-	if (!p)
+	if (!p) {
+		pv_log(WARN, "no parser plugin available for '%s' spec", value);
 		goto out;
+	}
 
 	config_name = p->parse_initrd_config_name(buf);
 
 out:
 	if (tokv)
 		free(tokv);
-	if (spec)
-		free(spec);
+	if (value)
+		free(value);
 
 	return config_name;
 }

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,7 @@
 #ifndef PV_PARSER_H
 #define PV_PARSER_H
 
-#include <stdbool.h>
-
-#include "pantavisor.h"
-
-//  pantavisor-multi-platform@1
-struct pv_state* multi1_parse(struct pv_state *this, const char *buf);
-char* multi1_parse_initrd_config_name(const char *buf);
-
-//  pantavisor-service-system@1
-struct pv_state* system1_parse(struct pv_state *this, const char *buf);
-char* system1_parse_initrd_config_name(const char *buf);
+#include "state.h"
 
 struct pv_state* pv_parser_get_state(const char *buf, const char *rev);
 char* pv_parser_get_initrd_config_name(const char *buf);

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -34,12 +34,12 @@
 #define pv_log(level, msg, ...)         vlog(MODULE_NAME, level, msg, ## __VA_ARGS__)
 #include "log.h"
 
+#include "parser_multi1.h"
 #include "addons.h"
 #include "platforms.h"
 #include "volumes.h"
 #include "objects.h"
 #include "pantavisor.h"
-#include "parser.h"
 #include "state.h"
 #include "json.h"
 #include "utils/str.h"

--- a/parser/parser_multi1.h
+++ b/parser/parser_multi1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Pantacor Ltd.
+ * Copyright (c) 2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,26 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef PV_LXC_H
-#define PV_LXC_H
+#ifndef PV_PARSER_MULSTI1_H
+#define PV_PARSER_MULSTI1_H
 
-#include "../pantavisor.h"
-#include "../config.h"
-#include "../platforms.h"
+#include "state.h"
 
-void pv_set_new_log_fn(void *fn_pv_new_log);
-void pv_set_pv_instance_fn(void *fn_pv_get_instance);
-void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
-	void *fn_pv_paths_pv_log,
-	void *fn_pv_paths_pv_log_plat,
-	void *fn_pv_paths_pv_log_file,
-	void *fn_pv_paths_pv_usrmeta_key,
-	void *fn_pv_paths_pv_usrmeta_plat_key,
-	void *fn_pv_paths_lib_hook,
-	void *fn_pv_paths_volumes_plat_file,
-	void *fn_pv_paths_configs_file);
-
-void* pv_start_container(struct pv_platform *p, const char *rev, char *conf_file, void *data);
-void* pv_stop_container(struct pv_platform *p, char *conf_file, void *data);
+struct pv_state* multi1_parse(struct pv_state *this, const char *buf);
+char* multi1_parse_initrd_config_name(const char *buf);
 
 #endif

--- a/parser/parser_system1.h
+++ b/parser/parser_system1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Pantacor Ltd.
+ * Copyright (c) 2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,26 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef PV_LXC_H
-#define PV_LXC_H
+#ifndef PV_PARSER_SYSTEM1_H
+#define PV_PARSER_SYSTEM1_H
 
-#include "../pantavisor.h"
-#include "../config.h"
-#include "../platforms.h"
+#include "state.h"
 
-void pv_set_new_log_fn(void *fn_pv_new_log);
-void pv_set_pv_instance_fn(void *fn_pv_get_instance);
-void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
-	void *fn_pv_paths_pv_log,
-	void *fn_pv_paths_pv_log_plat,
-	void *fn_pv_paths_pv_log_file,
-	void *fn_pv_paths_pv_usrmeta_key,
-	void *fn_pv_paths_pv_usrmeta_plat_key,
-	void *fn_pv_paths_lib_hook,
-	void *fn_pv_paths_volumes_plat_file,
-	void *fn_pv_paths_configs_file);
-
-void* pv_start_container(struct pv_platform *p, const char *rev, char *conf_file, void *data);
-void* pv_stop_container(struct pv_platform *p, char *conf_file, void *data);
+struct pv_state* system1_parse(struct pv_state *this, const char *buf);
+char* system1_parse_initrd_config_name(const char *buf);
 
 #endif

--- a/paths.c
+++ b/paths.c
@@ -273,11 +273,11 @@ void pv_paths_etc_file(char *buf, size_t size, const char *name)
 	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, pv_config_get_system_etcdir(), name);
 }
 
-#define PV_CONFIGS_PATHF "%s/"
+#define PV_CONFIGS_PATHF "%s/%s"
 
-void pv_paths_configs(char *buf, size_t size)
+void pv_paths_configs_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF, pv_config_get_system_confdir());
+	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF, pv_config_get_system_confdir(), name);
 }
 
 #define PV_CERT_PATHF "%s/%s"

--- a/paths.h
+++ b/paths.h
@@ -115,7 +115,7 @@ void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const 
 
 void pv_paths_etc_file(char *buf, size_t size, const char *name);
 
-void pv_paths_configs(char *buf, size_t size);
+void pv_paths_configs_file(char *buf, size_t size, const char *name);
 
 void pv_paths_cert(char *buf, size_t size, const char* name);
 

--- a/platforms.c
+++ b/platforms.c
@@ -362,7 +362,7 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_instance_fn");
 
-	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
+	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
 	if (__pv_paths)
 		__pv_paths(pv_paths_pv_file,
 			pv_paths_pv_log,
@@ -370,7 +370,9 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 			pv_paths_pv_log_file,
 			pv_paths_pv_usrmeta_key,
 			pv_paths_pv_usrmeta_plat_key,
-			pv_paths_lib_hook);
+			pv_paths_lib_hook,
+			pv_paths_volumes_plat_file,
+			pv_paths_configs_file);
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_paths_fn");
 
@@ -567,8 +569,7 @@ int pv_platform_start(struct pv_platform *p)
 	data = ctrl->start(p, s->rev, path, (void *) &pid);
 
 	if (!data) {
-		pv_log(ERROR, "error starting platform: \"%s\"",
-			p->name);
+		pv_log(ERROR, "error starting platform: '%s'", p->name);
 		return -1;
 	}
 

--- a/state.c
+++ b/state.c
@@ -616,7 +616,9 @@ static int pv_state_unmount_platforms_volumes(struct pv_state *s)
 	// unmount platform volumes
 	dl_list_for_each_safe(p, tmp_p, &s->platforms,
 			struct pv_platform, list) {
-		if (pv_platform_is_stopped(p)) {
+		if (!(pv_platform_is_stopping(p) ||
+			pv_platform_is_starting(p) ||
+			pv_platform_is_started(p))) {
 			if (pv_state_unmount_platform_volumes(s, p))
 				ret = -1;
 		}
@@ -628,6 +630,11 @@ static int pv_state_unmount_platforms_volumes(struct pv_state *s)
 int pv_state_stop(struct pv_state *s)
 {
 	int ret = 0;
+
+	if (s == NULL)
+		return -1;
+
+	pv_log(DEBUG, "stopping state %s", s->rev);
 
 	pv_state_lenient_stop(s);
 

--- a/state.h
+++ b/state.h
@@ -30,7 +30,7 @@ typedef enum {
 	SPEC_MULTI1,
 	SPEC_SYSTEM1,
 	SPEC_UNKNOWN
-} state_spec_t ;
+} state_spec_t;
 
 struct pv_bsp {
 	union {

--- a/updater.c
+++ b/updater.c
@@ -1154,8 +1154,8 @@ static void pv_trail_remote_free(struct trail_remote *trail)
 		free(trail->endpoint_trail_queued);
 	if (trail->endpoint_trail_new)
 		free(trail->endpoint_trail_new);
-	if (trail->endpoint_trail_queued)
-		free(trail->endpoint_trail_queued);
+	if (trail->endpoint_trail_downloading)
+		free(trail->endpoint_trail_downloading);
 	if (trail->endpoint_trail_inprogress)
 		free(trail->endpoint_trail_inprogress);
 


### PR DESCRIPTION
This change introduces the changes that are necessary to make apengine init mode work. This init mode allows to run Pantavisor in an existing Linux distro.

It is set in pantavisor.config like:

```
system.init.mode=appengine
```

With this, Pantavisor will expect state JSONs with the pantavisor-service-system@1 spec, but will not allow the bsp keys in them. 

List of changes:
* bootloader: get cmdline from pv struct instead of from disk
* config: fix value string override
* config: fix keep_factory
* config: move log.dir to pantavisor.config
* config_parser: get cmdline from pv struct instead of from disk
* ctrl: unlink socket after closing it to allow reopening
* init: avoid early mounts in appengine init mode
* init: allow cmdline as an argument. Load from disk if argument not used
* metadata: do not remove usrmeta and devmeta lists if empty, which could case a crash
* mount: avoid late mounts in appengine init mode
* mount: avoid executing pv_e2fsgrow if not in embedded mode
* pantavisor: store cmdline in pv struct
* pantavisor: fix state not being stopped (and thus volumes not unmounted) in some rollback cases
* pantavisor: avoid reseting or rebooting in appengine init mode. Exit instead
* parser: minor refactor to allow easier addition of new parse formats
* parser: limit appengine init mode to system1
* parser_system1: minor refactor to allow reuse of parser code from other formats
* parser_system1: disable bsp and non app groups in appengine init mode
* paths: configs now accept file names
* ph_logger: close and unlink socket when stopping log main service
* pv_lxc: add some missing dynamic paths
* pv_lxc: shutdown containers that failed to start to avoid leftovers in further executions
* state: unmount volumes allways except when plat is stopping, starting or started
* storage: avoid linking bsp artifacts in appengine init mode
* updater: fix endpoint downloading being freed twice