### PR TITLE
Feature/lxc console log

### DIFF
--- a/logserver.c
+++ b/logserver.c
@@ -38,6 +38,8 @@
 #include <stdarg.h>
 #include <fcntl.h>
 #include <time.h>
+#include <inttypes.h>
+#include <glob.h>
 
 #include "utils/fs.h"
 #include "utils/fs.h"
@@ -45,6 +47,7 @@
 #include "utils/system.h"
 #include "pvctl_utils.h"
 #include "bootloader.h"
+#include "config.h"
 
 #ifdef DEBUG
 #define WARN_ONCE(msg, args...)                                                \
@@ -70,6 +73,8 @@
 #define PH_LOGGER_MAX_EPOLL_FD (50)
 #define LOGSERVER_FLAG_STOP (1 << 0)
 #define LOGSERVER_BACKLOG (20)
+#define LOGSERVER_MAX_EV (5)
+#define LOGSERVER_MAX_HEADER_LEN (50)
 
 #define LOG_PROTOCOL_LEGACY 0
 
@@ -86,12 +91,37 @@ struct logserver_msg {
 	char buffer[0];
 };
 
+struct logserver_fd {
+	char *platform;
+	char *src;
+	int fd;
+	struct dl_list list;
+};
+
+struct logserver_output {
+	bool sfile;
+	bool ftree;
+};
+
+struct logserver_log {
+	int maxsize;
+	int maxfile;
+};
+
 struct logserver {
-	pid_t service_pid;
+	pid_t pid;
 	int flags;
-	int epoll_fd;
-	int sock_fd;
+	int epfd;
+	int logsock;
+	int fdsock;
 	char *revision;
+	struct logserver_log log;
+	struct logserver_output out;
+	// logserver_fd
+	struct dl_list fdlst;
+	// tmp store for fd returned by connect
+	// only if was sent to the fd_sock
+	struct dl_list tmplst;
 };
 
 struct logserver_msg_data {
@@ -106,16 +136,72 @@ struct logserver_msg_data {
 	char *data;
 };
 
-static struct logserver logserver_g = { .service_pid = -1,
+static struct logserver logserver_g = { .pid = -1,
 					.flags = 0,
-					.epoll_fd = -1,
-					.sock_fd = -1,
+					.epfd = -1,
+					.logsock = -1,
+					.fdsock = -1,
+					.log = { .maxsize = -1, .maxfile = 3 },
+					.out = { .sfile = false,
+						 .ftree = true },
 					.revision = NULL };
 
 static int
 logserver_log_msg_data_null(const struct logserver_msg_data *msg_data)
 {
 	return 0;
+}
+
+static int logserver_openlog(const char *path)
+{
+	int fd = open(path, O_CREAT | O_SYNC | O_RDWR | O_APPEND, 0644);
+
+	struct stat st;
+	if (fstat(fd, &st) != 0)
+		return fd;
+
+	if (st.st_size < logserver_g.log.maxsize)
+		return fd;
+
+	char pattern[PATH_MAX] = { 0 };
+	snprintf(pattern, PATH_MAX, "%s.*.gz", path);
+
+	glob_t glist;
+	int r = glob(pattern, 0, NULL, &glist);
+	if (r != 0 && r != GLOB_NOMATCH)
+		return fd;
+
+	// looking for the newest file
+	size_t max = 0;
+	for (size_t i = 0; i < glist.gl_pathc; ++i) {
+		char str[PATH_MAX] = { 0 };
+		strcpy(str, glist.gl_pathv[i]);
+		str[strlen(str) - 3] = '\0';
+		size_t n = strtoumax(strrchr(str, '.') + 1, NULL, 10);
+		if (n > max)
+			max = n;
+	}
+	// next file
+	++max;
+
+	// only keep maxfile files
+	if ((int)glist.gl_pathc >= logserver_g.log.maxfile) {
+		char delete_path[PATH_MAX] = { 0 };
+		snprintf(delete_path, PATH_MAX, "%s.%zd.gz", path,
+			 max - logserver_g.log.maxfile);
+		pv_fs_path_remove(delete_path, false);
+	}
+
+	globfree(&glist);
+
+	char path_gz[PATH_MAX] = { 0 };
+	snprintf(path_gz, PATH_MAX, "%s.%zd", path, max);
+	pv_fs_file_gzip(path, path_gz);
+
+	ftruncate(fd, 0);
+	lseek(fd, 0, SEEK_SET);
+
+	return fd;
 }
 
 static int
@@ -126,8 +212,6 @@ logserver_log_msg_data_file_tree(const struct logserver_msg_data *msg_data)
 	int ret = -1;
 	char *dup_pathname = NULL;
 	char *fname = NULL;
-	struct stat st;
-	const int MAX_SIZE = 2 * 1024 * 1024;
 	bool source_is_pv = !strncmp(msg_data->platform, PV_PLATFORM_STR,
 				     strlen(PV_PLATFORM_STR));
 
@@ -142,13 +226,9 @@ logserver_log_msg_data_file_tree(const struct logserver_msg_data *msg_data)
 	 */
 	if (pv_fs_mkdir_p(fname, 0755))
 		goto error;
-	log_fd = open(pathname, O_CREAT | O_SYNC | O_RDWR | O_APPEND, 0644);
+
+	log_fd = logserver_openlog(pathname);
 	if (log_fd >= 0) {
-		if (!fstat(log_fd, &st)) {
-			/* Do we need to make a zip out of it?*/
-			if (st.st_size >= MAX_SIZE)
-				ftruncate(log_fd, 0);
-		}
 		if (source_is_pv) {
 			dprintf(log_fd,
 				"[pantavisor] %" PRIu64 " %s\t -- [%s]: %.*s\n",
@@ -180,8 +260,6 @@ logserver_log_msg_data_single_file(const struct logserver_msg_data *msg_data)
 	size_t json_len;
 	int log_fd;
 	char *json = NULL;
-	struct stat st;
-	const int MAX_SIZE = 2 * 1024 * 1024;
 	struct logserver_msg_data msg_data_json_escaped = {
 		.version = msg_data->version,
 		.level = msg_data->level,
@@ -222,13 +300,9 @@ logserver_log_msg_data_single_file(const struct logserver_msg_data *msg_data)
 		goto out;
 	pv_paths_pv_log_plat(pathname, sizeof(pathname), logserver_g.revision,
 			     "pv.log");
-	log_fd = open(pathname, O_CREAT | O_SYNC | O_RDWR | O_APPEND, 0644);
+
+	log_fd = logserver_openlog(pathname);
 	if (log_fd >= 0) {
-		if (!fstat(log_fd, &st)) {
-			/* Do we need to make a zip out of it?*/
-			if (st.st_size >= MAX_SIZE)
-				ftruncate(log_fd, 0);
-		}
 		dprintf(log_fd, "%s", json);
 		close(log_fd);
 		ret = 0;
@@ -246,10 +320,10 @@ out:
 
 static int logserver_log_msg_data(const struct logserver_msg_data *msg_data)
 {
-	if (pv_config_get_log_server_output_file_tree())
+	if (logserver_g.out.ftree)
 		logserver_log_msg_data_file_tree(msg_data);
 
-	if (pv_config_get_log_server_output_single_file())
+	if (logserver_g.out.sfile)
 		logserver_log_msg_data_single_file(msg_data);
 
 	return 0;
@@ -259,9 +333,9 @@ static int pv_log(int level, char *msg, ...)
 {
 	va_list args;
 	va_start(args, msg);
-	if (logserver_g.service_pid < 0) {
+	if (logserver_g.pid < 0) {
 		__log_to_console(MODULE_NAME, level, msg, args);
-	} else if (logserver_g.service_pid == 0) {
+	} else if (logserver_g.pid == 0) {
 		struct buffer *pv_buffer = pv_buffer_get(true);
 		char *buf = pv_buffer->buf;
 		int buf_len;
@@ -358,8 +432,7 @@ static int logserver_msg_parse_data(struct logserver_msg *msg,
 	return ret;
 }
 
-static int logserver_handle_msg(struct logserver *logserver,
-				struct logserver_msg *msg)
+static int logserver_handle_msg(struct logserver_msg *msg)
 {
 	struct logserver_msg_data msg_data;
 	int ret;
@@ -374,109 +447,372 @@ static int logserver_handle_msg(struct logserver *logserver,
 	return ret;
 }
 
-static int logserver_read_write(struct logserver *logserver)
+static int logserver_epoll_command(int fd, int cmd)
 {
-	struct epoll_event ep_event[LOGSERVER_FLAG_STOP];
-	int ret = 0;
-	int nr_logs = 0;
-again:
-	ret = epoll_wait(logserver->epoll_fd, ep_event, LOGSERVER_FLAG_STOP,
-			 -1);
-	if (ret < 0) {
-		if (errno == EINTR)
-			goto again;
-		else {
-			pv_log(ERROR, "could not epoll_wait: %s",
-			       strerror(errno));
-			return -1;
-		}
-	}
-	while (ret > 0) {
-		int work_fd;
-		/* Only one way comm.*/
-		struct sockaddr __unused;
-		/* index into event array*/
-		ret -= 1;
-		work_fd = ep_event[ret].data.fd;
-
-		if (work_fd == logserver->sock_fd) {
-			socklen_t sock_size = sizeof(__unused);
-			int client_fd = -1;
-		accept_again:
-			client_fd = accept(logserver->sock_fd, &__unused,
-					   &sock_size);
-			if (client_fd >= 0) {
-				/* reuse ep_event to add the new client_fd
-				 * to epoll.
-				 */
-				memset(&ep_event[ret], 0,
-				       sizeof(ep_event[ret]));
-				ep_event[ret].events = EPOLLIN;
-				ep_event[ret].data.fd = client_fd;
-
-				if (epoll_ctl(logserver->epoll_fd,
-					      EPOLL_CTL_ADD, client_fd,
-					      &ep_event[ret])) {
-					pv_log(ERROR, "could not epoll_ctl: %s",
-					       strerror(errno));
-					close(client_fd); /*So client would know*/
-				}
-			} else if (client_fd < 0 && errno == EINTR)
-				goto accept_again;
-			else {
-				pv_log(ERROR, "could not accept: %s",
-				       strerror(errno));
-			}
-		} else {
-			/* We've data to read.*/
-			struct buffer *log_buffer = NULL;
-
-			log_buffer = pv_buffer_get(true);
-			if (log_buffer) {
-				int nr_read = 0;
-				struct logserver_msg *msg =
-					(struct logserver_msg *)log_buffer->buf;
-
-				nr_read = pv_fs_file_read_nointr(
-					work_fd, log_buffer->buf,
-					log_buffer->size);
-				if (nr_read > 0) {
-					logserver_handle_msg(logserver, msg);
-					nr_logs++;
-				}
-			}
-			ep_event[ret].events = EPOLLIN;
-			epoll_ctl(logserver->epoll_fd, EPOLL_CTL_DEL, work_fd,
-				  &ep_event[ret]);
-			close(work_fd);
-			pv_buffer_drop(log_buffer);
-		}
-	}
-	return nr_logs;
+	struct epoll_event ev;
+	ev.events = EPOLLIN;
+	ev.data.fd = fd;
+	errno = 0;
+	return epoll_ctl(logserver_g.epfd, cmd, fd, &ev);
 }
 
-static int logserver_open_socket()
+static int logserver_epoll_add(int fd)
 {
-	int fd;
-	struct sockaddr_un addr;
+	return logserver_epoll_command(fd, EPOLL_CTL_ADD);
+}
 
-	fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (fd == -1) {
-		pv_log(ERROR, "unable to open control socket: %d", errno);
-		goto out;
+static int logserver_epoll_del(int fd)
+{
+	return logserver_epoll_command(fd, EPOLL_CTL_DEL);
+}
+
+static int logserver_accept_connection(int sockd)
+{
+	int fd = -1;
+	errno = 0;
+
+	do {
+		fd = accept(sockd, NULL, NULL);
+		if (errno != 0 && errno != EINTR) {
+			pv_log(ERROR, "could not accept: %s", strerror(errno));
+			return -1;
+		}
+	} while (fd < 0);
+
+	return fd;
+}
+
+static struct logserver_fd *logserver_fd_new(char *platform, char *src, int fd)
+{
+	struct logserver_fd *lfd = calloc(1, sizeof(struct logserver_fd));
+	if (!lfd)
+		return NULL;
+
+	if (platform)
+		lfd->platform = strdup(platform);
+	if (src)
+		lfd->src = strdup(src);
+	lfd->fd = fd;
+	dl_list_init(&lfd->list);
+
+	return lfd;
+}
+
+static void logserver_fd_free(struct logserver_fd *lfd)
+{
+	if (!lfd)
+		return;
+
+	if (lfd->platform)
+		free(lfd->platform);
+	if (lfd->src)
+		free(lfd->src);
+	free(lfd);
+}
+
+static bool logserver_list_exists(struct dl_list *lst, int fd)
+{
+	struct logserver_fd *it, *tmp;
+
+	dl_list_for_each_safe(it, tmp, lst, struct logserver_fd, list)
+	{
+		if (fd == it->fd)
+			return true;
 	}
 
-	memset(&addr, 0, sizeof(addr));
-	addr.sun_family = AF_UNIX;
-	pv_paths_pv_file(addr.sun_path, sizeof(addr.sun_path) - 1,
-			 LOGCTRL_FNAME);
+	return false;
+}
 
-	if (bind(fd, (const struct sockaddr *)&addr, sizeof(addr)) == -1) {
+static void logserver_list_del(struct dl_list *lst, int fd,
+			       const char *platform)
+{
+	struct logserver_fd *it, *tmp;
+	dl_list_for_each_safe(it, tmp, lst, struct logserver_fd, list)
+	{
+		if (platform) {
+			if (strcmp(it->platform, platform) == 0) {
+				dl_list_del(&it->list);
+				logserver_fd_free(it);
+				return;
+			}
+		} else {
+			if (it->fd == fd) {
+				dl_list_del(&it->list);
+				logserver_fd_free(it);
+				return;
+			}
+		}
+	}
+}
+
+static int logserver_list_add(struct dl_list *tmplst, struct logserver_fd *lfd)
+{
+	if (!lfd)
+		return -1;
+	dl_list_add(tmplst, &lfd->list);
+	return 0;
+}
+
+static struct logserver_fd *logserver_fetch_fd_from_list(struct dl_list *l,
+							 int fd)
+{
+	struct logserver_fd *it, *tmp;
+	dl_list_for_each_safe(it, tmp, l, struct logserver_fd, list)
+	{
+		if (it->fd == fd) {
+			return it;
+		}
+	}
+	return NULL;
+}
+
+static struct logserver_fd *logserver_get_fd(int sockfd)
+{
+	union {
+		char buf[CMSG_SPACE(sizeof(int))];
+		struct cmsghdr align;
+	} ctrl;
+
+	char platform[LOGSERVER_MAX_HEADER_LEN] = { 0 };
+	char src[LOGSERVER_MAX_HEADER_LEN] = { 0 };
+
+	struct iovec iov[2];
+	iov[0] = (struct iovec){ .iov_base = platform,
+				 .iov_len = LOGSERVER_MAX_HEADER_LEN };
+	iov[1] = (struct iovec){ .iov_base = src,
+				 .iov_len = LOGSERVER_MAX_HEADER_LEN };
+
+	struct msghdr msg = { .msg_name = NULL,
+			      .msg_namelen = 0,
+			      .msg_iov = iov,
+			      .msg_iovlen = 2,
+			      .msg_control = ctrl.buf,
+			      .msg_controllen = sizeof(ctrl.buf) };
+
+	errno = 0;
+	if (recvmsg(sockfd, &msg, 0) < 0) {
+		pv_log(ERROR, "error receiving fd: %s", strerror(errno));
+		return NULL;
+	}
+
+	struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg) {
+		pv_log(ERROR, "error receiving fd, NULL structure\n");
+		return NULL;
+	}
+
+	int fd;
+	memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
+
+	return logserver_fd_new(platform, src, fd);
+}
+
+static int logserver_epoll_wait(struct epoll_event *ev)
+{
+	int ready = 0;
+	errno = 0;
+	do {
+		ready = epoll_wait(logserver_g.epfd, ev, LOGSERVER_MAX_EV, -1);
+
+		if (errno != 0 && errno != EINTR) {
+			pv_log(ERROR, "error calling epoll_wait: %s",
+			       strerror(errno));
+			return 0;
+		}
+	} while (ready < 0);
+
+	return ready;
+}
+
+static void logserver_consume_log_data(int fd)
+{
+	struct buffer *buffer = pv_buffer_get(true);
+
+	if (!buffer)
+		return;
+
+	if (pv_fs_file_read_nointr(fd, buffer->buf, buffer->size) > 0) {
+		struct logserver_msg *msg = (struct logserver_msg *)buffer->buf;
+		logserver_handle_msg(msg);
+	}
+
+	pv_buffer_drop(buffer);
+}
+
+static void logserver_consume_fd(int fd)
+{
+	struct buffer *buffer = pv_buffer_get(true);
+	ssize_t size = 0;
+	if (!buffer)
+		return;
+
+	size = pv_fs_file_read_nointr(fd, buffer->buf, buffer->size);
+	if (size > 0) {
+		struct logserver_fd *lfd =
+			logserver_fetch_fd_from_list(&logserver_g.fdlst, fd);
+
+		struct logserver_msg_data d = { .version = LOG_PROTOCOL_LEGACY,
+						.level = DEBUG,
+						.tsec = (uint64_t)time(NULL),
+						.platform = lfd->platform,
+						.source = lfd->src,
+						.data = buffer->buf,
+						.data_len = size };
+		logserver_log_msg_data(&d);
+	}
+	pv_buffer_drop(buffer);
+}
+
+static int logserver_process_fd(int curfd)
+{
+	int ret = 0;
+	struct logserver_fd *lfd = NULL;
+
+	logserver_list_del(&logserver_g.tmplst, curfd, NULL);
+	logserver_epoll_del(curfd);
+
+	lfd = logserver_get_fd(curfd);
+
+	if (!lfd) {
+		ret = -1;
+		goto clean_all;
+	}
+
+	// unsubscribe the platform
+	if (lfd->fd < 0) {
+		logserver_list_del(&logserver_g.fdlst, 0, lfd->platform);
+		pv_log(INFO, "fd (%d) for platform %s:%s unsubscribed", lfd->fd,
+		       lfd->platform, lfd->src);
+		ret = 0;
+		goto clean_all;
+	}
+
+	// subcribe new fd
+	if (logserver_list_add(&logserver_g.fdlst, lfd) != 0) {
+		ret = -1;
+		goto clean_all;
+	}
+
+	if (logserver_epoll_add(lfd->fd) != 0) {
+		ret = -1;
+		goto clean_all;
+	}
+
+	pv_log(DEBUG, "new fd (%d) for %s:%s subscribed", lfd->fd,
+	       lfd->platform, lfd->src);
+	return ret;
+
+clean_all:
+	if (lfd)
+		logserver_fd_free(lfd);
+
+	if (ret != 0)
+		pv_log(DEBUG, "couldn't subscribe fd (%d) for %s:%s", lfd->fd,
+		       lfd->platform, lfd->src);
+
+	return ret;
+}
+
+static void logserver_loop()
+{
+	struct epoll_event ev[LOGSERVER_MAX_EV];
+	int n_events = logserver_epoll_wait(ev);
+
+	if (n_events < 1) {
+		return;
+	}
+
+	int logsock = logserver_g.logsock;
+	int fdsock = logserver_g.fdsock;
+	struct dl_list *tmplst = &logserver_g.tmplst;
+	struct dl_list *fdlst = &logserver_g.fdlst;
+
+	int curfd = -1;
+	for (int i = 0; i < n_events; ++i) {
+		curfd = ev[i].data.fd;
+		if (curfd == logsock || curfd == fdsock) {
+			int fd = logserver_accept_connection(curfd);
+			if (fd < 0) {
+				continue;
+			}
+
+			if (logserver_epoll_add(fd) != 0) {
+				close(fd);
+				continue;
+			}
+
+			if (curfd == fdsock) {
+				struct logserver_fd *lfd =
+					logserver_fd_new(NULL, NULL, fd);
+
+				if (logserver_list_add(tmplst, lfd) != 0) {
+					logserver_fd_free(lfd);
+					logserver_epoll_del(fd);
+					close(fd);
+				}
+			}
+		} else if (logserver_list_exists(tmplst, curfd)) {
+			logserver_process_fd(curfd);
+			close(curfd);
+		} else {
+			bool sub = logserver_list_exists(fdlst, curfd);
+
+			if (!sub) {
+				logserver_consume_log_data(curfd);
+				logserver_epoll_del(curfd);
+				close(curfd);
+			} else {
+				logserver_consume_fd(curfd);
+			}
+		}
+	}
+}
+
+static int logserver_open_client_socket(const char *fname)
+{
+	struct sockaddr_un addr = { 0 };
+
+	errno = 0;
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd == -1) {
+		pv_log(ERROR, "unable to open control socket: %s", errno);
+		return -1;
+	}
+
+	addr.sun_family = AF_UNIX;
+	pv_paths_pv_file(addr.sun_path, sizeof(addr.sun_path) - 1, fname);
+
+	int r = connect(fd, (struct sockaddr *)&addr,
+			sizeof(struct sockaddr_un));
+	if (r == -1) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+static int logserver_open_server_socket(const char *fname)
+{
+	struct sockaddr_un addr = { 0 };
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd == -1) {
+		pv_log(ERROR, "unable to open control socket: %d", errno);
+		return -1;
+	}
+
+	addr.sun_family = AF_UNIX;
+	pv_paths_pv_file(addr.sun_path, sizeof(addr.sun_path) - 1, fname);
+
+	// sometimes, the socket file still exists after reboot
+	unlink(addr.sun_path);
+
+	if (bind(fd, (const struct sockaddr *)&addr, sizeof(addr.sun_path)) ==
+	    -1) {
 		pv_log(ERROR, "unable to bind control socket: %s",
 		       strerror(errno));
 		close(fd);
-		fd = -1;
-		goto out;
+		return -1;
 	}
 
 	// queue upto LOGSERVER_BACKLOG commands
@@ -484,17 +820,16 @@ static int logserver_open_socket()
 		pv_log(ERROR, "unable to listen to control socket: %d\n",
 		       strerror(errno));
 		close(fd);
-		fd = -1;
+		return -1;
 	}
-out:
+
 	return fd;
 }
 
-static pid_t logserver_start_service(struct logserver *logserver,
-				     const char *revision)
+static pid_t logserver_start_service(const char *revision)
 {
-	logserver->service_pid = fork();
-	if (logserver->service_pid == 0) {
+	logserver_g.pid = fork();
+	if (logserver_g.pid == 0) {
 		if (logserver_g.revision)
 			free(logserver_g.revision);
 		logserver_g.revision = strdup(revision);
@@ -514,25 +849,25 @@ static pid_t logserver_start_service(struct logserver *logserver,
 
 		pv_log(DEBUG, "starting logserver loop");
 
-		while (!(logserver->flags & LOGSERVER_FLAG_STOP)) {
-			logserver_read_write(logserver);
+		while (!(logserver_g.flags & LOGSERVER_FLAG_STOP)) {
+			logserver_loop();
 		}
 		_exit(EXIT_SUCCESS);
 	}
 
-	return logserver->service_pid;
+	return logserver_g.pid;
 }
 
-static void logserver_start(struct logserver *logserver, const char *revision)
+static void logserver_start(const char *revision)
 {
-	if (logserver->service_pid == -1) {
-		logserver_start_service(logserver, revision);
+	if (logserver_g.pid == -1) {
+		logserver_start_service(revision);
 		pv_log(DEBUG, "starting log service with pid %d",
-		       (int)logserver->service_pid);
+		       (int)logserver_g.pid);
 
-		if (logserver->service_pid > 0) {
+		if (logserver_g.pid > 0) {
 			pv_log(DEBUG, "started log service with pid %d",
-			       (int)logserver->service_pid);
+			       (int)logserver_g.pid);
 		} else {
 			pv_log(ERROR, "unable to start log service");
 		}
@@ -543,14 +878,14 @@ static void logserver_stop()
 {
 	pv_log(DEBUG, "stopping logserver service...");
 
-	if (logserver_g.service_pid > 0) {
-		pv_system_kill_lenient(logserver_g.service_pid);
-		pv_system_kill_force(logserver_g.service_pid);
+	if (logserver_g.pid > 0) {
+		pv_system_kill_lenient(logserver_g.pid);
+		pv_system_kill_force(logserver_g.pid);
 		pv_log(DEBUG, "stopped logserver service with pid %d",
-		       logserver_g.service_pid);
+		       logserver_g.pid);
 	}
 
-	logserver_g.service_pid = -1;
+	logserver_g.pid = -1;
 }
 
 // XXX: this is bad code now. stop must never happen here; we
@@ -564,39 +899,67 @@ void pv_logserver_toggle(struct pantavisor *pv, const char *rev)
 
 	// only start if we have log_capture configured
 	if (pv_config_get_log_capture()) {
-		logserver_start(&logserver_g, rev);
+		logserver_start(rev);
 	}
 }
 
 int pv_logserver_init()
 {
-	struct epoll_event ep_event;
+	logserver_g.log.maxsize = pv_config_get_log_logmax();
 
-	logserver_g.sock_fd = logserver_open_socket();
-	logserver_g.epoll_fd = epoll_create1(0);
+	if (pv_config_get_log_capture()) {
+		logserver_g.out.sfile =
+			pv_config_get_log_server_output_single_file();
+		logserver_g.out.ftree =
+			pv_config_get_log_server_output_file_tree();
+	} else {
+		logserver_g.out.sfile = false;
+		logserver_g.out.ftree = false;
+	}
 
-	if (logserver_g.epoll_fd < 0 || logserver_g.sock_fd < 0) {
-		pv_log(DEBUG, "logserver_g epoll_fd = %d",
-		       logserver_g.epoll_fd);
-		pv_log(DEBUG, "logserver_g sock_fd = %d", logserver_g.sock_fd);
-		pv_log(DEBUG, "errno  =%d", errno);
+	errno = 0;
+	logserver_g.epfd = epoll_create1(0);
+
+	if (logserver_g.epfd < 0) {
+		pv_log(ERROR, "could not create logserver_g epoll fd");
+		return -1;
+	}
+
+	logserver_g.logsock = logserver_open_server_socket(LOGCTRL_FNAME);
+	if (logserver_g.logsock < 0)
+		pv_log(WARN,
+		       "could not initialize log socket, logs will not be captured");
+
+	logserver_g.fdsock = logserver_open_server_socket(LOGFD_FNAME);
+	if (logserver_g.fdsock)
+		pv_log(WARN,
+		       "could not open fd socket, some containers logs will be lost");
+
+	if (logserver_epoll_add(logserver_g.logsock) == -1) {
+		pv_log(WARN,
+		       "could not init log socket, logs will not be captured");
 		goto out;
 	}
 
-	ep_event.events = EPOLLIN;
-	ep_event.data.fd = logserver_g.sock_fd;
-	if (epoll_ctl(logserver_g.epoll_fd, EPOLL_CTL_ADD, ep_event.data.fd,
-		      &ep_event))
+	if (logserver_epoll_add(logserver_g.fdsock) == -1) {
+		pv_log(WARN,
+		       "could not init fd socket, some containers logs will be lost");
 		goto out;
+	}
 
-	logserver_start_service(&logserver_g, pv_bootloader_get_rev());
-	pv_log(DEBUG, "started log service with pid %d",
-	       (int)logserver_g.service_pid);
+	dl_list_init(&logserver_g.fdlst);
+	dl_list_init(&logserver_g.tmplst);
+	logserver_start_service(pv_bootloader_get_rev());
+	pv_log(DEBUG, "started log service with pid %d", (int)logserver_g.pid);
 
 	return 0;
 out:
-	close(logserver_g.sock_fd);
-	close(logserver_g.epoll_fd);
+	if (logserver_g.logsock >= 0)
+		close(logserver_g.logsock);
+	if (logserver_g.fdsock >= 0)
+		close(logserver_g.fdsock);
+	if (logserver_g.epfd >= 0)
+		close(logserver_g.epfd);
 
 	return -1;
 }
@@ -653,8 +1016,7 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 		.source = src,
 	};
 
-	if (logserver_g.service_pid <= 0 ||
-	    level > pv_config_get_log_loglevel())
+	if (logserver_g.pid <= 0 || level > pv_config_get_log_loglevel())
 		return -1;
 
 	vmsg_buffer = pv_buffer_get(true);
@@ -707,8 +1069,8 @@ int pv_logserver_send_log(bool is_platform, char *platform, char *src,
 
 void pv_logserver_reload(void)
 {
-	if (logserver_g.service_pid >= 0)
-		kill(logserver_g.service_pid, SIGUSR1);
+	if (logserver_g.pid >= 0)
+		kill(logserver_g.pid, SIGUSR1);
 }
 
 void pv_logserver_stop(void)
@@ -716,15 +1078,66 @@ void pv_logserver_stop(void)
 	return logserver_stop();
 }
 
+static void logserver_close(int sockd, const char *name)
+{
+	if (sockd < 0)
+		return;
+
+	char path[PATH_MAX];
+	pv_paths_pv_file(path, PATH_MAX, name);
+	pv_log(DEBUG, "closing %s with fd %d\n", path, sockd);
+	close(sockd);
+	unlink(path);
+}
+
 void pv_logserver_close()
 {
-	char path[PATH_MAX];
+	if (logserver_g.logsock >= 0)
+		logserver_close(logserver_g.logsock, LOGCTRL_FNAME);
+	if (logserver_g.fdsock >= 0)
+		logserver_close(logserver_g.fdsock, LOGFD_FNAME);
+}
 
-	if (logserver_g.sock_fd >= 0) {
-		pv_paths_pv_file(path, PATH_MAX, LOGCTRL_FNAME);
-		pv_log(DEBUG, "closing %s with fd %d", path,
-		       logserver_g.sock_fd);
-		close(logserver_g.sock_fd);
-		unlink(path);
-	}
+int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src)
+{
+	char plat_buf[LOGSERVER_MAX_HEADER_LEN] = { 0 };
+	char src_buf[LOGSERVER_MAX_HEADER_LEN] = { 0 };
+
+	strncpy(plat_buf, platform, LOGSERVER_MAX_HEADER_LEN - 1);
+	strncpy(src_buf, src, LOGSERVER_MAX_HEADER_LEN - 1);
+
+	struct iovec iov[2];
+	iov[0] = (struct iovec){ .iov_base = plat_buf,
+				 .iov_len = LOGSERVER_MAX_HEADER_LEN };
+	iov[1] = (struct iovec){ .iov_base = src_buf,
+				 .iov_len = LOGSERVER_MAX_HEADER_LEN };
+
+	union {
+		char buf[CMSG_SPACE(sizeof(int))];
+		struct cmsghdr align;
+	} ctrl;
+
+	struct msghdr msg = { .msg_name = NULL,
+			      .msg_namelen = 0,
+			      .msg_iov = iov,
+			      .msg_iovlen = 2,
+			      .msg_control = ctrl.buf,
+			      .msg_controllen = sizeof(ctrl.buf) };
+
+	struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+
+	int sockfd = logserver_open_client_socket(LOGFD_FNAME);
+
+	int r = sendmsg(sockfd, &msg, 0);
+
+	return r;
+}
+
+int pv_logserver_unsubscribe_fd(const char *platform, const char *src)
+{
+	return pv_logserver_subscribe_fd(-1, platform, src);
 }

--- a/logserver.h
+++ b/logserver.h
@@ -41,5 +41,7 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 void pv_logserver_reload(void);
 void pv_logserver_stop(void);
 void pv_logserver_close(void);
+int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src);
+int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
 
 #endif /* LOGSERVER_H */

--- a/paths.h
+++ b/paths.h
@@ -28,6 +28,7 @@
 #define PHHOST_FNAME "pantahub-host"
 #define PVCTRL_FNAME "pv-ctrl"
 #define LOGCTRL_FNAME "pv-ctrl-log"
+#define LOGFD_FNAME "pv-fd-log"
 
 void pv_paths_pv_file(char *buf, size_t size, const char *name);
 
@@ -49,8 +50,6 @@ void pv_paths_pv_devmeta_plat_key(char *buf, size_t size, const char *plat,
 #define LXC_LOG_SUBDIR "lxc"
 #define LOGS_PV_DNAME "pantavisor"
 #define LOGS_PV_FNAME "pantavisor.log"
-#define LXC_LOG_FNAME LXC_LOG_SUBDIR "/lxc.log"
-#define LXC_CONSOLE_LOG_FNAME LXC_LOG_SUBDIR "/console.log"
 
 void pv_paths_pv_log(char *buf, size_t size, const char *rev);
 void pv_paths_pv_log_plat(char *buf, size_t size, const char *rev,

--- a/platforms.h
+++ b/platforms.h
@@ -69,6 +69,12 @@ struct pv_status {
 	plat_status_t goal;
 };
 
+struct pv_platform_log {
+	int console_tty;
+	int console_pt;
+	int lxc_pipe[2];
+};
+
 struct pv_platform {
 	char *name;
 	char *type;
@@ -77,6 +83,7 @@ struct pv_platform {
 	unsigned long ns_share;
 	void *data;
 	pid_t init_pid;
+	struct pv_platform_log log;
 	struct pv_status status;
 	struct pv_group *group;
 	struct pv_state *state;

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -26,7 +26,6 @@
 #include "../config.h"
 #include "../platforms.h"
 
-void pv_set_new_log_fn(void *fn_pv_new_log);
 void pv_set_pv_instance_fn(void *fn_pv_get_instance);
 void pv_set_pv_paths_fn(
 	void *fn_pv_paths_pv_file, void *fn_pv_paths_pv_log,
@@ -38,7 +37,8 @@ void pv_set_pv_paths_fn(
 	void *fn_pv_paths_lib_lxc_lxcpath);
 
 void *pv_start_container(struct pv_platform *p, const char *rev,
-			 char *conf_file, void *data);
+			 char *conf_file, int logfd, void *data);
 void *pv_stop_container(struct pv_platform *p, char *conf_file, void *data);
+int pv_console_log_getfd(struct pv_platform_log *log, void *data);
 
 #endif

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -396,18 +396,15 @@ int pv_fs_file_unlock(int fd)
 
 int pv_fs_file_gzip(const char *fname, const char *target_name)
 {
-	int outfile[] = { -1, -1 };
 	char cmd[PATH_MAX + 32];
 
-	snprintf(cmd, sizeof(cmd), "gzip %s", fname);
-	outfile[1] = open(target_name, O_RDWR | O_APPEND | O_CREAT);
-	if (outfile[1] >= 0) {
-		tsh_run_io(cmd, 1, NULL, NULL, outfile, NULL);
-		close_fd(&outfile[1]);
-		pv_fs_path_sync(target_name);
-		return 0;
-	}
-	return -1;
+	if (pv_fs_file_copy(fname, target_name, 0644) != 0)
+		return -1;
+
+	snprintf(cmd, sizeof(cmd), "gzip %s", target_name);
+	tsh_run_io(cmd, 1, NULL, NULL, NULL, NULL);
+	pv_fs_path_sync(target_name);
+	return 0;
 }
 
 int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode)


### PR DESCRIPTION
* Adds to the logserver the ability to subscribe/unsubscribe a file descriptor for:
  - Add data to the pv.log (when single file mode is set)
  - Create an isolated file with the data in a directory named like the "source" of the fd (if the source is a/b/c the folders will be created).
* Add API in the pv_lxc plugin to get the console log fd from lxc.
* Add API to set a pipe to capture lxc logs (in the start function).