### PR TITLE
Refactor file and fs libraries

### DIFF
--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -39,26 +39,6 @@ bool pv_filesystem_path_is_directory(const char *path)
     return false;
 }
 
-static int get_directory(char *dir, const char *path)
-{
-    if (!pv_filesystem_path_exist(path)) {
-        dir = NULL;
-        return -1;
-    }
-
-    if (pv_filesystem_path_is_directory(path)) {
-        strncpy(dir, path, strnlen(path, PATH_MAX));
-        return 0;
-    } else if (errno == ENOTDIR) {
-        char copy[PATH_MAX];
-        strncpy(copy, path, strnlen(path, PATH_MAX));
-
-        char *tmp = dirname(copy);
-        strncpy(dir, tmp, strnlen(path, PATH_MAX));
-    }
-    return 0;
-}
-
 void pv_filesystem_path_sync(const char *path)
 {
     char dir[PATH_MAX] = { 0 };

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <libgen.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -143,3 +143,14 @@ free_dir:
 
     return ret;
 }
+int pv_fs_path_rename(const char *src_path, const char *dst_path)
+{
+    pv_fs_path_sync(src_path);
+
+    int ret = rename(src_path, dst_path);
+    if (ret < 0)
+        return ret;
+
+    pv_fs_path_sync(dst_path);
+    return 0;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,4 +1,5 @@
 #include "filesystem.h"
+#include "tsh.h"
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -380,4 +381,19 @@ int pv_fs_file_unlock(int fd)
         ret = fcntl(fd, F_SETLK, &flock);
 
     return ret;
+}
+
+int pv_fs_file_gzip(const char *fname, const char *target_name)
+{
+	int outfile[] = { -1, -1 };
+	char cmd[PATH_MAX + 32];
+
+	snprintf(cmd, sizeof(cmd), "gzip %s", fname);
+	outfile[1] = open(target_name, O_RDWR | O_APPEND | O_CREAT);
+	if (outfile[1] >= 0) {
+		tsh_run_io(cmd, 1, NULL, NULL, outfile, NULL);
+		close_fd(&outfile[1]);
+		return 0;
+	}
+	return -1;
 }

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -262,26 +262,6 @@ int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname, co
     return cur_size == size ? 0 : -1;
 }
 
-char *pv_filesystem_file_get_xattr_dup(const char *fname, const char *attr)
-{
-    ssize_t size = getxattr(fname, attr, NULL, 0);
-    if (size < 1)
-        return NULL;
-
-    char *val = malloc(size);
-    if (!val)
-        return NULL;
-
-    ssize_t cur_size = getxattr(fname, attr, val, size);
-
-    if (cur_size != size) {
-        free(val);
-        return NULL;
-    }
-
-    return val;
-}
-
 int pv_filesystem_file_set_xattr(const char *fname, const char *attr, const char *value)
 {
     ssize_t size = getxattr(fname, attr, NULL, 0);

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -354,6 +354,7 @@ int pv_filesystem_file_gzip(const char *fname, const char *target_name)
 	if (outfile[1] >= 0) {
 		tsh_run_io(cmd, 1, NULL, NULL, outfile, NULL);
 		close_fd(&outfile[1]);
+    pv_filesystem_path_sync(target_name);
 		return 0;
 	}
 	return -1;

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,5 +1,6 @@
 #include "filesystem.h"
 #include "tsh.h"
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -12,6 +13,7 @@
 #include <sys/stat.h>
 #include <sys/xattr.h>
 #include <unistd.h>
+
 static void close_fd(int *fd)
 {
     if (!fd || *fd < 0)
@@ -127,6 +129,7 @@ void pv_fs_path_join(char *buf, int size, ...)
 
     va_end(list);
 }
+
 int pv_fs_path_remove(const char *path, bool recursive)
 {
     if (!recursive) {
@@ -157,6 +160,7 @@ free_dir:
 
     return ret;
 }
+
 int pv_fs_path_rename(const char *src_path, const char *dst_path)
 {
     pv_fs_path_sync(src_path);
@@ -168,6 +172,7 @@ int pv_fs_path_rename(const char *src_path, const char *dst_path)
     pv_fs_path_sync(dst_path);
     return 0;
 }
+
 int pv_fs_file_tmp(char *tmp, const char *fname)
 {
     if (!fname)
@@ -211,6 +216,7 @@ out:
 
     return ret;
 }
+
 ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src)
 {
     lseek(src, 0, SEEK_SET);
@@ -314,6 +320,7 @@ int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value)
     size = setxattr(fname, attr, value, strlen(value), flag);
     return size > 0 ? 0 : -1;
 }
+
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size)
 {
     ssize_t written = 0;
@@ -349,6 +356,7 @@ ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size)
     }
     return total_read;
 }
+
 int pv_fs_file_lock(int fd)
 {
     struct flock flock;

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -5,8 +5,10 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 static void close_fd(int *fd)
 {
@@ -273,3 +275,28 @@ size_t pv_fs_path_get_size(const char *path)
     return st.st_size;
 }
 
+int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr)
+{
+    ssize_t cur_size = getxattr(fname, attr, value, size);
+    return cur_size == size ? 0 : -1;
+}
+
+char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr)
+{
+    ssize_t size = getxattr(fname, attr, NULL, 0);
+    if (size < 1)
+        return NULL;
+
+    char *val = malloc(size);
+    if (!val)
+        return NULL;
+
+    ssize_t cur_size = getxattr(fname, attr, val, size);
+
+    if (cur_size != size) {
+        free(val);
+        return NULL;
+    }
+
+    return val;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -154,6 +154,21 @@ int pv_fs_path_rename(const char *src_path, const char *dst_path)
     pv_fs_path_sync(dst_path);
     return 0;
 }
+int pv_fs_file_tmp(char *tmp, const char *fname)
+{
+    if (!fname)
+        return -1;
+
+    size_t size = strnlen(fname, PATH_MAX) + 5;
+
+    if (size > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    snprintf(tmp, size, "%s.tmp", fname);
+    return 0;
+}
 size_t pv_fs_path_get_size(const char *path)
 {
     struct stat st;

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,5 +1,6 @@
 #include <dirent.h>
 #include <fcntl.h>
+#include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
 bool pv_fs_path_exist(const char *path)
@@ -50,4 +51,22 @@ void pv_fs_path_sync(const char *path)
         fsync(fd);
         close(fd);
     }
+}
+void pv_fs_path_join(char *buf, int size, ...)
+{
+    char fmt[PATH_MAX] = { 0 };
+
+    for (int i = 0; i < size; ++i) {
+        fmt[i * 3 + 0] = '%';
+        fmt[i * 3 + 1] = 's';
+        fmt[i * 3 + 2] = '/';
+    }
+
+    va_list list;
+    va_start(list, size);
+
+    vsnprintf(buf, PATH_MAX, fmt, list);
+    buf[strnlen(buf, PATH_MAX) - 1] = '\0';
+
+    va_end(list);
 }

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -16,332 +16,336 @@
 
 static void close_fd(int *fd)
 {
-    if (!fd || *fd < 0)
-        return;
+	if (!fd || *fd < 0)
+		return;
 
-    close(*fd);
-    *fd = -1;
+	close(*fd);
+	*fd = -1;
 }
 
 bool pv_filesystem_path_exist(const char *path)
 {
-    return access(path, F_OK) == 0;
+	return access(path, F_OK) == 0;
 }
 
 bool pv_filesystem_path_is_directory(const char *path)
 {
-    DIR *tmp = opendir(path);
-    if (tmp) {
-        closedir(tmp);
-        return true;
-    }
+	DIR *tmp = opendir(path);
+	if (tmp) {
+		closedir(tmp);
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 void pv_filesystem_path_sync(const char *path)
 {
-    char dir[PATH_MAX] = { 0 };
-    if (!path)
-        return;
+	char dir[PATH_MAX] = { 0 };
+	if (!path)
+		return;
 
-    strncpy(dir, path, strnlen(path, PATH_MAX));
-    char *sync_dir = dirname(dir);
+	strncpy(dir, path, strnlen(path, PATH_MAX));
+	char *sync_dir = dirname(dir);
 
-    int fd = open(sync_dir, O_RDONLY);
-    if (fd > -1) {
-        fsync(fd);
-        close(fd);
-    }
+	int fd = open(sync_dir, O_RDONLY);
+	if (fd > -1) {
+		fsync(fd);
+		close(fd);
+	}
 }
 
 int pv_filesystem_mkdir_p(const char *path, mode_t mode)
 {
-    if (!path)
-        return -1;
+	if (!path)
+		return -1;
 
-    if (pv_filesystem_path_exist(path)) {
-        errno = EEXIST;
-        return -1;
-    }
+	if (pv_filesystem_path_exist(path)) {
+		errno = EEXIST;
+		return -1;
+	}
 
-    char cur_path[PATH_MAX] = {0};
+	char cur_path[PATH_MAX] = { 0 };
 
-    int i = -1;
-    do {
-        ++i;
-        if (path[i] == '/' || path[i] == '\0') {
-            memcpy(cur_path, path, i);
-            cur_path[i] = '\0';
-            if (mkdir(cur_path, mode) != 0 && errno != EEXIST)
-                return -1;
-        }
-    } while (path[i]);
+	int i = -1;
+	do {
+		++i;
+		if (path[i] == '/' || path[i] == '\0') {
+			memcpy(cur_path, path, i);
+			cur_path[i] = '\0';
+			if (mkdir(cur_path, mode) != 0 && errno != EEXIST)
+				return -1;
+		}
+	} while (path[i]);
 
-    return 0;
+	return 0;
 }
 
 void pv_filesystem_path_concat(char *buf, int size, ...)
 {
-    char fmt[PATH_MAX] = { 0 };
+	char fmt[PATH_MAX] = { 0 };
 
-    for (int i = 0; i < size; ++i) {
-        fmt[i * 3 + 0] = '%';
-        fmt[i * 3 + 1] = 's';
-        fmt[i * 3 + 2] = '/';
-    }
+	for (int i = 0; i < size; ++i) {
+		fmt[i * 3 + 0] = '%';
+		fmt[i * 3 + 1] = 's';
+		fmt[i * 3 + 2] = '/';
+	}
 
-    va_list list;
-    va_start(list, size);
+	va_list list;
+	va_start(list, size);
 
-    vsnprintf(buf, PATH_MAX, fmt, list);
-    buf[strnlen(buf, PATH_MAX) - 1] = '\0';
+	vsnprintf(buf, PATH_MAX, fmt, list);
+	buf[strnlen(buf, PATH_MAX) - 1] = '\0';
 
-    va_end(list);
+	va_end(list);
 }
 
 int pv_filesystem_path_remove(const char *path, bool recursive)
 {
-    if (!recursive) {
-        int ret = remove(path);
-        pv_filesystem_path_sync(path);
-        return ret;
-    }
+	if (!recursive) {
+		int ret = remove(path);
+		pv_filesystem_path_sync(path);
+		return ret;
+	}
 
-    struct dirent **arr = NULL;
-    int n = scandir(path, &arr, NULL, alphasort);
+	struct dirent **arr = NULL;
+	int n = scandir(path, &arr, NULL, alphasort);
 
-    for (int i = 0; i < n; ++i) {
-        // discard . and .. from scandir
-        if (!strcmp(arr[i]->d_name, ".") || !strcmp(arr[i]->d_name, ".."))
-            goto free_dir;
+	for (int i = 0; i < n; ++i) {
+		// discard . and .. from scandir
+		if (!strcmp(arr[i]->d_name, ".") ||
+		    !strcmp(arr[i]->d_name, ".."))
+			goto free_dir;
 
-        char new_path[PATH_MAX] = { 0 };
-        pv_filesystem_path_concat(new_path, 2, path, arr[i]->d_name);
+		char new_path[PATH_MAX] = { 0 };
+		pv_filesystem_path_concat(new_path, 2, path, arr[i]->d_name);
 
-        if (arr[i]->d_type == DT_DIR)
-            pv_filesystem_path_remove(new_path, true);
-        else
-            pv_filesystem_path_remove(new_path, false);
+		if (arr[i]->d_type == DT_DIR)
+			pv_filesystem_path_remove(new_path, true);
+		else
+			pv_filesystem_path_remove(new_path, false);
 
-free_dir:
-        free(arr[i]);
-    }
-    int ret = remove(path);
-    free(arr);
-    pv_filesystem_path_sync(path);
+	free_dir:
+		free(arr[i]);
+	}
+	int ret = remove(path);
+	free(arr);
+	pv_filesystem_path_sync(path);
 
-    return ret;
+	return ret;
 }
 
 int pv_filesystem_path_rename(const char *src_path, const char *dst_path)
 {
-    pv_filesystem_path_sync(src_path);
+	pv_filesystem_path_sync(src_path);
 
-    int ret = rename(src_path, dst_path);
-    if (ret < 0)
-        return ret;
+	int ret = rename(src_path, dst_path);
+	if (ret < 0)
+		return ret;
 
-    pv_filesystem_path_sync(dst_path);
-    return 0;
+	pv_filesystem_path_sync(dst_path);
+	return 0;
 }
 
 int pv_filesystem_file_tmp(char *tmp, const char *fname)
 {
-    if (!fname)
-        return -1;
+	if (!fname)
+		return -1;
 
-    size_t size = strnlen(fname, PATH_MAX) + 5;
+	size_t size = strnlen(fname, PATH_MAX) + 5;
 
-    if (size > PATH_MAX) {
-        errno = ENAMETOOLONG;
-        return -1;
-    }
+	if (size > PATH_MAX) {
+		errno = ENAMETOOLONG;
+		return -1;
+	}
 
-    snprintf(tmp, size, "%s.tmp", fname);
-    return 0;
+	snprintf(tmp, size, "%s.tmp", fname);
+	return 0;
 }
 
 int pv_filesystem_file_save(const char *fname, const char *data, mode_t mode)
 {
-    char tmp[PATH_MAX] = { 0 };
-    if (pv_filesystem_file_tmp(tmp, fname) != 0)
-        return -1;
+	char tmp[PATH_MAX] = { 0 };
+	if (pv_filesystem_file_tmp(tmp, fname) != 0)
+		return -1;
 
-    int ret = -1;
-    int fd = open(tmp, O_CREAT | O_WRONLY | O_TRUNC | O_SYNC, mode);
-    if (fd < 0)
-        goto out;
+	int ret = -1;
+	int fd = open(tmp, O_CREAT | O_WRONLY | O_TRUNC | O_SYNC, mode);
+	if (fd < 0)
+		goto out;
 
-    if (write(fd, data, strlen(data)) < 0)
-        goto out;
+	if (write(fd, data, strlen(data)) < 0)
+		goto out;
 
-    close_fd(&fd);
+	close_fd(&fd);
 
-    ret = pv_filesystem_path_rename(tmp, fname);
+	ret = pv_filesystem_path_rename(tmp, fname);
 
 out:
-    if (fd > 0)
-        close_fd(&fd);
+	if (fd > 0)
+		close_fd(&fd);
 
-    ret = pv_filesystem_path_remove(tmp, false);
-    pv_filesystem_path_sync(tmp);
+	ret = pv_filesystem_path_remove(tmp, false);
+	pv_filesystem_path_sync(tmp);
 
-    return ret;
+	return ret;
 }
 
 ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src)
 {
-    lseek(src, 0, SEEK_SET);
-    lseek(dst, 0, SEEK_SET);
+	lseek(src, 0, SEEK_SET);
+	lseek(dst, 0, SEEK_SET);
 
-    char buf[4096] = { 0 };
-    ssize_t read_bytes = 0;
-    ssize_t write_bytes = 0;
+	char buf[4096] = { 0 };
+	ssize_t read_bytes = 0;
+	ssize_t write_bytes = 0;
 
-    while (read_bytes = read(src, buf, 4096), read_bytes > 0)
-        write_bytes += write(dst, buf, read_bytes);
+	while (read_bytes = read(src, buf, 4096), read_bytes > 0)
+		write_bytes += write(dst, buf, read_bytes);
 
-    if (close_src)
-        close_fd(&src);
+	if (close_src)
+		close_fd(&src);
 
-    return write_bytes;
+	return write_bytes;
 }
 
-int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t mode)
+int pv_filesystem_file_copy_from_path(const char *src, const char *dst,
+				      mode_t mode)
 {
-    if (!pv_filesystem_path_exist(src))
-        return -1;
+	if (!pv_filesystem_path_exist(src))
+		return -1;
 
-    char tmp_path[PATH_MAX] = { 0 };
-    if (pv_filesystem_file_tmp(tmp_path, src) != 0)
-        return -1;
+	char tmp_path[PATH_MAX] = { 0 };
+	if (pv_filesystem_file_tmp(tmp_path, src) != 0)
+		return -1;
 
-    int tmp_fd = open(tmp_path, O_CREAT | O_WRONLY | O_TRUNC, mode);
-    if (tmp_fd < 0)
-        return -1;
+	int tmp_fd = open(tmp_path, O_CREAT | O_WRONLY | O_TRUNC, mode);
+	if (tmp_fd < 0)
+		return -1;
 
-    int src_fd = open(src, O_RDONLY, 0);
-    if (src < 0)
-        goto out;
+	int src_fd = open(src, O_RDONLY, 0);
+	if (src < 0)
+		goto out;
 
-    pv_filesystem_file_copy_fd(src_fd, tmp_fd, true);
-    close_fd(&tmp_fd);
+	pv_filesystem_file_copy_fd(src_fd, tmp_fd, true);
+	close_fd(&tmp_fd);
 
-    int ret = pv_filesystem_path_rename(tmp_path, dst);
-    if (ret < 0)
-        goto out;
+	int ret = pv_filesystem_path_rename(tmp_path, dst);
+	if (ret < 0)
+		goto out;
 
 out:
-    if (src_fd > -1)
-        close_fd(&src_fd);
+	if (src_fd > -1)
+		close_fd(&src_fd);
 
-    if (tmp_fd > -1)
-        close_fd(&tmp_fd);
+	if (tmp_fd > -1)
+		close_fd(&tmp_fd);
 
-    if (pv_filesystem_path_exist(tmp_path))
-        pv_filesystem_path_remove(tmp_path, false);
+	if (pv_filesystem_path_exist(tmp_path))
+		pv_filesystem_path_remove(tmp_path, false);
 
-    pv_filesystem_path_sync(src);
-    pv_filesystem_path_sync(dst);
+	pv_filesystem_path_sync(src);
+	pv_filesystem_path_sync(dst);
 
-    return ret;
+	return ret;
 }
 
 size_t pv_filesystem_path_get_size(const char *path)
 {
-    struct stat st;
+	struct stat st;
 
-    stat(path, &st);
-    return st.st_size;
+	stat(path, &st);
+	return st.st_size;
 }
 
-int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname, const char *attr)
+int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname,
+				 const char *attr)
 {
-    ssize_t cur_size = getxattr(fname, attr, value, size);
-    return cur_size == size ? 0 : -1;
+	ssize_t cur_size = getxattr(fname, attr, value, size);
+	return cur_size == size ? 0 : -1;
 }
 
-int pv_filesystem_file_set_xattr(const char *fname, const char *attr, const char *value)
+int pv_filesystem_file_set_xattr(const char *fname, const char *attr,
+				 const char *value)
 {
-    ssize_t size = getxattr(fname, attr, NULL, 0);
+	ssize_t size = getxattr(fname, attr, NULL, 0);
 
-    int flag = XATTR_REPLACE;
-    if (size < 0 && errno == ENODATA)
-        flag = XATTR_CREATE;
+	int flag = XATTR_REPLACE;
+	if (size < 0 && errno == ENODATA)
+		flag = XATTR_CREATE;
 
-    size = setxattr(fname, attr, value, strlen(value), flag);
-    return size > 0 ? 0 : -1;
+	size = setxattr(fname, attr, value, strlen(value), flag);
+	return size > 0 ? 0 : -1;
 }
 
 ssize_t pv_filesystem_file_write_nointr(int fd, const char *buf, ssize_t size)
 {
-    ssize_t written = 0;
+	ssize_t written = 0;
 
-    while (written != size) {
-        ssize_t cur_write = write(fd, buf + written, size - written);
+	while (written != size) {
+		ssize_t cur_write = write(fd, buf + written, size - written);
 
-        if (cur_write < 0) {
-            if (errno == EINTR)
-                continue;
-            break;
-        }
-        written += cur_write;
-    }
-    return written;
+		if (cur_write < 0) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		written += cur_write;
+	}
+	return written;
 }
 
 ssize_t pv_filesystem_file_read_nointr(int fd, char *buf, ssize_t size)
 {
-    ssize_t total_read = 0;
+	ssize_t total_read = 0;
 
-    while (total_read != size) {
-        int cur_read = read(fd, buf + total_read, size - total_read);
+	while (total_read != size) {
+		int cur_read = read(fd, buf + total_read, size - total_read);
 
-        if (cur_read < 0) {
-            if (errno == EINTR)
-                continue;
-            break;
-        }
-        if (cur_read == 0)
-            break;
-        total_read += cur_read;
-    }
-    return total_read;
+		if (cur_read < 0) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+		if (cur_read == 0)
+			break;
+		total_read += cur_read;
+	}
+	return total_read;
 }
 
 int pv_filesystem_file_lock(int fd)
 {
-    struct flock flock;
+	struct flock flock;
 
-    flock.l_whence = SEEK_SET;
-    // Lock the whole file
-    flock.l_len = 0;
-    flock.l_start = 0;
-    flock.l_type = F_WRLCK;
+	flock.l_whence = SEEK_SET;
+	// Lock the whole file
+	flock.l_len = 0;
+	flock.l_start = 0;
+	flock.l_type = F_WRLCK;
 
-    int ret = -1;
-    while (ret < 0 && errno == EINTR)
-        ret = fcntl(fd, F_SETLK, &flock);
+	int ret = -1;
+	while (ret < 0 && errno == EINTR)
+		ret = fcntl(fd, F_SETLK, &flock);
 
-    return ret;
+	return ret;
 }
 
 int pv_filesystem_file_unlock(int fd)
 {
-    struct flock flock;
+	struct flock flock;
 
-    flock.l_whence = SEEK_SET;
-    // Lock the whole file
-    flock.l_len = 0;
-    flock.l_start = 0;
-    flock.l_type = F_UNLCK;
+	flock.l_whence = SEEK_SET;
+	// Lock the whole file
+	flock.l_len = 0;
+	flock.l_start = 0;
+	flock.l_type = F_UNLCK;
 
-    int ret = -1;
-    while (ret < 0 && errno == EINTR)
-        ret = fcntl(fd, F_SETLK, &flock);
+	int ret = -1;
+	while (ret < 0 && errno == EINTR)
+		ret = fcntl(fd, F_SETLK, &flock);
 
-    return ret;
+	return ret;
 }
 
 int pv_filesystem_file_gzip(const char *fname, const char *target_name)
@@ -354,7 +358,7 @@ int pv_filesystem_file_gzip(const char *fname, const char *target_name)
 	if (outfile[1] >= 0) {
 		tsh_run_io(cmd, 1, NULL, NULL, outfile, NULL);
 		close_fd(&outfile[1]);
-    pv_filesystem_path_sync(target_name);
+		pv_filesystem_path_sync(target_name);
 		return 0;
 	}
 	return -1;
@@ -362,7 +366,7 @@ int pv_filesystem_file_gzip(const char *fname, const char *target_name)
 
 int pv_filesystem_file_check_and_open(const char *fname, int flags, mode_t mode)
 {
-    if (!pv_filesystem_path_exist(fname))
-        return -1;
-    return open(fname, flags, mode);
+	if (!pv_filesystem_path_exist(fname))
+		return -1;
+	return open(fname, flags, mode);
 }

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -301,3 +301,15 @@ char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr)
 
     return val;
 }
+
+int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value)
+{
+    ssize_t size = getxattr(fname, attr, NULL, 0);
+
+    int flag = XATTR_REPLACE;
+    if (size < 0 && errno == ENODATA)
+        flag = XATTR_CREATE;
+
+    size = setxattr(fname, attr, value, strlen(value), flag);
+    return size > 0 ? 0 : -1;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -335,7 +335,7 @@ int pv_filesystem_file_lock(int fd)
     struct flock flock;
 
     flock.l_whence = SEEK_SET;
-    /*Lock the whole file*/
+    // Lock the whole file
     flock.l_len = 0;
     flock.l_start = 0;
     flock.l_type = F_WRLCK;
@@ -352,7 +352,7 @@ int pv_filesystem_file_unlock(int fd)
     struct flock flock;
 
     flock.l_whence = SEEK_SET;
-    /*Lock the whole file*/
+    // Lock the whole file
     flock.l_len = 0;
     flock.l_start = 0;
     flock.l_type = F_UNLCK;

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -397,3 +397,10 @@ int pv_fs_file_gzip(const char *fname, const char *target_name)
 	}
 	return -1;
 }
+
+int pv_file_check_and_open_file(const char *fname, int flags, mode_t mode)
+{
+    if (!pv_fs_path_exist(fname))
+        return -1;
+    return open(fname, flags, mode);
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -83,27 +83,18 @@ int pv_filesystem_mkdir_p(const char *path, mode_t mode)
         return -1;
     }
 
-    char cur_path[PATH_MAX];
+    char cur_path[PATH_MAX] = {0};
 
-    size_t created = 0;
-    unsigned long i = 0;
-    while (path[i]) {
-        if (path[i] == '/') {
-            memcpy(cur_path, path, i + 1);
-            cur_path[i + 2] = '\0';
+    int i = -1;
+    do {
+        ++i;
+        if (path[i] == '/' || path[i] == '\0') {
+            memcpy(cur_path, path, i);
+            cur_path[i] = '\0';
             if (mkdir(cur_path, mode) != 0 && errno != EEXIST)
                 return -1;
-            created = i + 1;
         }
-        ++i;
-    }
-
-    // create the last directory, this happend when the given path
-    // doesn't finish with '/'
-    if (created < strlen(path)) {
-        if (mkdir(path, mode) != 0 && errno != EEXIST)
-            return -1;
-    }
+    } while (path[i]);
 
     return 0;
 }

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -208,7 +208,7 @@ out:
     return ret;
 }
 
-ssize_t pv_filesystem_file_copy_from_fd(int src, int dst, bool close_src)
+ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src)
 {
     lseek(src, 0, SEEK_SET);
     lseek(dst, 0, SEEK_SET);
@@ -243,7 +243,7 @@ int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t m
     if (src < 0)
         goto out;
 
-    pv_filesystem_file_copy_from_fd(src_fd, tmp_fd, true);
+    pv_filesystem_file_copy_fd(src_fd, tmp_fd, true);
     close_fd(&tmp_fd);
 
     int ret = pv_filesystem_path_rename(tmp_path, dst);

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -62,11 +62,13 @@ static int get_directory(char *dir, const char *path)
 void pv_filesystem_path_sync(const char *path)
 {
     char dir[PATH_MAX] = { 0 };
-
-    if (get_directory(dir, path) != 0)
+    if (!path)
         return;
 
-    int fd = open(dir, O_RDONLY);
+    strncpy(dir, path, strnlen(path, PATH_MAX));
+    char *sync_dir = dirname(dir);
+
+    int fd = open(sync_dir, O_RDONLY);
     if (fd > -1) {
         fsync(fd);
         close(fd);

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -121,7 +121,9 @@ void pv_filesystem_path_join(char *buf, int size, ...)
 int pv_filesystem_path_remove(const char *path, bool recursive)
 {
     if (!recursive) {
-        return remove(path);
+        int ret = remove(path);
+        pv_filesystem_path_sync(path);
+        return ret;
     }
 
     struct dirent **arr = NULL;
@@ -145,6 +147,7 @@ free_dir:
     }
     int ret = remove(path);
     free(arr);
+    pv_filesystem_path_sync(path);
 
     return ret;
 }

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,0 +1,5 @@
+#include <unistd.h>
+bool pv_fs_path_exist(const char *path)
+{
+    return access(path, F_OK) == 0;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -313,3 +313,38 @@ int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value)
     size = setxattr(fname, attr, value, strlen(value), flag);
     return size > 0 ? 0 : -1;
 }
+ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size)
+{
+    ssize_t written = 0;
+
+    while (written != size) {
+        ssize_t cur_write = write(fd, buf + written, size - written);
+
+        if (cur_write < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        written += cur_write;
+    }
+    return written;
+}
+
+ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size)
+{
+    ssize_t total_read = 0;
+
+    while (total_read != size) {
+        int cur_read = read(fd, buf + total_read, size - total_read);
+
+        if (cur_read < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        if (cur_read == 0)
+            break;
+        total_read += cur_read;
+    }
+    return total_read;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,4 +1,6 @@
 #include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
 #include <unistd.h>
 bool pv_fs_path_exist(const char *path)
 {
@@ -16,3 +18,36 @@ bool pv_fs_path_is_directory(const char *path)
     return false;
 }
 
+static int get_directory(char *dir, const char *path)
+{
+    if (!pv_fs_path_exist(path)) {
+        dir = NULL;
+        return -1;
+    }
+
+    if (pv_fs_path_is_directory(path)) {
+        strncpy(dir, path, strnlen(path, PATH_MAX));
+        return 0;
+    } else if (errno == ENOTDIR) {
+        char copy[PATH_MAX];
+        strncpy(copy, path, strnlen(path, PATH_MAX));
+
+        char *tmp = dirname(copy);
+        strncpy(dir, tmp, strnlen(path, PATH_MAX));
+    }
+    return 0;
+}
+
+void pv_fs_path_sync(const char *path)
+{
+    char dir[PATH_MAX] = { 0 };
+
+    if (get_directory(dir, path) != 0)
+        return;
+
+    int fd = open(dir, O_RDONLY);
+    if (fd > -1) {
+        fsync(fd);
+        close(fd);
+    }
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -81,7 +81,7 @@ int pv_filesystem_mkdir_p(const char *path, mode_t mode)
     return 0;
 }
 
-void pv_filesystem_path_join(char *buf, int size, ...)
+void pv_filesystem_path_concat(char *buf, int size, ...)
 {
     char fmt[PATH_MAX] = { 0 };
 
@@ -117,7 +117,7 @@ int pv_filesystem_path_remove(const char *path, bool recursive)
             goto free_dir;
 
         char new_path[PATH_MAX] = { 0 };
-        pv_filesystem_path_join(new_path, 2, path, arr[i]->d_name);
+        pv_filesystem_path_concat(new_path, 2, path, arr[i]->d_name);
 
         if (arr[i]->d_type == DT_DIR)
             pv_filesystem_path_remove(new_path, true);

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -154,3 +154,11 @@ int pv_fs_path_rename(const char *src_path, const char *dst_path)
     pv_fs_path_sync(dst_path);
     return 0;
 }
+size_t pv_fs_path_get_size(const char *path)
+{
+    struct stat st;
+
+    stat(path, &st);
+    return st.st_size;
+}
+

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,5 +1,18 @@
+#include <dirent.h>
 #include <unistd.h>
 bool pv_fs_path_exist(const char *path)
 {
     return access(path, F_OK) == 0;
 }
+
+bool pv_fs_path_is_directory(const char *path)
+{
+    DIR *tmp = opendir(path);
+    if (tmp) {
+        closedir(tmp);
+        return true;
+    }
+
+    return false;
+}
+

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -348,3 +348,36 @@ ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size)
     }
     return total_read;
 }
+int pv_fs_file_lock(int fd)
+{
+    struct flock flock;
+
+    flock.l_whence = SEEK_SET;
+    /*Lock the whole file*/
+    flock.l_len = 0;
+    flock.l_start = 0;
+    flock.l_type = F_WRLCK;
+
+    int ret = -1;
+    while (ret < 0 && errno == EINTR)
+        ret = fcntl(fd, F_SETLK, &flock);
+
+    return ret;
+}
+
+int pv_fs_file_unlock(int fd)
+{
+    struct flock flock;
+
+    flock.l_whence = SEEK_SET;
+    /*Lock the whole file*/
+    flock.l_len = 0;
+    flock.l_start = 0;
+    flock.l_type = F_UNLCK;
+
+    int ret = -1;
+    while (ret < 0 && errno == EINTR)
+        ret = fcntl(fd, F_SETLK, &flock);
+
+    return ret;
+}

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -1,3 +1,4 @@
+#include "filesystem.h"
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/utils/filesystem.c
+++ b/utils/filesystem.c
@@ -83,9 +83,6 @@ int pv_filesystem_mkdir_p(const char *path, mode_t mode)
         return -1;
     }
 
-    if (errno != 0 && errno != ENOENT)
-        return -1;
-
     char cur_path[PATH_MAX];
 
     size_t created = 0;

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -24,6 +24,7 @@
 #define UTILS_FILESYSTEM_H
 
 #include <stdbool.h>
+#include <sys/types.h>
 
 bool pv_fs_path_exist(const char *path);
 bool pv_fs_path_is_directory(const char *path);

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -28,4 +28,5 @@
 bool pv_fs_path_exist(const char *path);
 bool pv_fs_path_is_directory(const char *path);
 void pv_fs_path_sync(const char *path);
+void pv_fs_path_join(char *buf, int size, ...);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -38,4 +38,6 @@ int pv_fs_file_tmp(char *tmp, const char *fname);
 int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
 int pv_fs_file_copy_from_path(const char *src, const char *dst, mode_t mode);
 ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
+char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr);
+int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -34,4 +34,5 @@ int pv_fs_mkdir_p(const char *path, mode_t mode);
 int pv_fs_path_remove(const char *path, bool recursive);
 int pv_fs_path_rename(const char *src_path, const char *dst_path);
 size_t pv_fs_path_get_size(const char *path);
+int pv_fs_file_tmp(char *tmp, const char *fname);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -26,95 +26,29 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
-/*
- * Check if the given path exist
- * */
 bool pv_filesystem_path_exist(const char *path);
-/*
- * check if the given path is a directory
- * */
 bool pv_filesystem_path_is_directory(const char *path);
-/*
- * Sync the given path. If path points to a file,
- * then the parent folder is synced
- * */
 void pv_filesystem_path_sync(const char *path);
-/*
- * Path concatenation, the value is returned on the given buffer
- * */
 void pv_filesystem_path_concat(char *buf, int size, ...);
-/*
- * Creates a directory with the given path and mode
- * All subdirectories will be created.
- * */
 int pv_filesystem_mkdir_p(const char *path, mode_t mode);
-/*
- * Remove a path (file or directory). If recursive is true then all
- * subdirectories will be deleted
- * */
 int pv_filesystem_path_remove(const char *path, bool recursive);
-/*
- * Rename a path(file or directory)
- * */
 int pv_filesystem_path_rename(const char *src_path, const char *dst_path);
-/*
- * Returns the file size for the given path
- * */
 size_t pv_filesystem_path_get_size(const char *path);
-/*
- * Creates a temporary path based on the given fname
- * */
 int pv_filesystem_file_tmp(char *tmp, const char *fname);
-/* Save the given data on fname using a specific mode.
- * If the file doesn't exist, will be created.
- * If file exists, it will be truncated.
- * */
 int pv_filesystem_file_save(const char *fname, const char *data, mode_t mode);
-/*
- * Copy a file from src to dst.
- * */
 int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t mode);
-/*
- * Copy the contents of the src file descriptor to dst. If close_src is true
- * the file pointed by src will be closed.
- * */
+
+// sync function should be called after copy
 ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src);
-/*
- * Get an extended attribute from the given file.
- * NOTE: This function recives a buffer (value) where the attribute
- * will be write, so is important to provide a buffer with the right size.
- * */
+
+// Returns 0 on success -1 on error. Check errno for details
 int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
-/*
- * Set an extended attribute in the given file
- * */
 int pv_filesystem_file_set_xattr(const char *fname, const char *attr, const char *value);
-/*
- * Write the given buffer in the file pointed by fd.
- * NOTE: this function blocks until the file is completely written.
- * */
 ssize_t pv_filesystem_file_write_nointr(int fd, const char *buf, ssize_t size);
-/*
- * Reads into the given buffer from the file pointed by fd.
- * NOTE: this function blocks until the file completely read.
- * */
 ssize_t pv_filesystem_file_read_nointr(int fd, char *buf, ssize_t size);
-/*
- * Lock the given file descriptor
- * */
 int pv_filesystem_file_lock(int fd);
-/*
- * Unlock the given file descriptor
- * */
 int pv_filesystem_file_unlock(int fd);
-/*
- * Gzip the given file
- * */
 int pv_filesystem_file_gzip(const char *fname, const char *target_name);
-/*
- * Checks if the given file exists and open it usign the flags and mode
- * provided.
- * */
 int pv_filesystem_file_check_and_open(const char *fname, int flags, mode_t mode);
 
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -23,4 +23,7 @@
 #ifndef UTILS_FILESYSTEM_H
 #define UTILS_FILESYSTEM_H
 
+#include <stdbool.h>
+
+bool pv_fs_path_exist(const char *path);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -36,4 +36,6 @@ int pv_fs_path_rename(const char *src_path, const char *dst_path);
 size_t pv_fs_path_get_size(const char *path);
 int pv_fs_file_tmp(char *tmp, const char *fname);
 int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
+int pv_fs_file_copy_from_path(const char *src, const char *dst, mode_t mode);
+ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -42,7 +42,7 @@ void pv_filesystem_path_sync(const char *path);
 /*
  * Path concatenation, the value is returned on the given buffer
  * */
-void pv_filesystem_path_join(char *buf, int size, ...);
+void pv_filesystem_path_concat(char *buf, int size, ...);
 /*
  * Creates a directory with the given path and mode
  * All subdirectories will be created.

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -41,4 +41,6 @@ ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
 char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr);
 int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
 int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value);
+ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
+ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef UTILS_FILESYSTEM_H
+#define UTILS_FILESYSTEM_H
+
+#endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -29,4 +29,5 @@ bool pv_fs_path_exist(const char *path);
 bool pv_fs_path_is_directory(const char *path);
 void pv_fs_path_sync(const char *path);
 void pv_fs_path_join(char *buf, int size, ...);
+int pv_fs_mkdir_p(const char *path, mode_t mode);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -30,4 +30,5 @@ bool pv_fs_path_is_directory(const char *path);
 void pv_fs_path_sync(const char *path);
 void pv_fs_path_join(char *buf, int size, ...);
 int pv_fs_mkdir_p(const char *path, mode_t mode);
+int pv_fs_path_remove(const char *path, bool recursive);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -26,4 +26,5 @@
 #include <stdbool.h>
 
 bool pv_fs_path_exist(const char *path);
+bool pv_fs_path_is_directory(const char *path);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -35,4 +35,5 @@ int pv_fs_path_remove(const char *path, bool recursive);
 int pv_fs_path_rename(const char *src_path, const char *dst_path);
 size_t pv_fs_path_get_size(const char *path);
 int pv_fs_file_tmp(char *tmp, const char *fname);
+int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -33,4 +33,5 @@ void pv_fs_path_join(char *buf, int size, ...);
 int pv_fs_mkdir_p(const char *path, mode_t mode);
 int pv_fs_path_remove(const char *path, bool recursive);
 int pv_fs_path_rename(const char *src_path, const char *dst_path);
+size_t pv_fs_path_get_size(const char *path);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -45,4 +45,5 @@ ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
 ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
 int pv_fs_file_lock(int fd);
 int pv_fs_file_unlock(int fd);
+int pv_fs_file_gzip(const char *fname, const char *target_name);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -38,12 +38,14 @@ int pv_filesystem_file_tmp(char *tmp, const char *fname);
 int pv_filesystem_file_save(const char *fname, const char *data, mode_t mode);
 int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t mode);
 
-// sync function should be called after copy
+// This function doesn't perform sync
 ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src);
 
 // Returns 0 on success -1 on error. Check errno for details
 int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
 int pv_filesystem_file_set_xattr(const char *fname, const char *attr, const char *value);
+
+// This function doesn't perform sync
 ssize_t pv_filesystem_file_write_nointr(int fd, const char *buf, ssize_t size);
 ssize_t pv_filesystem_file_read_nointr(int fd, char *buf, ssize_t size);
 int pv_filesystem_file_lock(int fd);

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -27,4 +27,5 @@
 
 bool pv_fs_path_exist(const char *path);
 bool pv_fs_path_is_directory(const char *path);
+void pv_fs_path_sync(const char *path);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -43,4 +43,6 @@ int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char
 int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value);
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
 ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
+int pv_fs_file_lock(int fd);
+int pv_fs_file_unlock(int fd);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -26,25 +26,100 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
+/*
+ * Check if the given path exist
+ * */
 bool pv_fs_path_exist(const char *path);
+/*
+ * check if the given path is a directory
+ * */
 bool pv_fs_path_is_directory(const char *path);
+/*
+ * Sync the given path. If path points to a file,
+ * then the parent folder is synced
+ * */
 void pv_fs_path_sync(const char *path);
+/*
+ * Path concatenation, the value is returned on the given buffer
+ * */
 void pv_fs_path_join(char *buf, int size, ...);
+/*
+ * Creates a directory with the given path and mode
+ * All subdirectories will be created.
+ * */
 int pv_fs_mkdir_p(const char *path, mode_t mode);
+/*
+ * Remove a path (file or directory). If recursive is true then all
+ * subdirectories will be deleted
+ * */
 int pv_fs_path_remove(const char *path, bool recursive);
+/*
+ * Rename a path(file or directory)
+ * */
 int pv_fs_path_rename(const char *src_path, const char *dst_path);
+/*
+ * Returns the file size for the given path
+ * */
 size_t pv_fs_path_get_size(const char *path);
+/*
+ * Creates a temporary path based on the given fname
+ * */
 int pv_fs_file_tmp(char *tmp, const char *fname);
+/* Save the given data on fname using a specific mode.
+ * If the file doesn't exist, will be created.
+ * If file exists, it will be truncated.
+ * */
 int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
+/*
+ * Copy a file from src to dst.
+ * */
 int pv_fs_file_copy_from_path(const char *src, const char *dst, mode_t mode);
+/*
+ * Copy the contents of the src file descriptor to dst. If close_src is true
+ * the file pointed by src will be closed.
+ * */
 ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
+/*
+ * Get an extended attribute from the given file.
+ * NOTE: This function allocate a new buffer and it can be freed with free()
+ * */
 char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr);
+/*
+ * Get an extended attribute from the given file.
+ * NOTE: This function recives a buffer (value) where the attribute
+ * will be write, so is important to provide a buffer with the right size.
+ * */
 int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
+/*
+ * Set an extended attribute in the given file
+ * */
 int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value);
+/*
+ * Write the given buffer in the file pointed by fd.
+ * NOTE: this function blocks until the file is completely written.
+ * */
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
+/*
+ * Reads into the given buffer from the file pointed by fd.
+ * NOTE: this function blocks until the file completely read.
+ * */
 ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
+/*
+ * Lock the given file descriptor
+ * */
 int pv_fs_file_lock(int fd);
+/*
+ * Unlock the given file descriptor
+ * */
 int pv_fs_file_unlock(int fd);
+/*
+ * Gzip the given file
+ * */
 int pv_fs_file_gzip(const char *fname, const char *target_name);
+/*
+ * Checks if the given file exists and open it usign the flags and mode
+ * provided.
+ * */
 int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode);
+
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -40,4 +40,5 @@ int pv_fs_file_copy_from_path(const char *src, const char *dst, mode_t mode);
 ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
 char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr);
 int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
+int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -29,97 +29,97 @@
 /*
  * Check if the given path exist
  * */
-bool pv_fs_path_exist(const char *path);
+bool pv_filesystem_path_exist(const char *path);
 /*
  * check if the given path is a directory
  * */
-bool pv_fs_path_is_directory(const char *path);
+bool pv_filesystem_path_is_directory(const char *path);
 /*
  * Sync the given path. If path points to a file,
  * then the parent folder is synced
  * */
-void pv_fs_path_sync(const char *path);
+void pv_filesystem_path_sync(const char *path);
 /*
  * Path concatenation, the value is returned on the given buffer
  * */
-void pv_fs_path_join(char *buf, int size, ...);
+void pv_filesystem_path_join(char *buf, int size, ...);
 /*
  * Creates a directory with the given path and mode
  * All subdirectories will be created.
  * */
-int pv_fs_mkdir_p(const char *path, mode_t mode);
+int pv_filesystem_mkdir_p(const char *path, mode_t mode);
 /*
  * Remove a path (file or directory). If recursive is true then all
  * subdirectories will be deleted
  * */
-int pv_fs_path_remove(const char *path, bool recursive);
+int pv_filesystem_path_remove(const char *path, bool recursive);
 /*
  * Rename a path(file or directory)
  * */
-int pv_fs_path_rename(const char *src_path, const char *dst_path);
+int pv_filesystem_path_rename(const char *src_path, const char *dst_path);
 /*
  * Returns the file size for the given path
  * */
-size_t pv_fs_path_get_size(const char *path);
+size_t pv_filesystem_path_get_size(const char *path);
 /*
  * Creates a temporary path based on the given fname
  * */
-int pv_fs_file_tmp(char *tmp, const char *fname);
+int pv_filesystem_file_tmp(char *tmp, const char *fname);
 /* Save the given data on fname using a specific mode.
  * If the file doesn't exist, will be created.
  * If file exists, it will be truncated.
  * */
-int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
+int pv_filesystem_file_save(const char *fname, const char *data, mode_t mode);
 /*
  * Copy a file from src to dst.
  * */
-int pv_fs_file_copy_from_path(const char *src, const char *dst, mode_t mode);
+int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t mode);
 /*
  * Copy the contents of the src file descriptor to dst. If close_src is true
  * the file pointed by src will be closed.
  * */
-ssize_t pv_fs_file_copy_from_fd(int src, int dst, bool close_src);
+ssize_t pv_filesystem_file_copy_from_fd(int src, int dst, bool close_src);
 /*
  * Get an extended attribute from the given file.
  * NOTE: This function allocate a new buffer and it can be freed with free()
  * */
-char *pv_fs_file_get_xattr_dup(const char *fname, const char *attr);
+char *pv_filesystem_file_get_xattr_dup(const char *fname, const char *attr);
 /*
  * Get an extended attribute from the given file.
  * NOTE: This function recives a buffer (value) where the attribute
  * will be write, so is important to provide a buffer with the right size.
  * */
-int pv_fs_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
+int pv_filesystem_file_get_xattr(char *value, size_t size, const char *fname, const char *attr);
 /*
  * Set an extended attribute in the given file
  * */
-int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value);
+int pv_filesystem_file_set_xattr(const char *fname, const char *attr, const char *value);
 /*
  * Write the given buffer in the file pointed by fd.
  * NOTE: this function blocks until the file is completely written.
  * */
-ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
+ssize_t pv_filesystem_file_write_nointr(int fd, const char *buf, ssize_t size);
 /*
  * Reads into the given buffer from the file pointed by fd.
  * NOTE: this function blocks until the file completely read.
  * */
-ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
+ssize_t pv_filesystem_file_read_nointr(int fd, char *buf, ssize_t size);
 /*
  * Lock the given file descriptor
  * */
-int pv_fs_file_lock(int fd);
+int pv_filesystem_file_lock(int fd);
 /*
  * Unlock the given file descriptor
  * */
-int pv_fs_file_unlock(int fd);
+int pv_filesystem_file_unlock(int fd);
 /*
  * Gzip the given file
  * */
-int pv_fs_file_gzip(const char *fname, const char *target_name);
+int pv_filesystem_file_gzip(const char *fname, const char *target_name);
 /*
  * Checks if the given file exists and open it usign the flags and mode
  * provided.
  * */
-int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode);
+int pv_filesystem_file_check_and_open(const char *fname, int flags, mode_t mode);
 
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -32,4 +32,5 @@ void pv_fs_path_sync(const char *path);
 void pv_fs_path_join(char *buf, int size, ...);
 int pv_fs_mkdir_p(const char *path, mode_t mode);
 int pv_fs_path_remove(const char *path, bool recursive);
+int pv_fs_path_rename(const char *src_path, const char *dst_path);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -81,11 +81,6 @@ int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t m
 ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src);
 /*
  * Get an extended attribute from the given file.
- * NOTE: This function allocate a new buffer and it can be freed with free()
- * */
-char *pv_filesystem_file_get_xattr_dup(const char *fname, const char *attr);
-/*
- * Get an extended attribute from the given file.
  * NOTE: This function recives a buffer (value) where the attribute
  * will be write, so is important to provide a buffer with the right size.
  * */

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -46,4 +46,5 @@ ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
 int pv_fs_file_lock(int fd);
 int pv_fs_file_unlock(int fd);
 int pv_fs_file_gzip(const char *fname, const char *target_name);
+int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode);
 #endif

--- a/utils/filesystem.h
+++ b/utils/filesystem.h
@@ -78,7 +78,7 @@ int pv_filesystem_file_copy_from_path(const char *src, const char *dst, mode_t m
  * Copy the contents of the src file descriptor to dst. If close_src is true
  * the file pointed by src will be closed.
  * */
-ssize_t pv_filesystem_file_copy_from_fd(int src, int dst, bool close_src);
+ssize_t pv_filesystem_file_copy_fd(int src, int dst, bool close_src);
 /*
  * Get an extended attribute from the given file.
  * NOTE: This function allocate a new buffer and it can be freed with free()


### PR DESCRIPTION
This is the first of three PR to complete refactor the code present on `utils/fs.h` and `utils/file.h`
This PR adds `utils/filesystem.h` with all functions to replace the current implementations.

Next step:

1. Replace library calls
2. Delete the old libraries