### PR TITLE
fix: updater interval preventing other network operations

### DIFF
--- a/config.c
+++ b/config.c
@@ -436,6 +436,8 @@ static int pv_config_load_creds_from_file(char *path,
 
 	config->metadata.devmeta_interval = config_get_value_int(
 		&config_list, "metadata.devmeta.interval", 10);
+	config->metadata.usrmeta_interval = config_get_value_int(
+		&config_list, "metadata.usrmeta.interval", 5);
 
 	config_clear_items(&config_list);
 
@@ -503,6 +505,8 @@ static int pv_config_override_config_from_file(char *path,
 				  &config->libthttp.loglevel);
 	config_override_value_int(&config_list, "metadata.devmeta.interval",
 				  &config->metadata.devmeta_interval);
+	config_override_value_int(&config_list, "metadata.usrmeta.interval",
+				  &config->metadata.usrmeta_interval);
 	config_override_value_int(&config_list, "lxc.log.level",
 				  &config->lxc.log_level);
 
@@ -587,6 +591,8 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config,
 
 	write_config_tuple_int(fd, "metadata.devmeta.interval",
 			       config->metadata.devmeta_interval);
+	write_config_tuple_int(fd, "metadata.usrmeta.interval",
+			       config->metadata.usrmeta_interval);
 
 	close(fd);
 	if (pv_fs_path_rename(tmp_path, path) < 0) {
@@ -652,6 +658,8 @@ void pv_config_override_value(const char *key, const char *value)
 		pv->config.libthttp.loglevel = atoi(value);
 	else if (!strcmp(key, "metadata.devmeta.interval"))
 		pv->config.metadata.devmeta_interval = atoi(value);
+	else if (!strcmp(key, "metadata.usrmeta.interval"))
+		pv->config.metadata.usrmeta_interval = atoi(value);
 }
 
 void pv_config_free()
@@ -1080,6 +1088,11 @@ int pv_config_get_metadata_devmeta_interval()
 	return pv_get_instance()->config.metadata.devmeta_interval;
 }
 
+int pv_config_get_metadata_usrmeta_interval()
+{
+	return pv_get_instance()->config.metadata.usrmeta_interval;
+}
+
 char *pv_config_get_json()
 {
 	struct pv_json_ser js;
@@ -1236,6 +1249,9 @@ char *pv_config_get_json()
 		pv_json_ser_key(&js, "metadata.devmeta.interval");
 		pv_json_ser_number(&js,
 				   pv_config_get_metadata_devmeta_interval());
+		pv_json_ser_key(&js, "metadata.usrmeta.interval");
+		pv_json_ser_number(&js,
+				   pv_config_get_metadata_usrmeta_interval());
 
 		pv_json_ser_object_pop(&js);
 	}

--- a/config.h
+++ b/config.h
@@ -178,6 +178,7 @@ struct pantavisor_secureboot {
 
 struct pantavisor_metadata {
 	int devmeta_interval;
+	int usrmeta_interval;
 };
 
 struct pantavisor_config {
@@ -309,6 +310,7 @@ char *pv_config_get_secureboot_certdir(void);
 bool pv_config_get_secureboot_checksum(void);
 
 int pv_config_get_metadata_devmeta_interval(void);
+int pv_config_get_metadata_usrmeta_interval(void);
 
 char *pv_config_get_json(void);
 

--- a/metadata.c
+++ b/metadata.c
@@ -725,9 +725,6 @@ int pv_metadata_init_devmeta(struct pantavisor *pv)
 	}
 	pv_buffer_drop(buffer);
 	pv->metadata->devmeta_uploaded = false;
-	timer_start(&pv->metadata->devmeta_tm,
-		    pv_config_get_metadata_devmeta_interval(), 0,
-		    RELATIV_TIMER);
 
 	return 0;
 }
@@ -740,14 +737,6 @@ int pv_metadata_upload_devmeta(struct pantavisor *pv)
 	struct dl_list *head = NULL;
 	int json_avail = 0, ret = 0;
 	struct buffer *buffer = NULL;
-
-	struct timer_state st = timer_current_state(&pv->metadata->devmeta_tm);
-	if (!st.fin)
-		return 0;
-
-	timer_start(&pv->metadata->devmeta_tm,
-		    pv_config_get_metadata_devmeta_interval(), 0,
-		    RELATIV_TIMER);
 
 	/*
 	 * we can use one of the large buffer. Since

--- a/metadata.h
+++ b/metadata.h
@@ -49,7 +49,6 @@ struct pv_metadata {
 	struct dl_list usermeta; // pv_meta
 	struct dl_list devmeta; // pv_meta
 	bool devmeta_uploaded;
-	struct timer devmeta_tm;
 };
 
 int pv_metadata_factory_meta(struct pantavisor *pv);


### PR DESCRIPTION
Right now, all network operations updater.interval are performed at least in less than updater.interval seconds. This mainly includes:
* check if there is no ph connection and rollback if it times out
* check if connection is not stable during testing and rolback
* turn on/off ph logger depending on config
* send dev meta to ph
* receive user meta from ph
* check ph for new updates

These operations are not performed if updater.timer is timed out. In the case of the rollbacks, they won't be performed if the rollback or commit timer are less than the updater interval.

With this PR, all network operations are evaluated every second. Furthermore, sending dev meta, receiving usr meta and checking ph for updates depend on its own timers.