### PR TITLE
close logserver fds before killing its pid

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -127,6 +127,9 @@ static int pv_ctrl_socket_open()
 	pv_paths_pv_file(addr.sun_path, sizeof(addr.sun_path) - 1,
 			 PVCTRL_FNAME);
 
+	// sometimes, the socket file still exists after reboot
+	unlink(addr.sun_path);
+
 	if (bind(fd, (const struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		pv_log(ERROR, "ctrl socket with fd %d open error: %s", fd,
 		       strerror(errno));

--- a/logserver.h
+++ b/logserver.h
@@ -40,7 +40,6 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 
 void pv_logserver_reload(void);
 void pv_logserver_stop(void);
-void pv_logserver_close(void);
 int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src);
 int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -876,18 +876,19 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 	if (pv_config_get_system_init_mode() != IM_APPENGINE)
 		reboot(shutdown_type_reboot_cmd(t));
 
+	// close pvctrl
+	pv_ctrl_socket_close(pv->ctrl_fd);
+
+	// stop logs now
+	pv_logserver_stop();
+	pv_log_umount();
+
 	// unmount everything
 	pv_storage_umount();
 	pv_mount_umount();
 	pv_init_umount();
 
-	// stop logs now
-	pv_logserver_stop();
-
-	pv_ctrl_socket_close(pv->ctrl_fd);
-	pv_logserver_close();
-	pv_log_umount();
-
+	// free up memory
 	pv_bootloader_remove();
 	pv_remove(pv);
 

--- a/ph_logger.c
+++ b/ph_logger.c
@@ -774,12 +774,14 @@ void ph_logger_toggle(char *rev)
 
 void ph_logger_stop_lenient()
 {
-	pv_log(DEBUG, "stopping ph logger services...");
-
-	if (ph_logger.push_service > 0)
+	if (ph_logger.push_service > 0) {
+		pv_log(DEBUG, "stopping ph logger push service...");
 		pv_system_kill_lenient(ph_logger.push_service);
-	if (ph_logger.range_service > 0)
+	}
+	if (ph_logger.range_service > 0) {
+		pv_log(DEBUG, "stopping ph logger range service...");
 		pv_system_kill_lenient(ph_logger.range_service);
+	}
 }
 
 void ph_logger_stop_force()


### PR DESCRIPTION
A bunch of small changes I did while testing appengine shuts down before WAIT state is reached. List of changes:
* ctrl: unlink before binding to remove existing pv-ctrl sockets
* logserver: merge close and stop functions
* logserver: add fd closing before stopping the PID, which was causing a freeze
* pantavisor: stop logserver after we stop ph_logger, platforms and pvctrl, but before unmount and free up memory
* ph_logger: improve logs when stopping services