### PR TITLE
groups.json

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -97,7 +97,8 @@ LOCAL_GENERATED_SRC_FILES := version.c
 LOCAL_COPY_FILES := scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
 	scripts/hooks_lxc-mount.d/export.sh:lib/pv/hooks_lxc-mount.d/export.sh \
 	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
-	scripts/JSON.sh:lib/pv/JSON.sh
+	scripts/JSON.sh:lib/pv/JSON.sh \
+	defaults/groups.json:etc/pantavisor/defaults/groups.json
 
 include $(BUILD_EXECUTABLE)
 

--- a/defaults/groups.json
+++ b/defaults/groups.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name":"data",
+    "description":"Containers which volumes we want to mount but not to be started",
+    "restart_policy": "system",
+    "status_goal": "MOUNTED"
+  },
+  {
+    "name":"root",
+    "description":"Container or containers that are in charge of setting network connectivity up for the board",
+    "restart_policy": "system",
+    "status_goal": "STARTED"
+  },
+  {
+    "name":"platform",
+    "description": "Middleware and utility containers",
+    "restart_policy": "system",
+    "status_goal": "STARTED"
+  },
+  {
+    "name":"app",
+    "description": "Application level containers",
+    "restart_policy": "container",
+    "status_goal": "STARTED"
+  }
+]

--- a/group.c
+++ b/group.c
@@ -31,13 +31,16 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #include "log.h"
 
-struct pv_group *pv_group_new(char *name)
+struct pv_group *pv_group_new(char *name, plat_status_t status,
+			      restart_policy_t restart)
 {
 	struct pv_group *g;
 
 	g = calloc(1, sizeof(struct pv_group));
 	if (g) {
 		g->name = strdup(name);
+		g->default_status_goal = status;
+		g->default_restart_policy = restart;
 		dl_list_init(&g->platform_refs);
 	}
 
@@ -151,6 +154,12 @@ void pv_group_add_json(struct pv_json_ser *js, struct pv_group *g)
 	{
 		pv_json_ser_key(js, "name");
 		pv_json_ser_string(js, g->name);
+		pv_json_ser_key(js, "status_goal");
+		pv_json_ser_string(
+			js, pv_platform_status_string(g->default_status_goal));
+		pv_json_ser_key(js, "restart_policy");
+		pv_json_ser_string(js, pv_platforms_restart_policy_str(
+					       g->default_restart_policy));
 		pv_json_ser_key(js, "status");
 		pv_json_ser_array(js);
 		{

--- a/group.h
+++ b/group.h
@@ -29,11 +29,14 @@
 
 struct pv_group {
 	char *name;
+	plat_status_t default_status_goal;
+	restart_policy_t default_restart_policy;
 	struct dl_list platform_refs; // pv_platform_ref
 	struct dl_list list; // pv_group
 };
 
-struct pv_group *pv_group_new(char *name);
+struct pv_group *pv_group_new(char *name, plat_status_t status,
+			      restart_policy_t restart);
 void pv_group_empty_platform_refs(struct pv_group *g);
 void pv_group_free(struct pv_group *g);
 

--- a/paths.h
+++ b/paths.h
@@ -135,6 +135,8 @@ void pv_paths_writable(char *buf, size_t size);
 #define PV_PANTAVISOR_CONFIG_PATH "/etc/pantavisor.config"
 
 #define DROPBEAR_DNAME "dropbear"
+#define PV_DNAME "pantavisor"
+#define PV_DEFAULTS_GROUPS PV_DNAME "/defaults/groups.json"
 #define PVS_DNAME "pantavisor/pvs"
 #define PVS_PK_FNAME PVS_DNAME "/pub.pem"
 #define PVS_CERT_FNAME PVS_DNAME "/certs/ca.pem"

--- a/platforms.c
+++ b/platforms.c
@@ -97,7 +97,7 @@ struct pv_cont_ctrl cont_ctrl[PV_CONT_MAX] = {
 	//	{ "docker", start_docker_platform, stop_docker_platform }
 };
 
-static const char *pv_platform_status_string(plat_status_t status)
+const char *pv_platform_status_string(plat_status_t status)
 {
 	switch (status) {
 	case PLAT_NONE:
@@ -254,7 +254,7 @@ static const char *pv_platforms_role_str(roles_mask_t role)
 	return "unknown";
 }
 
-static const char *pv_platforms_restart_policy_str(restart_policy_t policy)
+const char *pv_platforms_restart_policy_str(restart_policy_t policy)
 {
 	switch (policy) {
 	case RESTART_SYSTEM:

--- a/platforms.h
+++ b/platforms.h
@@ -134,6 +134,9 @@ void pv_platform_set_role(struct pv_platform *p, roles_mask_t role);
 void pv_platform_unset_role(struct pv_platform *p, roles_mask_t role);
 bool pv_platform_has_role(struct pv_platform *p, roles_mask_t role);
 
+const char *pv_platform_status_string(plat_status_t status);
+const char *pv_platforms_restart_policy_str(restart_policy_t policy);
+
 void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p);
 void pv_platform_add_goal_json(struct pv_json_ser *js, struct pv_platform *p);
 

--- a/state.h
+++ b/state.h
@@ -55,6 +55,7 @@ struct pv_state {
 	struct dl_list objects; //pv_object
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
+	bool default_groups;
 	char *json;
 	int tryonce;
 	bool local;
@@ -73,7 +74,7 @@ struct pv_json *pv_state_fetch_json(struct pv_state *s, const char *name);
 
 state_spec_t pv_state_spec(struct pv_state *s);
 
-void pv_state_validate(struct pv_state *s);
+int pv_state_validate(struct pv_state *s);
 bool pv_state_validate_checksum(struct pv_state *s);
 
 int pv_state_start(struct pv_state *s);


### PR DESCRIPTION
This PR introduces groups.json that permits to override the default groups (data, root, platform and app). New groups have a default restart policy and default status goal. However, those will be overloaded if explicitly configured at container level.

List of changes:
* group: add default status goal and default restart policy to struct
* parser: parse groups.json in state, which is an array of groups with name, status goal and restart policy
* parser: default groups are taken from initrd rootfs if groups.json is not present
* state: avoid creating default groups, which is parser's responsibility now
* state: add default status goal and restart policy to default groups
* state: post-parse validation now checks if any platform does not have a group attached, in case of non-default groups defined
* state: post-parse validation now sets restart policy and status goal to containers based on their default value at group level