### PR TITLE
cgroup version detection

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -997,6 +997,11 @@ static int pv_pantavisor_init(struct pv_init *this)
 	pv->synced = false;
 	pv->loading_objects = false;
 	pv->hard_poweroff = false;
+
+	// detect cgroup version
+	pv->cgroupv = pv_system_get_cgroup_version();
+	pv_log(DEBUG, "cgroup version detected '%s'",
+	       pv_system_cgroupv_string(pv->cgroupv));
 out:
 	return 0;
 }

--- a/pantavisor.h
+++ b/pantavisor.h
@@ -26,6 +26,8 @@
 
 #include "config.h"
 
+#include "utils/system.h"
+
 #define RUNLEVEL_DATA 0
 #define RUNLEVEL_ROOT 1
 #define RUNLEVEL_PLATFORM 2
@@ -52,6 +54,7 @@ struct pantavisor {
 	bool synced;
 	bool loading_objects;
 	bool hard_poweroff;
+	cgroup_version_t cgroupv;
 	int ctrl_fd;
 };
 

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -230,6 +230,13 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 			 pv_lxc_get_lxc_log_level());
 		c->set_config_item(c, "lxc.log.level", log_level);
 	}
+	// cgroup version lxc config
+	c->get_config_item(c, "lxc.cgroup.devices.allow", path, PATH_MAX);
+	if ((__pv_get_instance()->cgroupv == CGROUP_V2) && strlen(path)) {
+		c->set_config_item(c, "lxc.cgroup.devices.allow", NULL);
+		c->set_config_item(c, "lxc.cgroup2.devices.allow", path);
+	}
+	// role specific lxc config
 	if (p->roles & PLAT_ROLE_MGMT) {
 		__pv_paths_pv_file(path, PATH_MAX, "");
 		snprintf(entry, sizeof(entry),

--- a/utils/system.h
+++ b/utils/system.h
@@ -25,6 +25,8 @@
 
 #include <stdint.h>
 
+#include <sys/types.h>
+
 #ifdef __arm__
 #define PV_ARCH "arm"
 #elif __aarch64__
@@ -43,9 +45,23 @@
 #define PV_BITS "64"
 #endif
 
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
+
+typedef enum {
+	CGROUP_UNKNOWN,
+	CGROUP_V1,
+	CGROUP_UNIFIED,
+	CGROUP_V2
+} cgroup_version_t;
+
 int get_endian(void);
 int get_dt_model(char *buf, int buflen);
 int get_cpu_model(char *buf, int buflen);
+cgroup_version_t pv_system_get_cgroup_version(void);
+const char *pv_system_cgroupv_string(cgroup_version_t cgroupv);
+
 void pv_system_kill_lenient(pid_t pid);
 void pv_system_kill_force(pid_t pid);
 


### PR DESCRIPTION
cgroup version is now detected when initializing pantavisor. Based on the /sys/fs/cgroup/ file type and /sys/fs/cgroup/unified/, we determine if the system has the v1, the unified or the v2.

This information is then used from ctrl so sender platform name can be get from v2. It is also used in lxc plugin to substitute lxc.cgroup.devices.allow = a with lxc.cgroup2.devices.allow = a