### PR TITLE
add devmeta to storage and allow pvctrl management

### DIFF
--- a/config.c
+++ b/config.c
@@ -210,7 +210,9 @@ static int pv_config_load_config_from_file(char *path, struct pantavisor_config 
 	config->debug.ssh = config_get_value_bool(&config_list, "debug.ssh", true);
 
 	config->cache.dropbearcachedir = config_get_value_string(&config_list, "dropbear.cache.dir", "/storage/cache/dropbear");
-	config->cache.metacachedir = config_get_value_string(&config_list, "meta.cache.dir", "/storage/cache/meta");
+	config->cache.usrmetadir = config_get_value_string(&config_list, "cache.usrmetadir", "/storage/cache/meta");
+	config_override_value_string(&config_list, "meta.cache.dir", &config->cache.usrmetadir);
+	config->cache.devmetadir = config_get_value_string(&config_list, "cache.devmetadir", "/storage/cache/devmeta");
 
 	config->bl.type = config_get_value_bl_type(&config_list, "bootloader.type", BL_UBOOT_PLAIN);
 	config->bl.mtd_only = config_get_value_bool(&config_list, "bootloader.mtd_only", false);
@@ -477,8 +479,10 @@ void pv_config_free()
 {
 	struct pantavisor *pv = pv_get_instance();
 
-	if (pv->config.cache.metacachedir)
-		free(pv->config.cache.metacachedir);
+	if (pv->config.cache.usrmetadir)
+		free(pv->config.cache.usrmetadir);
+	if (pv->config.cache.devmetadir)
+		free(pv->config.cache.devmetadir);
 	if (pv->config.cache.dropbearcachedir)
 		free(pv->config.cache.dropbearcachedir);
 
@@ -551,7 +555,8 @@ char* pv_config_get_system_confdir() { return pv_get_instance()->config.sys.conf
 bool pv_config_get_debug_shell() { return pv_get_instance()->config.debug.shell; }
 bool pv_config_get_debug_ssh() { return pv_get_instance()->config.debug.ssh; }
 
-char* pv_config_get_cache_metacachedir() { return pv_get_instance()->config.cache.metacachedir; }
+char* pv_config_get_cache_usrmetadir() { return pv_get_instance()->config.cache.usrmetadir; }
+char* pv_config_get_cache_devmetadir() { return pv_get_instance()->config.cache.devmetadir; }
 char* pv_config_get_cache_dropbearcachedir() { return pv_get_instance()->config.cache.dropbearcachedir; }
 
 char* pv_config_get_creds_type() { return pv_get_instance()->config.creds.type; }
@@ -649,8 +654,10 @@ char* pv_config_get_json()
 		pv_json_ser_bool(&js, pv_config_get_debug_ssh());
 		pv_json_ser_key(&js, "dropbear.cache.dir");
 		pv_json_ser_string(&js, pv_config_get_cache_dropbearcachedir());
-		pv_json_ser_key(&js, "meta.cache.dir");
-		pv_json_ser_string(&js, pv_config_get_cache_metacachedir());
+		pv_json_ser_key(&js, "cache.usrmetadir");
+		pv_json_ser_string(&js, pv_config_get_cache_usrmetadir());
+		pv_json_ser_key(&js, "cache.devmetadir");
+		pv_json_ser_string(&js, pv_config_get_cache_devmetadir());
 		pv_json_ser_key(&js, "bootloader.type");
 		pv_json_ser_int(&js, pv_config_get_bl_type());
 		pv_json_ser_key(&js, "bootloader.mtd_only");

--- a/config.h
+++ b/config.h
@@ -48,7 +48,8 @@ struct pantavisor_debug {
 };
 
 struct pantavisor_cache {
-	char *metacachedir;
+	char *usrmetadir;
+	char *devmetadir;
 	char *dropbearcachedir;
 };
 
@@ -214,7 +215,8 @@ char* pv_config_get_system_confdir(void);
 bool pv_config_get_debug_shell(void);
 bool pv_config_get_debug_ssh(void);
 
-char* pv_config_get_cache_metacachedir(void);
+char* pv_config_get_cache_usrmetadir(void);
+char* pv_config_get_cache_devmetadir(void);
 char* pv_config_get_cache_dropbearcachedir(void);
 
 char* pv_config_get_creds_type(void);

--- a/metadata.h
+++ b/metadata.h
@@ -53,7 +53,6 @@ struct pv_metadata {
 int pv_metadata_factory_meta(struct pantavisor *pv);
 bool pv_metadata_factory_meta_done(struct pantavisor *pv);
 
-void pv_metadata_init_usermeta(struct pv_state *s);
 int pv_metadata_add_usermeta(const char *key, const char *value);
 int pv_metadata_rm_usermeta(const char *key);
 char *pv_metadata_get_usermeta(char *key);
@@ -61,7 +60,8 @@ void pv_metadata_parse_usermeta(char *buf);
 
 int pv_metadata_init_devmeta(struct pantavisor *pv);
 int pv_metadata_upload_devmeta(struct pantavisor *pv);
-void pv_metadata_add_devmeta(const char *key, const char *value);
+int pv_metadata_add_devmeta(const char *key, const char *value);
+int pv_metadata_rm_devmeta(const char *key);
 void pv_metadata_parse_devmeta(const char *buf);
 
 void pv_metadata_remove(void);

--- a/mount.c
+++ b/mount.c
@@ -51,11 +51,13 @@ static int ph_mount_init(struct pv_init *this)
 	if (stat(pv_path, &st) != 0)
 		mkdir_p(pv_path, 0500);
 
+	// Logs
 	pv_paths_storage_log(storage_path, PATH_MAX);
 	if (stat(storage_path, &st) != 0)
 		mkdir_p(storage_path, 0500);
 
-	pv_paths_storage_meta(storage_path, PATH_MAX);
+	// User meta
+	pv_paths_storage_usrmeta(storage_path, PATH_MAX);
 	if (stat(storage_path, &st) != 0)
 		mkdir_p(storage_path, 0500);
 	pv_paths_pv_usrmeta_key(pv_path, PATH_MAX, "");
@@ -63,6 +65,16 @@ static int ph_mount_init(struct pv_init *this)
 		mkdir_p(pv_path, 0755);
 	mount_bind(storage_path, pv_path);
 
+	// Device meta
+	pv_paths_storage_devmeta(storage_path, PATH_MAX);
+	if (stat(storage_path, &st) != 0)
+		mkdir_p(storage_path, 0500);
+	pv_paths_pv_devmeta_key(pv_path, PATH_MAX, "");
+	if (stat(pv_path, &st) != 0)
+		mkdir_p(pv_path, 0755);
+	mount_bind(storage_path, pv_path);
+
+	// Dropbear
 	pv_paths_storage_dropbear(storage_path, PATH_MAX);
 	if (stat(storage_path, &st) != 0)
 		mkdir_p(storage_path, 0500);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -251,7 +251,6 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 
 	// meta data initialization, also to be uploaded as soon as possible when connected
 	pv_metadata_init_devmeta(pv);
-	pv_metadata_init_usermeta(pv->state);
 
 	if (!pv_update_is_transitioning(pv->update)) {
 		if (pv_state_start(pv->state)) {

--- a/paths.c
+++ b/paths.c
@@ -51,6 +51,19 @@ void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, cons
 	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PLAT_PATHF, pv_config_get_system_rundir(), plat, key);
 }
 
+#define PV_DEVMETA_PATHF      PV_PATH"/"DEVMETA_DNAME"/%s"
+#define PV_DEVMETA_PLAT_PATHF PV_PATH"/device-meta.%s/%s"
+
+void pv_paths_pv_devmeta_key(char *buf, size_t size, const char *key)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_DEVMETA_PATHF, pv_config_get_system_rundir(), key);
+}
+
+void pv_paths_pv_devmeta_plat_key(char *buf, size_t size, const char *plat, const char *key)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_DEVMETA_PLAT_PATHF, pv_config_get_system_rundir(), plat, key);
+}
+
 #define PV_LOGS_PATHF      PV_PATH"/"LOGS_DNAME"/%s"
 #define PV_LOGS_PLAT_PATHF PV_LOGS_PATHF"/%s"
 #define PV_LOGS_FILE_PATHF PV_LOGS_PLAT_PATHF"/%s"
@@ -82,9 +95,14 @@ void pv_paths_storage_log(char *buf, size_t size)
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_log_logdir());
 }
 
-void pv_paths_storage_meta(char *buf, size_t size)
+void pv_paths_storage_usrmeta(char *buf, size_t size)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_metacachedir());
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_usrmetadir());
+}
+
+void pv_paths_storage_devmeta(char *buf, size_t size)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF, pv_config_get_cache_devmetadir());
 }
 
 void pv_paths_storage_dropbear(char *buf, size_t size)

--- a/paths.h
+++ b/paths.h
@@ -37,6 +37,11 @@ void pv_paths_pv_file(char *buf, size_t size, const char *name);
 void pv_paths_pv_usrmeta_key(char *buf, size_t size, const char *key);
 void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat, const char *key);
 
+#define DEVMETA_DNAME "device-meta"
+
+void pv_paths_pv_devmeta_key(char *buf, size_t size, const char *key);
+void pv_paths_pv_devmeta_plat_key(char *buf, size_t size, const char *plat, const char *key);
+
 #define LOGS_DNAME            "logs"
 #define LOGS_ERROR_DNAME      "error"
 #define LXC_LOG_SUBDIR        "lxc"
@@ -51,7 +56,8 @@ void pv_paths_pv_log_file(char *buf, size_t size, const char *rev, const char *p
 
 void pv_paths_storage(char *buf, size_t size);
 void pv_paths_storage_log(char *buf, size_t size);
-void pv_paths_storage_meta(char *buf, size_t size);
+void pv_paths_storage_usrmeta(char *buf, size_t size);
+void pv_paths_storage_devmeta(char *buf, size_t size);
 void pv_paths_storage_dropbear(char *buf, size_t size);
 
 #define COREPV_FNAME "corepv"
@@ -126,5 +132,6 @@ void pv_paths_tmp(char *buf, size_t size, const char *path);
 #define PLATFORM_PVCTRL_SOCKET_PATH PLATFORM_PV_PATH"/"PVCTRL_FNAME
 #define PLATFORM_LOG_CTRL_PATH      PLATFORM_PV_PATH"/"LOGCTRL_FNAME
 #define PLATFORM_USER_META_PATH     PLATFORM_PV_PATH"/"USRMETA_DNAME
+#define PLATFORM_DEVICE_META_PATH   PLATFORM_PV_PATH"/"DEVMETA_DNAME
 
 #endif /* PATHS_H */

--- a/platforms.c
+++ b/platforms.c
@@ -275,7 +275,7 @@ char* pv_platform_get_json(struct pv_platform *p)
 {
 	struct pv_condition_ref *cr, *tmp;
 	struct pv_json_ser js;
-	char *group = NULL, *line;
+	char *group = NULL;
 	const char *status = pv_platform_status_string(p->status);
 	int i;
 
@@ -423,7 +423,7 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 	else
 		pv_log(ERROR, "Couldn't locate symbol pv_set_pv_instance_fn");
 
-	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
+	void (*__pv_paths)(void*, void*, void*, void*, void*, void*, void*, void*, void*, void*, void*) = dlsym(lib, "pv_set_pv_paths_fn");
 	if (__pv_paths)
 		__pv_paths(pv_paths_pv_file,
 			pv_paths_pv_log,
@@ -431,6 +431,8 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 			pv_paths_pv_log_file,
 			pv_paths_pv_usrmeta_key,
 			pv_paths_pv_usrmeta_plat_key,
+			pv_paths_pv_devmeta_key,
+			pv_paths_pv_devmeta_plat_key,
 			pv_paths_lib_hook,
 			pv_paths_volumes_plat_file,
 			pv_paths_configs_file);

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -34,6 +34,8 @@ void pv_set_pv_paths_fn(void *fn_pv_paths_pv_file,
 	void *fn_pv_paths_pv_log_file,
 	void *fn_pv_paths_pv_usrmeta_key,
 	void *fn_pv_paths_pv_usrmeta_plat_key,
+	void *fn_pv_paths_pv_devmeta_key,
+	void *fn_pv_paths_pv_devmeta_plat_key,
 	void *fn_pv_paths_lib_hook,
 	void *fn_pv_paths_volumes_plat_file,
 	void *fn_pv_paths_configs_file);

--- a/storage.c
+++ b/storage.c
@@ -942,15 +942,6 @@ out:
 	return ret;
 }
 
-void pv_storage_init_plat_usermeta(const char *name)
-{
-	char path[PATH_MAX];
-
-	pv_paths_pv_usrmeta_plat_key(path, PATH_MAX, name, "");
-	if (!dir_exist(path))
-		mkdir_p(path, 0755);
-}
-
 void pv_storage_save_usermeta(const char *key, const char *value)
 {
 	char path[PATH_MAX];
@@ -967,7 +958,9 @@ void pv_storage_save_usermeta(const char *key, const char *value)
 	if (pkey) {
 		*pkey = '\0';
 		pkey++;
-		pv_storage_init_plat_usermeta(pname);
+		pv_paths_pv_usrmeta_plat_key(path, PATH_MAX, pname, "");
+		if (!dir_exist(path))
+			mkdir_p(path, 0755);
 		pv_paths_pv_usrmeta_plat_key(path, PATH_MAX, pname, pkey);
 		if (pv_file_save(path, value, 0644) < 0)
 			pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
@@ -993,6 +986,55 @@ void pv_storage_rm_usermeta(const char *key)
 		pv_paths_pv_usrmeta_plat_key(path, PATH_MAX, pname, pkey);
 		remove(path);
 		pv_log(DEBUG, "removed usermeta in %s", path);
+	}
+
+	free(pname);
+}
+
+void pv_storage_save_devmeta(const char *key, const char *value)
+{
+	char path[PATH_MAX];
+	char *pname, *pkey;
+
+	pv_log(DEBUG, "saving devmeta file with key %s and value %s", key, value);
+
+	pv_paths_pv_devmeta_key(path, PATH_MAX, key);
+	if (pv_file_save(path, value, 0644) < 0)
+		pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
+
+	pname = strdup(key);
+	pkey = strchr(pname, '.');
+	if (pkey) {
+		*pkey = '\0';
+		pkey++;
+		pv_paths_pv_devmeta_plat_key(path, PATH_MAX, pname, "");
+		if (!dir_exist(path))
+			mkdir_p(path, 0755);
+		pv_paths_pv_devmeta_plat_key(path, PATH_MAX, pname, pkey);
+		if (pv_file_save(path, value, 0644) < 0)
+			pv_log(WARN, "could not save file %s: %s", path, strerror(errno));
+	}
+
+	free(pname);
+}
+
+void pv_storage_rm_devmeta(const char *key)
+{
+	char path[PATH_MAX];
+	char *pname, *pkey;
+
+	pv_paths_pv_devmeta_key(path, PATH_MAX, key);
+	remove(path);
+	pv_log(DEBUG, "removed devmeta in %s", path);
+
+	pname = strdup(key);
+	pkey = strchr(pname, '.');
+	if (pkey) {
+		*pkey = '\0';
+		pkey++;
+		pv_paths_pv_devmeta_plat_key(path, PATH_MAX, pname, pkey);
+		remove(path);
+		pv_log(DEBUG, "removed devmeta in %s", path);
 	}
 
 	free(pname);

--- a/storage.h
+++ b/storage.h
@@ -58,8 +58,9 @@ void pv_storage_gc_run_threshold(void);
 int pv_storage_meta_expand_jsons(struct pantavisor *pv, struct pv_state *s);
 int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s);
 
-void pv_storage_init_plat_usermeta(const char *name);
 void pv_storage_save_usermeta(const char *key, const char *value);
 void pv_storage_rm_usermeta(const char *key);
+void pv_storage_save_devmeta(const char *key, const char *value);
+void pv_storage_rm_devmeta(const char *key);
 
 #endif // PV_STORAGE_H


### PR DESCRIPTION
This allows devmeta to be saved on disk and loaded after reboots in a usrmeta fashion. It also adds new pvctrl requests to save and delete devmeta (for now it requires mgmt role).

List of changes:
* config: deprecate meta.cache.dir in favour of cache.usrmetadir
* config: add new cache.devmetadir pantavisor.config key
* ctrl: add new PUT and DELETE usrmeta requests
* metadata: avoid initializating user-meta.<plat> if there is nothing to store
* metadata: save devmeta in storage when added
* metadata: add new rm devmeta function
* metadata: load devmeta from storage when initializing pv
* mount: mount new device-meta dir in /pv
* paths: new path functions for /storage and /pv devmeta
* pv_lxc: mount /storage/device-meta in mgmt plats
* pv_lxc: mount /storage/device-meta.<plat> in non-mgmt plats
* storage: new functions to save and remove devmeta from disk