### PR TITLE
add mdev.sh to hooks_lxc-mount.d

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -94,7 +94,7 @@ LOCAL_GENERATED_SRC_FILES := version.c
 
 LOCAL_COPY_FILES := scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
 	scripts/hooks_lxc-mount.d/export.sh:lib/pv/hooks_lxc-mount.d/export.sh \
-	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
+	scripts/hooks_lxc-host-start.d/mdevhost.sh:lib/pv/hooks_lxc-host-start.d/mdevhost.sh \
 	scripts/JSON.sh:lib/pv/JSON.sh
 
 include $(BUILD_EXECUTABLE)

--- a/atom.mk
+++ b/atom.mk
@@ -94,6 +94,7 @@ LOCAL_GENERATED_SRC_FILES := version.c
 
 LOCAL_COPY_FILES := scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
 	scripts/hooks_lxc-mount.d/export.sh:lib/pv/hooks_lxc-mount.d/export.sh \
+	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
 	scripts/JSON.sh:lib/pv/JSON.sh
 
 include $(BUILD_EXECUTABLE)

--- a/paths.c
+++ b/paths.c
@@ -239,6 +239,7 @@ void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat, const 
 #define PV_LIB_MODULES_PATHF     "%s/modules/%s"
 #define PV_LIB_VOLMOUNT_PATHF    "%s/pv/volmount/%s/%s"
 #define PV_LIB_HOOK_PATHF        "%s/pv/hooks_lxc-mount.d/%s"
+#define PV_LIB_HOOK_START_HOST_PATHF    "%s/pv/hooks_lxc-start-host.d/%s"
 #define PV_LIB_HOOKS_EARLY_SPAWN "%s/pv/hooks_early.spawn/%s"
 
 void pv_paths_lib_plugin(char *buf, size_t size, const char *name)
@@ -259,6 +260,11 @@ void pv_paths_lib_volmount(char *buf, size_t size, const char *type, const char 
 void pv_paths_lib_hook(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_PATHF, pv_config_get_system_libdir(), name);
+}
+
+void pv_paths_lib_hook_start_host(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_START_HOST_PATHF, pv_config_get_system_libdir(), name);
 }
 
 void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name)

--- a/paths.h
+++ b/paths.h
@@ -100,6 +100,7 @@ void pv_paths_lib_plugin(char *buf, size_t size, const char *name);
 void pv_paths_lib_modules(char *buf, size_t size, const char *release);
 void pv_paths_lib_volmount(char *buf, size_t size, const char *type, const char *name);
 void pv_paths_lib_hook(char *buf, size_t size, const char *name);
+void pv_paths_lib_hook_start_host(char *buf, size_t size, const char *name);
 void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name);
 
 void pv_paths_root_file(char *buf, size_t size, const char *path);

--- a/platforms.c
+++ b/platforms.c
@@ -362,7 +362,7 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_instance_fn");
 
-	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
+	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
 	if (__pv_paths)
 		__pv_paths(pv_paths_pv_file,
 			pv_paths_pv_log,
@@ -370,7 +370,8 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 			pv_paths_pv_log_file,
 			pv_paths_pv_usrmeta_key,
 			pv_paths_pv_usrmeta_plat_key,
-			pv_paths_lib_hook);
+			pv_paths_lib_hook,
+			pv_paths_lib_hook_start_host);
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_paths_fn");
 

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -34,7 +34,8 @@ void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
 	void *fn_pv_paths_pv_log_file,
 	void *fn_pv_paths_pv_usrmeta_key,
 	void *fn_pv_paths_pv_usrmeta_plat_key,
-	void *fn_pv_paths_lib_hook);
+	void *fn_pv_paths_lib_hook,
+	void *fn_pv_paths_lib_hook_start_host);
 
 void* pv_start_container(struct pv_platform *p, const char *rev, char *conf_file, void *data);
 void* pv_stop_container(struct pv_platform *p, char *conf_file, void *data);

--- a/scripts/hooks_lxc-host-start.d/mdevhost.sh
+++ b/scripts/hooks_lxc-host-start.d/mdevhost.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+/bin/cat /proc/self/environ | tr '\0' '\n'
+
+container_mdev=/storage/trails/current/$LXC_NAME/mdev.json
+
+if ! [ -f $container_mdev ]; then
+	exit 0
+fi
+
+tmpf=`mktemp -t mdev.conf.XXXXXXX`
+
+echo "CONTAINER_DEV: $container_mdev"
+
+cat $container_mdev \
+	| /lib/pv/JSON.sh -l \
+	| grep '\["rules",' \
+	| sed 's/[^[:space:]]*[[:space:]]"//;s/"$//' \
+	> $tmpf
+
+FOLLOW_X_PID=$LXC_PID MDEV_CONF=$tmpf mdev -vvv -S -d >/dev/null 2>&1 </dev/null
+

--- a/scripts/hooks_lxc-host-start.d/mdevhost.sh
+++ b/scripts/hooks_lxc-host-start.d/mdevhost.sh
@@ -18,5 +18,5 @@ cat $container_mdev \
 	| sed 's/[^[:space:]]*[[:space:]]"//;s/"$//' \
 	> $tmpf
 
-FOLLOW_X_PID=$LXC_PID MDEV_CONF=$tmpf mdev -vvv -S -d >/dev/null 2>&1 </dev/null
+FOLLOW_X_PID=$LXC_PID MDEV_CONF=$tmpf mdev ${MDEV_VERBOSE:+-$MDEV_VERBOSE} -S -d >/dev/null 2>&1 </dev/null
 

--- a/scripts/hooks_lxc-mount.d/mdev.sh
+++ b/scripts/hooks_lxc-mount.d/mdev.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+container_mdev=/storage/trails/current/$LXC_NAME/mdev.json
+
+if ! [ -f $container_mdev ]; then
+	exit 0
+fi
+
+tmpf=`mktemp -t mdev.conf.XXXXXXX`
+cat $container_mdev \
+	| /lib/pv/JSON.sh -l \
+	| grep '\["rules",' \
+	| sed 's/[^[:space:]]*[[:space:]]"//;s/"$//' \
+	> $tmpf
+
+FOLLOW_X_ROOT=$LXC_ROOTFS_MOUNT MDEV_CONF=$tmpf mdev ${MDEV_VERBOSE:+-$MDEV_VERBOSE} -S -d
+


### PR DESCRIPTION
To use this put a mdev.json in your platform folder, e.g. for a container named "busy" you could do:

```
cat busy/mdev.json 
{
    "rules": [
        "hwrng 0:0 666 \u003epv/",
        "ebbchar 0:0 666 \u003epv/",
        ".* 0:0 000 !"
    ]
}