### PR TITLE
fix: usermeta does not unescape all special characters 

### DIFF
--- a/metadata.c
+++ b/metadata.c
@@ -462,6 +462,7 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 			break;
 
 		strncpy(value, um+(*key_i+1)->start, n);
+		pv_str_unescape_to_ascii(value, n);
 
 		// add or update metadata
 		// primitives with value 'null' have value NULL
@@ -864,17 +865,13 @@ int pv_metadata_factory_meta(struct pantavisor *pv)
 void pv_metadata_parse_usermeta(char *buf)
 {
 	struct pantavisor *pv = pv_get_instance();
-	char *body, *esc;
+	char *body = strdup(buf);
 
-	body = strdup(buf);
-	esc = pv_str_unescape_to_ascii(body, "\\n", '\n');
-	pv_usermeta_parse(pv, esc);
+	pv_usermeta_parse(pv, body);
 
 	if (body)
 		free(body);
-	if (esc)
-		free(esc);
-	// clear old
+
 	usermeta_clear(pv);
 }
 

--- a/utils/str.c
+++ b/utils/str.c
@@ -39,40 +39,41 @@ char *pv_str_replace_char(char *str, int len, char which, char what)
 	return str;
 }
 
-char *pv_str_unescape_to_ascii(char *buf, char *code, char c)
+void pv_str_unescape_to_ascii(char *buf, int size)
 {
-	char *p = 0;
-	char *new = 0;
-	char *old;
-	int pos = 0, replaced = 0;
-	char *tmp;
+	const char unescaped[] = { '"', '\\', 'b', 'f', 'n', 'r', 't' };
+	const char replacement[] = { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
 
-	tmp = malloc(strlen(buf) + strlen(code) + 1);
-	strcpy(tmp, buf);
-	strcat(tmp, code);
-	old = tmp;
+	int i = -1;
+	int j = 0;
 
-	p = strstr(tmp, code);
-	while (p) {
-		*p = '\0';
-		new = realloc(new, pos + strlen(tmp) + 2);
-		strcpy(new+pos, tmp);
-		pos = pos + strlen(tmp);
-		new[pos] = c;
-		pos += 1;
-		new[pos] = '\0';
-		replaced += 1;
-		tmp = p+strlen(code);
-		p = strstr(tmp, code);
-	}
+	bool ok = true;
+	do {
 
-	if (new[strlen(new)-1] == c)
-		new[strlen(new)-1] = '\0';
+		ok = true;
+		i = -1;
+		j = 0;
+		while (i < size) {
+next:
+			++i;
+			if (buf[i] == '\\') {
+				for (size_t k = 0; k < sizeof(unescaped); ++k) {
+					if (buf[i + 1] == unescaped[k]) {
+						buf[j] = replacement[k];
+						++i;
+						++j;
+						ok = false;
+						goto next;
+					}
+				}
+			}
 
-	if (old)
-		free(old);
+			buf[j] = buf[i];
+			++j;
+		}
+	} while (!ok);
 
-	return new;
+	buf[j] = '\0';
 }
 
 int pv_str_count_list(char **list)

--- a/utils/str.h
+++ b/utils/str.h
@@ -63,7 +63,7 @@
  */
 
 char *pv_str_replace_str(const char *s1, const char *s2, const char *s3);
-char *pv_str_unescape_to_ascii(char *buf, char *code, char c);
+void pv_str_unescape_to_ascii(char *buf, int size);
 char *pv_str_replace_char(char *str, int len, char which, char what);
 char *pv_str_skip_prefix(char *str, const char *key);
 int pv_str_count_list(char **list);


### PR DESCRIPTION
Some change was added to this PR:
- Add better function to unescape chars and replace the old `pv_str_unescape_to_ascii` from `utils/str.h`
- Change the strategy of how user-meta is unescaped, now the data is unescaped after parsing

Both changes help to fix a nasty bug I found if you create a variable with any name but with the value `ooo\nooo` (something with a `\n` in between) the device will freeze completely.
