### PR TITLE
fix: platforms not properly transfered to new state groups in non-reboot transitions

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -837,10 +837,9 @@ static int do_action_for_runlevel(struct json_key_action *jka, char *value)
 
 		g = pv_state_fetch_group(bundle->s, value);
 		if (!g) {
-			pv_log(ERROR, "could not find group %s", value);
+			pv_log(ERROR, "could not find group '%s'", value);
 			return -1;
 		}
-		(*bundle->platform)->group = g;
 		pv_group_add_platform(g, (*bundle->platform));
 	} else {
 		pv_log(WARN, "invalid runlevel value '%s' for platform '%s'",
@@ -863,10 +862,9 @@ static int do_action_for_group(struct json_key_action *jka, char *value)
 
 	g = pv_state_fetch_group(bundle->s, value);
 	if (!g) {
-		pv_log(ERROR, "could not find group %s", value);
+		pv_log(ERROR, "could not find group '%s'", value);
 		return -1;
 	}
-	(*bundle->platform)->group = g;
 	pv_group_add_platform(g, (*bundle->platform));
 
 	return 0;
@@ -1340,6 +1338,7 @@ static struct pv_state *system1_parse_objects(struct pv_state *this,
 		if (!strncmp("bsp/run.json", buf + (*k)->start, n) ||
 		    !strncmp("bsp/drivers.json", buf + (*k)->start, n) ||
 		    !strncmp("disks.json", buf + (*k)->start, n) ||
+		    !strncmp("groups.json", buf + (*k)->start, n) ||
 		    !strncmp("#spec", buf + (*k)->start, n)) {
 			k++;
 			continue;

--- a/state.c
+++ b/state.c
@@ -338,9 +338,8 @@ static void pv_state_set_default_groups(struct pv_state *s)
 	// if not, set first platform in group root
 	if (!root_configured && first_p) {
 		pv_log(WARN,
-		       "no platform was found in root group, "
+		       "no platform was found in 'root' group, "
 		       "so the first unconfigured one in alphabetical order will be set");
-		first_p->group = r;
 		pv_group_add_platform(r, first_p);
 	}
 
@@ -349,7 +348,6 @@ static void pv_state_set_default_groups(struct pv_state *s)
 	dl_list_for_each_safe(p, tmp, platforms, struct pv_platform, list)
 	{
 		if (p->group == NULL) {
-			p->group = d;
 			pv_group_add_platform(d, p);
 		}
 	}
@@ -982,7 +980,7 @@ static void pv_state_transfer_groups(struct pv_state *pending,
 		g = pv_state_fetch_group(current, p->group->name);
 		pv_log(DEBUG, "relinking platform %s to group %s", p->name,
 		       g->name);
-		p->group = g;
+		pv_group_add_platform(g, p);
 	}
 }
 


### PR DESCRIPTION
Platforms were added to groups like this 
```
(*bundle->platform)->group = g;
pv_group_add_platform(g, (*bundle->platform));
```

So, first link the group to the platform, then call pv_group_add_platform, which links a platform reference to the group.

This was not being done in non-reboot transitions, were we skipped the second part. This was causing new states to have groups with references to the old revisions.

In this PR we put everything inside pv_group_add_platform and we call that one in every case. This needs an extra step, which is removing the current reference of the platform in the group.