### PR TITLE
deprecate some of the log keys in ph config in favour of pv config

### DIFF
--- a/log.c
+++ b/log.c
@@ -145,7 +145,7 @@ static void pv_log_init(struct pantavisor *pv, const char *rev)
 	pv_paths_storage_log(storage_logs_path, PATH_MAX);
 	mount_bind(storage_logs_path, pv_logs_path);
 
-	pv_buffer_init(MAX_BUFFER_COUNT, pv_config_get_log_logsize());
+	pv_buffer_init(MAX_BUFFER_COUNT, pv_config_get_log_logsize() * 1024);
 
 	if (pv_logserver_init()) {
 		pv_log(ERROR, "logserver initialization failed");


### PR DESCRIPTION
Move most of log keys in pantahub.config to pantavisor.config that are related to logserver but not to pantahub interaction at all. The old log keys in pantahub.config are still supported to keep backwards compatibility.