### PR TITLE
add default group to group-less platforms when groups.json exist

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -832,6 +832,9 @@ static int do_action_for_runlevel(struct json_key_action *jka, char *value)
 	if (!(*bundle->platform) || !value)
 		return -1;
 
+	pv_log(WARN, "using deprecated runlevel for platform '%s' as group",
+	       (*bundle->platform)->name);
+
 	// runlevel is still valid in the state json to keep backwards compatibility, but internally it is substituted by groups
 	if (!strcmp(value, "data") || !strcmp(value, "root") ||
 	    !strcmp(value, "app") || !strcmp(value, "platform")) {
@@ -1395,7 +1398,7 @@ static struct pv_state *system1_parse_groups(struct pv_state *this,
 			goto out;
 		}
 
-		this->default_groups = true;
+		this->using_runlevels = true;
 
 		free(value);
 		value = NULL;

--- a/state.h
+++ b/state.h
@@ -55,7 +55,7 @@ struct pv_state {
 	struct dl_list objects; //pv_object
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
-	bool default_groups;
+	bool using_runlevels;
 	char *json;
 	int tryonce;
 	bool local;


### PR DESCRIPTION
The idea behind this patch is to set all group-less platforms to a default one when groups.json is present in the revision. This default group will be the last configured group in groups.json