### PR TITLE
fix: groups not cleaning old platform references during non-reboot transitions

### DIFF
--- a/group.c
+++ b/group.c
@@ -44,7 +44,7 @@ struct pv_group *pv_group_new(char *name)
 	return g;
 }
 
-static void pv_group_empty_platform_refs(struct pv_group *g)
+void pv_group_empty_platform_refs(struct pv_group *g)
 {
 	int num_platforms = 0;
 	struct pv_platform_ref *pr, *tmp;
@@ -115,6 +115,8 @@ static void pv_group_rm_platform(struct pv_group *g, struct pv_platform *p)
 		return;
 
 	pr = pv_group_fetch_platform_ref(g, p);
+	if (!pr)
+		return;
 
 	pv_log(DEBUG, "removing platform '%s' reference from group '%s'",
 	       p->name, g->name);

--- a/group.h
+++ b/group.h
@@ -34,6 +34,7 @@ struct pv_group {
 };
 
 struct pv_group *pv_group_new(char *name);
+void pv_group_empty_platform_refs(struct pv_group *g);
 void pv_group_free(struct pv_group *g);
 
 void pv_group_add_platform(struct pv_group *g, struct pv_platform *p);

--- a/state.c
+++ b/state.c
@@ -964,14 +964,19 @@ static void pv_state_transfer_platforms(struct pv_state *pending,
 	}
 }
 
-static void pv_state_transfer_groups(struct pv_state *pending,
-				     struct pv_state *current)
+static void pv_state_transfer_groups(struct pv_state *current)
 {
-	struct pv_platform *p, *tmp;
-	struct pv_group *g;
+	struct pv_group *g, *g_tmp;
+	struct pv_platform *p, *p_tmp;
+
+	// empty current group revision list
+	dl_list_for_each_safe(g, g_tmp, &current->groups, struct pv_group, list)
+	{
+		pv_group_empty_platform_refs(g);
+	}
 
 	// relink platform groups to current groups
-	dl_list_for_each_safe(p, tmp, &current->platforms, struct pv_platform,
+	dl_list_for_each_safe(p, p_tmp, &current->platforms, struct pv_platform,
 			      list)
 	{
 		if (!p->group)
@@ -990,7 +995,7 @@ void pv_state_transition(struct pv_state *pending, struct pv_state *current)
 
 	pv_state_remove_updated_platforms(current);
 	pv_state_transfer_platforms(pending, current);
-	pv_state_transfer_groups(pending, current);
+	pv_state_transfer_groups(current);
 
 	// copy revision to current now that we have everything we need from pending
 	current->rev = realloc(current->rev, len);


### PR DESCRIPTION
Currently, in non-reboot transitions, Pantavisor keeps the current state running for the new revision, but transfers the new/updated platforms from the pending state to the running one.This does not affect groups, as they are not changed whatsoever during non-reboot updates. We still have to re-link the platform reference list from the pending state to the current one.

Before this fix, Pantavisor was just re-linking the platforms belonging to the new revision, but the old ones belonging to platforms that were deleted or platforms that were modified were still there. This was causing Pantavisor to keep groups with lists of platform references that pointed to deleted structs etc.

With this fix, the list of references for each group are deleted during transitions, so the platforms belonging to the new revision can be cleanly re-linked to the groups.