### PR TITLE
Change unsigned int by size_t to avoid overflow

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -202,12 +202,12 @@ out:
 }
 
 struct pv_storage {
-	unsigned int total;
-	unsigned int free;
+	size_t total;
+	size_t free;
 	int free_percentage;
-	unsigned int reserved;
+	size_t reserved;
 	int reserved_percentage;
-	unsigned int real_free;
+	size_t real_free;
 	int real_free_percentage;
 	int threshold;
 };
@@ -243,15 +243,15 @@ static struct pv_storage* pv_storage_new()
 
 static void pv_storage_print(struct pv_storage* storage)
 {
-	pv_log(DEBUG, "total disk space: %d B", storage->total);
-	pv_log(DEBUG, "free disk space: %d B (%d%% of total)", storage->free, storage->free_percentage);
-	pv_log(DEBUG, "reserved disk space: %d B (%d%% of total)", storage->reserved, storage->reserved_percentage);
-	pv_log(INFO, "real free disk space: %d B (%d%% of total)", storage->real_free, storage->real_free_percentage);
+	pv_log(DEBUG, "total disk space: %zd B", storage->total);
+	pv_log(DEBUG, "free disk space: %zd B (%d%% of total)", storage->free, storage->free_percentage);
+	pv_log(DEBUG, "reserved disk space: %zd B (%d%% of total)", storage->reserved, storage->reserved_percentage);
+	pv_log(INFO, "real free disk space: %zd B (%d%% of total)", storage->real_free, storage->real_free_percentage);
 }
 
-unsigned int pv_storage_get_free()
+size_t pv_storage_get_free()
 {
-	unsigned int real_free = 0;
+	size_t real_free = 0;
 	struct pv_storage* storage;
 
 	storage = pv_storage_new();
@@ -315,9 +315,9 @@ int pv_storage_gc_run()
 	return reclaimed;
 }
 
-unsigned int pv_storage_gc_run_needed(unsigned int needed)
+size_t pv_storage_gc_run_needed(size_t needed)
 {
-	unsigned int available = pv_storage_get_free();
+	size_t available = pv_storage_get_free();
 
 	if (needed > available) {
 		pv_log(WARN, "%d B needed but only %d B available. Freeing up space...",

--- a/storage.h
+++ b/storage.h
@@ -22,6 +22,8 @@
 #ifndef PV_STORAGE_H
 #define PV_STORAGE_H
 
+#include <stddef.h>
+
 #define PREFIX_LOCAL_REV "locals/"
 #define SIZE_LOCAL_REV 64
 
@@ -49,9 +51,9 @@ int pv_storage_validate_file_checksum(char* path, char* checksum);
 bool pv_storage_validate_trails_object_checksum(const char *rev, const char *name, char *checksum);
 bool pv_storage_validate_trails_json_value(const char *rev, const char *name, char *val);
 
-unsigned int pv_storage_get_free(void);
+size_t pv_storage_get_free(void);
 int pv_storage_gc_run(void);
-unsigned int pv_storage_gc_run_needed(unsigned int needed);
+size_t pv_storage_gc_run_needed(size_t needed);
 void pv_storage_gc_defer_run_threshold(void);
 void pv_storage_gc_run_threshold(void);
 


### PR DESCRIPTION
Fix storage problems using a bigger type for the storage size