### PR TITLE
add configurable restart_policy at container level in run.json

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -975,6 +975,27 @@ static int do_action_for_group(struct json_key_action *jka, char *value)
 	return 0;
 }
 
+static int do_action_for_restart_policy(struct json_key_action *jka,
+					char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+
+	if (!(*bundle->platform) || !value)
+		return -1;
+
+	if (pv_str_matches(value, strlen(value), "system", strlen("system")))
+		pv_platform_set_restart_policy(*bundle->platform,
+					       RESTART_SYSTEM);
+	if (pv_str_matches(value, strlen(value), "container",
+			   strlen("container")))
+		pv_platform_set_restart_policy(*bundle->platform,
+					       RESTART_CONTAINER);
+	else
+		pv_log(WARN, "invalid restart policy '%s'", value);
+
+	return 0;
+}
+
 static int do_action_for_roles_object(struct json_key_action *jka, char *value)
 {
 	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
@@ -1191,6 +1212,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_runlevel, false),
 		ADD_JKA_ENTRY("group", JSMN_STRING, &bundle,
 			      do_action_for_group, false),
+		ADD_JKA_ENTRY("restart_policy", JSMN_STRING, &bundle,
+			      do_action_for_restart_policy, false),
 		ADD_JKA_ENTRY("roles", JSMN_OBJECT, &bundle,
 			      do_action_for_roles_object, false),
 		ADD_JKA_ENTRY("roles", JSMN_ARRAY, &bundle,

--- a/platforms.c
+++ b/platforms.c
@@ -141,6 +141,7 @@ struct pv_platform *pv_platform_add(struct pv_state *s, char *name)
 		p->name = strdup(name);
 		p->status = PLAT_NONE;
 		p->roles = PLAT_ROLE_MGMT;
+		p->restart_policy = RESTART_NONE;
 		p->updated = false;
 		p->state = s;
 		dl_list_init(&p->condition_refs);
@@ -285,6 +286,20 @@ static const char *pv_platforms_role_str(roles_mask_t role)
 	return "unknown";
 }
 
+static const char *pv_platforms_restart_policy_str(restart_policy_t policy)
+{
+	switch (policy) {
+	case RESTART_SYSTEM:
+		return "system";
+	case RESTART_CONTAINER:
+		return "container";
+	default:
+		return "unknown";
+	}
+
+	return "unknown";
+}
+
 char *pv_platform_get_json(struct pv_platform *p)
 {
 	struct pv_condition_ref *cr, *tmp;
@@ -325,7 +340,9 @@ char *pv_platform_get_json(struct pv_platform *p)
 		close_roles:
 			pv_json_ser_array_pop(&js);
 		}
-
+		pv_json_ser_key(&js, "restart_policy");
+		pv_json_ser_string(&js, pv_platforms_restart_policy_str(
+						p->restart_policy));
 		pv_json_ser_key(&js, "conditions");
 		pv_json_ser_array(&js);
 		{
@@ -925,6 +942,12 @@ bool pv_platform_is_stopped(struct pv_platform *p)
 bool pv_platform_is_updated(struct pv_platform *p)
 {
 	return p->updated;
+}
+
+void pv_platform_set_restart_policy(struct pv_platform *p,
+				    restart_policy_t policy)
+{
+	p->restart_policy = policy;
 }
 
 void pv_platform_set_role(struct pv_platform *p, roles_mask_t role)

--- a/platforms.h
+++ b/platforms.h
@@ -47,6 +47,12 @@ typedef enum {
 	DRIVER_MANUAL = (1 << 2)
 } plat_driver_t;
 
+typedef enum {
+	RESTART_NONE,
+	RESTART_SYSTEM,
+	RESTART_CONTAINER
+} restart_policy_t;
+
 struct pv_platform_driver {
 	plat_driver_t type;
 	bool loaded;
@@ -68,6 +74,7 @@ struct pv_platform {
 	struct pv_group *group;
 	struct pv_state *state;
 	int roles;
+	restart_policy_t restart_policy;
 	bool updated;
 	struct dl_list drivers;
 	struct dl_list condition_refs; // pv_condition_ref
@@ -109,6 +116,9 @@ bool pv_platform_is_started(struct pv_platform *p);
 bool pv_platform_is_stopping(struct pv_platform *p);
 bool pv_platform_is_stopped(struct pv_platform *p);
 bool pv_platform_is_updated(struct pv_platform *p);
+
+void pv_platform_set_restart_policy(struct pv_platform *p,
+				    restart_policy_t policy);
 
 void pv_platform_set_role(struct pv_platform *p, roles_mask_t role);
 void pv_platform_unset_role(struct pv_platform *p, roles_mask_t role);


### PR DESCRIPTION
This PR adds restart_policy to containers in run.json, which can be set to 'system' or 'container' to perform a full board reboot or a individual container reset. This value will override the previous behavior if any object or json is modified during an update, but it preserves the old behavior based on groups when not explicitly defined.

List of changes:
* parser: add restart_policy to run.json with 'system' and 'container' options
* platform: struct now stores restart_policy
* platform: json for pvcontrol now shows restart_policy value
* state: set 'system' default restart_policy if not explicitly configured for data, root and platform containers
* state: set 'container' default restart_policy if not explicitly configured for app containers
* state: decide whether to reboot or not for an update transition depending on container restart_policy