### PR TITLE
support shipping .json files in state json as objects

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -1446,7 +1446,8 @@ static struct pv_state *system1_parse_objects(struct pv_state *this,
 						     key))) {
 			pv_log(DEBUG, "skipping '%s'", key);
 			// if the extension is other .json, we add it to the list of jsons
-		} else if ((ext = strrchr(key, '.')) && !strcmp(ext, ".json")) {
+		} else if ((ext = strrchr(key, '.')) && !strcmp(ext, ".json") &&
+			   !pv_is_sha256_hex_string(value)) {
 			pv_log(DEBUG, "adding json '%s'", key);
 			pv_jsons_add(this, key, value);
 			// everything else is added to the list of objects

--- a/storage.c
+++ b/storage.c
@@ -812,6 +812,15 @@ int pv_storage_meta_expand_jsons(struct pantavisor *pv, struct pv_state *s)
 		value[n] = 0;
 		snprintf(value, n, "%s", buf + (*k + 1)->start);
 
+		// also skip unpacking this if json is a sha256 hex encoded string
+		if ((*k + 1)->type == JSMN_STRING &&
+		    pv_is_sha256_hex_string(value)) {
+			free(key);
+			free(value);
+			k++;
+			continue;
+		}
+
 		pv_paths_storage_trail_file(path, PATH_MAX, s->rev, key);
 		if (stat(path, &st) == 0)
 			goto out;

--- a/utils/str.h
+++ b/utils/str.h
@@ -97,4 +97,28 @@ static inline bool pv_str_endswith(const char *str1, int str1len,
 		!strncmp(str1, &str2[str2len - str1len], str1len));
 }
 
+static inline bool pv_is_sha256_hex_string(const char *value)
+{
+	bool issha = false;
+	if (!value)
+		return false;
+
+	if (strlen(value) == 64) {
+		const char *v = NULL;
+		for (v = value; *v; v++) {
+			if ((*v >= '0' && *v <= '9') ||
+			    (*v >= 'a' && *v <= 'f') ||
+			    (*v >= 'A' && *v <= 'F')) {
+				continue;
+			}
+			break;
+		}
+		// if we reached end of string, we are a valid sha
+		if (!*v) {
+			issha = true;
+		}
+	}
+	return issha;
+}
+
 #endif /* UTILS_PV_STRING_H_ */


### PR DESCRIPTION
We skip expanding those .json files then accordingly.

Introduce a helper function for pv_is_sha256_hex_string