### PR TITLE
fix: json-build mem leak and update library

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -116,6 +116,20 @@ include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
+LOCAL_LIBRARIES := libthttp
+
+LOCAL_DESTDIR := ./
+LOCAL_MODULE := json_test
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)
+
+LOCAL_SRC_FILES := utils/json.test.c \
+			utils/json.c
+
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
 LOCAL_DESTDIR := ./
 LOCAL_MODULE := init-dm
 LOCAL_LIBRARIES := cryptsetup

--- a/config.c
+++ b/config.c
@@ -1082,7 +1082,7 @@ char *pv_config_get_json()
 {
 	struct pv_json_ser js;
 
-	pv_json_ser_init(&js, 2048);
+	pv_json_ser_init(&js, 512);
 
 	pv_json_ser_object(&js);
 	{

--- a/utils/json-build/README.md
+++ b/utils/json-build/README.md
@@ -1,18 +1,16 @@
-JSON-BUILD
-==========
+# JSON-BUILD
 
-json-build is a zero-allocation JSON serializer compatible with C89. It is
-inspired by [jsmn](https://github.com/zserge/jsmn), a minimalistic JSON tokenizer.
+json-build is a zero-allocation JSON serializer written in ANSI C. Its
+tokenizer counterpart can be found at
+[jsmn-find](https://github.com/lcsmuller/jsmn-find).
 
-Features
---------
+## Features
 
 * compatible with C89
 * no dependencies
 * no dynamic memory allocation
 
-Usage
------
+## Usage
 
 Download `json-build.h`, include it, done.
 
@@ -54,10 +52,10 @@ for multiple C files, to avoid duplication of symbols you may define `JSONB_HEAD
 #include "json-build.h"
 ```
 
-API
----
+## API
 
 * `jsonb_init()` - initialize a jsonb handle
+* `jsonb_reset()` - reset the buffer's position tracker for streaming purposes
 * `jsonb_object()` - push an object to the builder stack
 * `jsonb_object_pop()` - pop an object from the builder stack
 * `jsonb_key()` - push an object key field to the builder stack
@@ -78,11 +76,11 @@ The following are the possible return codes for the builder functions:
 
 Its worth mentioning that all `JSONB_ERROR_` prefixed codes are negative.
 
-If you get `JSONB_ERROR_NOMEM` you can re-allocate a larger buffer and call
-the builder function once more.
+If you get `JSONB_ERROR_NOMEM` you can either:
+1. re-allocate a larger buffer and call the builder function once more
+2. call `jsonb_reset()` to reset the buffer's position tracker and call the builder function once more (useful for streaming with a fixed sized buffer!)
 
-Other info
-----------
+## Other info
 
 This software is distributed under [MIT license](www.opensource.org/licenses/mit-license.php),
 so feel free to integrate it in your commercial products.

--- a/utils/json.h
+++ b/utils/json.h
@@ -41,9 +41,9 @@ char *pv_json_array_get_one_str(const char *buf, int *n, jsmntok_t **tok);
 
 struct pv_json_ser {
 	jsonb b;
-	int block_size;
+	size_t block_size;
 	char *buf;
-	int size;
+	size_t size;
 };
 
 void pv_json_ser_init(struct pv_json_ser *js, size_t size);

--- a/utils/json.test.c
+++ b/utils/json.test.c
@@ -1,0 +1,28 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "json.h"
+
+int main()
+{
+	struct pv_json_ser js;
+
+	pv_json_ser_init(&js, 16);
+
+	pv_json_ser_object(&js);
+	{
+		pv_json_ser_key(&js, "one_key_thingy");
+		pv_json_ser_string(&js, "this will trigger a buf resize");
+
+		pv_json_ser_object_pop(&js);
+	}
+
+	char *buf = pv_json_ser_str(&js);
+
+	printf("buf: %s\n", buf);
+
+	free(buf);
+
+	return 0;
+}


### PR DESCRIPTION
A memory leak in json-build library was causing realloc of json_ser buffers to crash. Besides fixing that, this MR also updates the library to latest master and improves utils/json.

List of changes:
* atom: add utils/json.test.c
* config: bring back the previously crashing 512 B initial buffer to pvcontrol config ls
* utils/json-build: update library to latest master
* utils/json-build: fix _jsonb_escape mem leak
* utils/json: port the while and resize check to all json_ser functions
* utils/json: improve resize functionnot to overwrite if realloc fails
* utils/json: use size_t for sizes in struct
* utils/json.test: test if resizing works