### PR TITLE
fix logserver not transitioning logs to new revision on no reboot update

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -73,6 +73,20 @@ const char *pv_bootloader_get_done()
 	return pv_bootloader.pv_done;
 }
 
+int pv_bootloader_reload_pv_try()
+{
+	char *new1;
+	new1 = ops->get_env_key("pv_try");
+	if (pv_bootloader.pv_try && new1) {
+		char *old;
+		old = pv_bootloader.pv_try;
+		pv_bootloader.pv_try = new1;
+		free(old);
+		return 0;
+	}
+	return -1;
+}
+
 static int pv_bootloader_set_rev(char *rev)
 {
 	int len = strlen(rev) + 1;

--- a/bootloader.h
+++ b/bootloader.h
@@ -39,6 +39,7 @@ const char *pv_bootloader_get_rev(void);
 const char *pv_bootloader_get_try(void);
 const char *pv_bootloader_get_done(void);
 
+int pv_bootloader_reload_pv_try(void);
 bool pv_bootloader_update_in_progress(void);
 bool pv_bootloader_trying_update(void);
 

--- a/config.c
+++ b/config.c
@@ -139,6 +139,8 @@ static int config_parse_log_server_outputs(char *value)
 			server_outputs |= LOG_SERVER_OUTPUT_SINGLE_FILE;
 		else if (!strcmp(token, "filetree"))
 			server_outputs |= LOG_SERVER_OUTPUT_FILE_TREE;
+		else if (!strcmp(token, "nullsink"))
+			server_outputs |= LOG_SERVER_OUTPUT_NULL_SINK;
 	}
 
 	return server_outputs;

--- a/config.h
+++ b/config.h
@@ -129,8 +129,9 @@ struct pantavisor_network {
 };
 
 typedef enum {
-	LOG_SERVER_OUTPUT_SINGLE_FILE = 1 << 0,
-	LOG_SERVER_OUTPUT_FILE_TREE = 1 << 1,
+	LOG_SERVER_OUTPUT_NULL_SINK = 1 << 0,
+	LOG_SERVER_OUTPUT_SINGLE_FILE = 1 << 1,
+	LOG_SERVER_OUTPUT_FILE_TREE = 1 << 2,
 	LOG_SERVER_OUTPUT_SIZE
 } log_server_output_mask_t;
 

--- a/logserver.c
+++ b/logserver.c
@@ -113,6 +113,12 @@ static struct logserver logserver_g = { .service_pid = -1,
 					.revision = NULL };
 
 static int
+logserver_log_msg_data_null(const struct logserver_msg_data *msg_data)
+{
+	return 0;
+}
+
+static int
 logserver_log_msg_data_file_tree(const struct logserver_msg_data *msg_data)
 {
 	char pathname[PATH_MAX];
@@ -295,6 +301,27 @@ static void sigchld_handler(int signum)
 	 */
 	while (waitpid(-1, NULL, WNOHANG) > 0)
 		;
+}
+
+static void sigusr1_handler(int signum)
+{
+	pv_log(DEBUG, "signal handler to reload revision before %s",
+	       logserver_g.revision ? logserver_g.revision : "NULL");
+
+	if (pv_bootloader_reload_pv_try()) {
+		pv_log(ERROR,
+		       "failed to reread revision after no reboot transition; continuing to log to previous revision");
+		return;
+	}
+
+	char *sav = logserver_g.revision;
+	if (pv_bootloader_get_try())
+		logserver_g.revision = strdup(pv_bootloader_get_try());
+	if (sav)
+		free(sav);
+
+	pv_log(DEBUG, "signal handler to reload revision after %s",
+	       logserver_g.revision);
 }
 
 static int logserver_msg_parse_data(struct logserver_msg *msg,
@@ -482,6 +509,9 @@ static pid_t logserver_start_service(struct logserver *logserver,
 		sa.sa_handler = sigchld_handler;
 		sigaction(SIGCHLD, &sa, NULL);
 
+		sa.sa_handler = sigusr1_handler;
+		sigaction(SIGUSR1, &sa, NULL);
+
 		pv_log(DEBUG, "starting logserver loop");
 
 		while (!(logserver->flags & LOGSERVER_FLAG_STOP)) {
@@ -523,15 +553,19 @@ static void logserver_stop()
 	logserver_g.service_pid = -1;
 }
 
+// XXX: this is bad code now. stop must never happen here; we
+// should kill this function and do the starting directly in the main
+// lifecycle code that currently calls this; disabling log capture
+// should happen through a "nullsink".
 void pv_logserver_toggle(struct pantavisor *pv, const char *rev)
 {
 	if (!pv)
 		return;
 
+	// only start if we have log_capture configured
 	if (pv_config_get_log_capture()) {
 		logserver_start(&logserver_g, rev);
-	} else
-		logserver_stop();
+	}
 }
 
 int pv_logserver_init()
@@ -671,6 +705,12 @@ int pv_logserver_send_log(bool is_platform, char *platform, char *src,
 
 	va_end(args);
 	return ret;
+}
+
+void pv_logserver_reload(void)
+{
+	if (logserver_g.service_pid >= 0)
+		kill(logserver_g.service_pid, SIGUSR1);
 }
 
 void pv_logserver_stop(void)

--- a/logserver.h
+++ b/logserver.h
@@ -38,6 +38,7 @@ int pv_logserver_send_log(bool is_platform, char *platform, char *src,
 int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 			   int level, const char *msg, va_list args);
 
+void pv_logserver_reload(void);
 void pv_logserver_stop(void);
 void pv_logserver_close(void);
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -222,7 +222,8 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 		// for non-reboot updates...
 		pv_log(INFO, "transitioning...");
 
-		pv_logserver_stop();
+		pv_logserver_reload();
+
 		ph_logger_stop_lenient();
 		ph_logger_stop_force();
 
@@ -463,7 +464,6 @@ static pv_state_t pv_wait_network(struct pantavisor *pv)
 	}
 
 	// start or stop ph logger depending on network and configuration
-	pv_logserver_toggle(pv, pv->state->rev);
 	ph_logger_toggle(pv->state->rev);
 
 	// update meta info


### PR DESCRIPTION
* dont stop logserver on transition (we always accept logs)
* send USR1 signal on transition to logserver
* logserver rereads revision from bootloader pv_try on usr1 signal
* implement pv_bootloader_reload_pv_try in bootloader.c accordingly
* add LOG_SERVER_OUTPUT_NULL_SINK
* don't run pv_logserver_stop in pv_logserver_toggle
* don't run pv_logserver_toggle in _wait_network