### PR TITLE
refactor shutdown to be faster and add umounts

### DIFF
--- a/init.c
+++ b/init.c
@@ -576,3 +576,14 @@ int pv_do_execute_init()
 	}
 	return 0;
 }
+
+void pv_init_umount()
+{
+	char path[PATH_MAX];
+
+	pv_paths_writable(path, PATH_MAX);
+	umount(path);
+
+	pv_paths_exports(path, PATH_MAX);
+	umount(path);
+}

--- a/init.h
+++ b/init.h
@@ -85,4 +85,6 @@ extern struct pv_init pv_init_platform;
 extern struct pv_init pv_init_update;
 
 int pv_do_execute_init(void);
+void pv_init_umount(void);
+
 #endif

--- a/log.c
+++ b/log.c
@@ -145,9 +145,6 @@ static void pv_log_init(struct pantavisor *pv, const char *rev)
 	pv_paths_storage_log(storage_logs_path, PATH_MAX);
 	mount_bind(storage_logs_path, pv_logs_path);
 
-	if (pv_log_start(pv, rev) < 0)
-		return;
-
 	pv_buffer_init(MAX_BUFFER_COUNT, pv_config_get_log_logsize());
 
 	if (pv_logserver_init()) {
@@ -167,13 +164,6 @@ void exit_error(int err, char *msg)
 
 	sleep(20);
 	exit(0);
-}
-
-int pv_log_start(struct pantavisor *pv, const char *rev)
-{
-	if (!pv_config_get_log_capture())
-		return 0;
-	return 0;
 }
 
 void __log_to_console(char *module, int level, const char *fmt, ...)
@@ -215,6 +205,14 @@ const char *pv_log_level_name(int level)
 	if (level < FATAL || level >= ALL)
 		return "UNDEFINED";
 	return level_names[level].name;
+}
+
+void pv_log_umount(void)
+{
+	char path[PATH_MAX];
+
+	pv_paths_pv_log(path, PATH_MAX, "");
+	umount(path);
 }
 
 static int pv_log_early_init(struct pv_init *this)

--- a/log.h
+++ b/log.h
@@ -52,8 +52,6 @@ enum log_level {
 
 #define LOG_MAX_FILE_SIZE (2 * 1024 * 1024)
 
-int pv_log_start(struct pantavisor *pv, const char *rev);
-
 void __log(char *module, int level, const char *fmt, ...);
 
 void __log_to_console(char *module, int level, const char *fmt, ...);
@@ -62,4 +60,7 @@ void __log_to_console(char *module, int level, const char *fmt, ...);
  * Don't free the return value!
  */
 const char *pv_log_level_name(int level);
+
+void pv_log_umount(void);
+
 #endif

--- a/logserver.c
+++ b/logserver.c
@@ -42,6 +42,7 @@
 #include "utils/fs.h"
 #include "utils/fs.h"
 #include "utils/json.h"
+#include "utils/system.h"
 #include "pvctl_utils.h"
 #include "bootloader.h"
 
@@ -510,10 +511,13 @@ static void logserver_start(struct logserver *logserver, const char *revision)
 
 static void logserver_stop()
 {
+	pv_log(DEBUG, "stopping logserver service...");
+
 	if (logserver_g.service_pid > 0) {
-		pv_log(DEBUG, "stopping logserver service pid with pid %d",
+		pv_system_kill_lenient(logserver_g.service_pid);
+		pv_system_kill_force(logserver_g.service_pid);
+		pv_log(DEBUG, "stopped logserver service with pid %d",
 		       logserver_g.service_pid);
-		kill(logserver_g.service_pid, SIGKILL);
 	}
 
 	logserver_g.service_pid = -1;

--- a/mount.c
+++ b/mount.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <linux/limits.h>
 
+#include "mount.h"
 #include "init.h"
 #include "blkid.h"
 #include "utils/tsh.h"
@@ -85,6 +86,20 @@ static int ph_mount_init(struct pv_init *this)
 	mount_bind(storage_path, pv_path);
 
 	return 0;
+}
+
+void pv_mount_umount(void)
+{
+	char path[PATH_MAX];
+
+	pv_paths_pv_usrmeta_key(path, PATH_MAX, "");
+	umount(path);
+
+	pv_paths_pv_devmeta_key(path, PATH_MAX, "");
+	umount(path);
+
+	pv_paths_etc_file(path, PATH_MAX, DROPBEAR_DNAME);
+	umount(path);
 }
 
 static int pv_mount_init(struct pv_init *this)

--- a/mount.h
+++ b/mount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Pantacor Ltd.
+ * Copyright (c) 2022 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,34 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#ifndef PV_MOUNT_H
+#define PV_MOUNT_H
 
-#ifndef UTILS_SYSTEM_H
-#define UTILS_SYSTEM_H
+void pv_mount_umount(void);
 
-#include <stdint.h>
-
-#ifdef __arm__
-#define PV_ARCH "arm"
-#elif __aarch64__
-#define PV_ARCH "aarch64"
-#elif __x86_64__
-#define PV_ARCH "x86_64"
-#elif __mips__
-#define PV_ARCH "mips"
-#else
-#define PV_ARCH "unknown"
-#endif
-
-#if UINTPTR_MAX == 0xffffffff
-#define PV_BITS "32"
-#else
-#define PV_BITS "64"
-#endif
-
-int get_endian(void);
-int get_dt_model(char *buf, int buflen);
-int get_cpu_model(char *buf, int buflen);
-void pv_system_kill_lenient(pid_t pid);
-void pv_system_kill_force(pid_t pid);
-
-#endif // UTILS_SYSTEM_H
+#endif // PV_MOUNT_H

--- a/ph_logger.h
+++ b/ph_logger.h
@@ -45,8 +45,8 @@
 #define WARN_ONCE(msg, args...)
 #endif
 
-void ph_logger_toggle(struct pantavisor *pv, char *rev);
-void ph_logger_stop(struct pantavisor *pv);
-void ph_logger_close(void);
+void ph_logger_toggle(char *rev);
+void ph_logger_stop_lenient(void);
+void ph_logger_stop_force(void);
 
 #endif /* __PH_LOGGER_H__ */

--- a/state.c
+++ b/state.c
@@ -706,16 +706,22 @@ static int pv_state_unmount_platforms_volumes(struct pv_state *s)
 	return ret;
 }
 
-int pv_state_stop(struct pv_state *s)
+void pv_state_stop_lenient(struct pv_state *s)
+{
+	if (!s)
+		return;
+
+	pv_log(DEBUG, "leniently stopping state %s", s->rev);
+
+	pv_state_lenient_stop(s);
+}
+
+int pv_state_stop_force(struct pv_state *s)
 {
 	int ret = 0;
 
-	if (s == NULL)
+	if (!s)
 		return -1;
-
-	pv_log(DEBUG, "stopping state %s", s->rev);
-
-	pv_state_lenient_stop(s);
 
 	if (!pv_state_check_all_stopped(s)) {
 		pv_state_force_stop(s);

--- a/state.h
+++ b/state.h
@@ -84,7 +84,8 @@ bool pv_state_validate_checksum(struct pv_state *s);
 
 int pv_state_start(struct pv_state *s);
 int pv_state_run(struct pv_state *s);
-int pv_state_stop(struct pv_state *s);
+void pv_state_stop_lenient(struct pv_state *s);
+int pv_state_stop_force(struct pv_state *s);
 
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);

--- a/storage.c
+++ b/storage.c
@@ -33,6 +33,7 @@
 
 #include <linux/limits.h>
 
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/prctl.h>
@@ -1097,6 +1098,15 @@ void pv_storage_rm_devmeta(const char *key)
 	}
 
 	free(pname);
+}
+
+void pv_storage_umount()
+{
+	char path[PATH_MAX];
+
+	pv_paths_storage(path, PATH_MAX);
+	umount(path);
+	pv_fs_path_sync(path);
 }
 
 static int pv_storage_init(struct pv_init *this)

--- a/storage.h
+++ b/storage.h
@@ -67,4 +67,6 @@ void pv_storage_rm_usermeta(const char *key);
 void pv_storage_save_devmeta(const char *key, const char *value);
 void pv_storage_rm_devmeta(const char *key);
 
+void pv_storage_umount(void);
+
 #endif // PV_STORAGE_H

--- a/utils/system.c
+++ b/utils/system.c
@@ -102,15 +102,20 @@ out:
 	return ret;
 }
 
-void kill_child_process(pid_t pid)
+void pv_system_kill_lenient(pid_t pid)
+{
+	if (pid <= 0)
+		return;
+
+	kill(pid, SIGTERM);
+}
+
+void pv_system_kill_force(pid_t pid)
 {
 	bool exited = false;
 
 	if (pid <= 0)
 		return;
-
-	// first, try to kill gracefully
-	kill(pid, SIGTERM);
 
 	// check process has end
 	for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
Add umounts to shutdown to free up the paths we are using after execution in appengine. The shutdown function has changed too to issue a lenient kill to the platform and ph logger forks first and then check if they are still running and finally send a force kill.

List of changes:
* init: new function to umount /writable and /exports
* logs: new function to umount logs in /pv
* logserver: modiy stop function to check if pid is still running after a timeout and issue a force kill if necessary
* mount: new function to umount devemta, usermeta and dropbear in /pv
* pantavisor: shutdown now issues lenient stop for ph logger and platforms at the same time. Then, check and force are sent if needed
* pantavisor: shutdown now umounts everything beyond /storage
* pantavisor: shutdown does not concern about umounting, socket closing and freeing up memory if a reboot or power off is ordered
* ph_logger: divide stop function in lenient and force
* state: divide stop function in lenient and force
* storage: new function to umount /storage
* utils/system: divide kill pid function in lenient and force