### PR TITLE
add configurable status_goal at container level in run.json

### DIFF
--- a/config.c
+++ b/config.c
@@ -308,8 +308,8 @@ static int pv_config_load_config_from_file(char *path,
 	config->net.brmask4 = config_get_value_string(
 		&config_list, "net.brmask4", "255.255.255.0");
 
-	config->updater.conditions_timeout = config_get_value_int(
-		&config_list, "updater.conditions.timeout", 2 * 60);
+	config->updater.goals_timeout = config_get_value_int(
+		&config_list, "updater.goals.timeout", 2 * 60);
 	config->updater.use_tmp_objects = config_get_value_bool(
 		&config_list, "updater.use_tmp_objects", false);
 
@@ -474,8 +474,8 @@ static int pv_config_override_config_from_file(char *path,
 				   &config->storage.gc.keep_factory);
 	config_override_value_int(&config_list, "updater.interval",
 				  &config->updater.interval);
-	config_override_value_int(&config_list, "updater.conditions.timeout",
-				  &config->updater.conditions_timeout);
+	config_override_value_int(&config_list, "updater.goals.timeout",
+				  &config->updater.goals_timeout);
 	config_override_value_int(&config_list, "updater.network_timeout",
 				  &config->updater.network_timeout);
 	config_override_value_int(&config_list, "updater.commit.delay",
@@ -929,9 +929,9 @@ int pv_config_get_updater_interval()
 {
 	return pv_get_instance()->config.updater.interval;
 }
-int pv_config_get_updater_conditions_timeout()
+int pv_config_get_updater_goals_timeout()
 {
-	return pv_get_instance()->config.updater.conditions_timeout;
+	return pv_get_instance()->config.updater.goals_timeout;
 }
 int pv_config_get_updater_network_timeout()
 {
@@ -1154,9 +1154,8 @@ char *pv_config_get_json()
 		pv_json_ser_key(&js, "updater.use_tmp_objects");
 		pv_json_ser_bool(
 			&js, pv_config_get_updater_network_use_tmp_objects());
-		pv_json_ser_key(&js, "updater.conditions.timeout");
-		pv_json_ser_number(&js,
-				   pv_config_get_updater_conditions_timeout());
+		pv_json_ser_key(&js, "updater.goals.timeout");
+		pv_json_ser_number(&js, pv_config_get_updater_goals_timeout());
 		pv_json_ser_key(&js, "revision.retries");
 		pv_json_ser_number(&js,
 				   pv_config_get_updater_revision_retries());

--- a/config.h
+++ b/config.h
@@ -99,7 +99,7 @@ struct pantavisor_disk {
 
 struct pantavisor_updater {
 	int interval;
-	int conditions_timeout;
+	int goals_timeout;
 	int network_timeout;
 	bool use_tmp_objects;
 	int revision_retries;
@@ -266,7 +266,7 @@ char *pv_config_get_disk_exportsdir(void);
 char *pv_config_get_disk_writabledir(void);
 
 int pv_config_get_updater_interval(void);
-int pv_config_get_updater_conditions_timeout(void);
+int pv_config_get_updater_goals_timeout(void);
 int pv_config_get_updater_network_timeout(void);
 bool pv_config_get_updater_network_use_tmp_objects(void);
 int pv_config_get_updater_revision_retries(void);

--- a/group.h
+++ b/group.h
@@ -22,15 +22,24 @@
 #ifndef PV_GROUP_H
 #define PV_GROUP_H
 
-#include "condition.h"
+#include "platforms.h"
+
 #include "utils/list.h"
+#include "utils/json.h"
 
 struct pv_group {
 	char *name;
+	struct dl_list platform_refs; // pv_platform_ref
 	struct dl_list list; // pv_group
 };
 
 struct pv_group *pv_group_new(char *name);
 void pv_group_free(struct pv_group *g);
+
+void pv_group_add_platform(struct pv_group *g, struct pv_platform *p);
+
+bool pv_group_check_goals(struct pv_group *g, bool log_warn);
+
+void pv_group_add_json(struct pv_json_ser *js, struct pv_group *g);
 
 #endif // PV_GROUP_H

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -245,7 +245,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		tokv = 0;
 	}
 
-	pv_platform_set_ready(this);
+	pv_platform_set_installed(this);
 out:
 	if (name)
 		free(name);

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -44,7 +44,6 @@
 #include "pantavisor.h"
 #include "parser_bundle.h"
 #include "group.h"
-#include "condition.h"
 #include "drivers.h"
 #include "state.h"
 #include "pvlogger.h"
@@ -387,108 +386,6 @@ out:
 		free(tokv);
 	if (buf)
 		free(buf);
-
-	return ret;
-}
-
-static struct pv_condition *parse_condition(struct pv_state *s, char *value)
-{
-	char *key = NULL, *val = NULL, *plat = NULL;
-	struct pv_condition *c = NULL;
-	jsmntok_t *condv;
-	int condc;
-
-	pv_log(DEBUG, "condition %s", value);
-
-	if (jsmnutil_parse_json(value, &condv, &condc) <= 0) {
-		pv_log(ERROR, "wrong format condition");
-		goto out;
-	}
-
-	key = pv_json_get_value(value, "key", condv, condc);
-	if (!key) {
-		pv_log(ERROR, "key not found in condition");
-		goto out;
-	}
-
-	val = pv_json_get_value(value, "value", condv, condc);
-	if (!val) {
-		pv_log(ERROR, "value not found in condition");
-		goto out;
-	}
-
-	plat = pv_json_get_value(value, "container", condv, condc);
-	// accept all containers by default
-	if (!plat)
-		plat = strdup("*");
-
-	c = pv_state_fetch_condition_value(s, plat, key, value);
-	if (c) {
-		pv_log(DEBUG, "condition found in state");
-		goto out;
-	}
-
-	c = pv_condition_new(plat, key, val);
-	if (!c) {
-		pv_log(ERROR, "could not create a new condition");
-		goto out;
-	}
-
-	pv_state_add_condition(s, c);
-
-out:
-	if (plat)
-		free(plat);
-	if (key)
-		free(key);
-	if (val)
-		free(val);
-	return c;
-}
-
-static int parse_platform_conditions(struct pv_state *s, struct pv_platform *p,
-				     char *value)
-{
-	struct pv_condition *c;
-	char *str = NULL;
-	int ret = 0, tokc;
-	jsmntok_t *tokv = NULL, **t = NULL, **i = NULL;
-
-	pv_log(DEBUG, "platform conditions %s", value);
-
-	if (jsmnutil_parse_json(value, &tokv, &tokc) < 0) {
-		pv_log(ERROR, "wrong format platform conditions");
-		goto out;
-	}
-
-	t = jsmnutil_get_array_toks(value, tokv);
-	i = t;
-	while (*i) {
-		str = pv_json_get_one_str(value, i);
-		if (!str)
-			break;
-
-		c = parse_condition(s, str);
-		if (!c)
-			goto out;
-
-		pv_platform_add_condition(p, c);
-
-		free(str);
-		str = NULL;
-
-		i++;
-	}
-
-	ret = 1;
-
-out:
-	if (str)
-		free(str);
-	if (t)
-		jsmnutil_tokv_free(t);
-	if (tokv)
-		free(tokv);
 
 	return ret;
 }
@@ -944,6 +841,7 @@ static int do_action_for_runlevel(struct json_key_action *jka, char *value)
 			return -1;
 		}
 		(*bundle->platform)->group = g;
+		pv_group_add_platform(g, (*bundle->platform));
 	} else {
 		pv_log(WARN, "invalid runlevel value '%s' for platform '%s'",
 		       value, (*bundle->platform)->name);
@@ -969,6 +867,7 @@ static int do_action_for_group(struct json_key_action *jka, char *value)
 		return -1;
 	}
 	(*bundle->platform)->group = g;
+	pv_group_add_platform(g, (*bundle->platform));
 
 	return 0;
 }
@@ -990,6 +889,26 @@ static int do_action_for_restart_policy(struct json_key_action *jka,
 					       RESTART_CONTAINER);
 	else
 		pv_log(WARN, "invalid restart policy '%s'", value);
+
+	return 0;
+}
+
+static int do_action_for_status_goal(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+
+	if (!(*bundle->platform) || !value)
+		return -1;
+
+	if (pv_str_matches(value, strlen(value), "MOUNTED", strlen("MOUNTED")))
+		pv_platform_set_status_goal(*bundle->platform, PLAT_MOUNTED);
+	else if (pv_str_matches(value, strlen(value), "STARTED",
+				strlen("STARTED")))
+		pv_platform_set_status_goal(*bundle->platform, PLAT_STARTED);
+	else if (pv_str_matches(value, strlen(value), "READY", strlen("READY")))
+		pv_platform_set_status_goal(*bundle->platform, PLAT_READY);
+	else
+		pv_log(WARN, "invalid status goal '%s'", value);
 
 	return 0;
 }
@@ -1176,21 +1095,6 @@ static int do_action_for_drivers(struct json_key_action *jka, char *value)
 	return 0;
 }
 
-static int do_action_for_conditions(struct json_key_action *jka, char *value)
-{
-	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
-
-	if (!(*bundle->platform) || !value)
-		return -1;
-
-	if (!parse_platform_conditions(bundle->s, *bundle->platform, value)) {
-		pv_log(ERROR, "could not parse platform conditions");
-		return -1;
-	}
-
-	return 0;
-}
-
 static int parse_platform(struct pv_state *s, char *buf, int n)
 {
 	char *config = NULL, *shares = NULL;
@@ -1212,6 +1116,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_group, false),
 		ADD_JKA_ENTRY("restart_policy", JSMN_STRING, &bundle,
 			      do_action_for_restart_policy, false),
+		ADD_JKA_ENTRY("status_goal", JSMN_STRING, &bundle,
+			      do_action_for_status_goal, false),
 		ADD_JKA_ENTRY("roles", JSMN_OBJECT, &bundle,
 			      do_action_for_roles_object, false),
 		ADD_JKA_ENTRY("roles", JSMN_ARRAY, &bundle,
@@ -1226,8 +1132,6 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_one_log, false),
 		ADD_JKA_ENTRY("storage", JSMN_OBJECT, &bundle,
 			      do_action_for_storage, false),
-		ADD_JKA_ENTRY("conditions", JSMN_STRING, &bundle,
-			      do_action_for_conditions, false),
 		ADD_JKA_ENTRY("drivers", JSMN_OBJECT, &bundle,
 			      do_action_for_drivers, false),
 		ADD_JKA_NULL_ENTRY()
@@ -1247,7 +1151,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		config = 0;
 	}
 
-	pv_platform_set_ready(this);
+	pv_platform_set_installed(this);
 out:
 	if (config)
 		free(config);

--- a/state.h
+++ b/state.h
@@ -55,7 +55,6 @@ struct pv_state {
 	struct dl_list objects; //pv_object
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
-	struct dl_list conditions; // pv_condition
 	char *json;
 	int tryonce;
 	bool local;
@@ -65,17 +64,12 @@ struct pv_state *pv_state_new(const char *rev, state_spec_t spec);
 void pv_state_free(struct pv_state *s);
 
 void pv_state_add_group(struct pv_state *s, struct pv_group *g);
-void pv_state_add_condition(struct pv_state *s, struct pv_condition *c);
 
 struct pv_group *pv_state_fetch_group(struct pv_state *s, const char *name);
 struct pv_platform *pv_state_fetch_platform(struct pv_state *s,
 					    const char *name);
 struct pv_object *pv_state_fetch_object(struct pv_state *s, const char *name);
 struct pv_json *pv_state_fetch_json(struct pv_state *s, const char *name);
-struct pv_condition *pv_state_fetch_condition_value(struct pv_state *s,
-						    const char *plat,
-						    const char *key,
-						    const char *eval_value);
 
 state_spec_t pv_state_spec(struct pv_state *s);
 
@@ -90,12 +84,13 @@ int pv_state_stop_force(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
-int pv_state_report_condition(struct pv_state *s, const char *plat,
-			      const char *key, const char *value);
-bool pv_state_check_conditions(struct pv_state *s);
+bool pv_state_check_goals(struct pv_state *s);
+
+int pv_state_interpret_signal(struct pv_state *s, const char *name,
+			      const char *signal, const char *payload);
 
 void pv_state_print(struct pv_state *s);
 char *pv_state_get_containers_json(struct pv_state *s);
-char *pv_state_get_conditions_json(struct pv_state *s);
+char *pv_state_get_groups_json(struct pv_state *s);
 
 #endif

--- a/utils/json.h
+++ b/utils/json.h
@@ -24,6 +24,7 @@
 #define UTILS_PV_JSON_H_
 
 #include <jsmn/jsmnutil.h>
+#include <stdbool.h>
 
 #define JSONB_STATIC
 #include "json-build/json-build.h"


### PR DESCRIPTION
This PR adds status_goal to the platform level configuration that substitutes the conditions feature.

List of changes:
* config: change updater.conditions.timeout with updater.goals.timeout
* ctrl: add GET /groups to list groups and status goals
* ctrl: add POST /signal to send ready signals
* ctrl: remove GET and PUT /conditions
* group: add list of platform refs for convinience
* group: check goals
* group: json function for pvcontrol
* pantavisor: switch condition rollback timer with goal one
* parser: remove condition parsing from run.json
* parser: add status_goal parsing from run.json
* platforms: substittue old READY status with INSTALLED
* platforms: add new READY status
* platforms: remove condition reporting when changing status
* platforms: remove list of condition refs
* platforms: add function to check if status_goal is reached
* platforms: add function to report signals to platform
* state: remove list of conditions
* state: modified condition rollback check behavior to depend on status_goal
* state: add function to set default status_goal when not defined in run.json
* state: modify "data" group flow to depend on status_goal instead
* state: modify json creation for pvcontrol to reflect the new status goal reality