### PR TITLE
Implement stdout as a logserver's sink

### DIFF
--- a/config.c
+++ b/config.c
@@ -141,6 +141,8 @@ static int config_parse_log_server_outputs(char *value)
 			server_outputs |= LOG_SERVER_OUTPUT_FILE_TREE;
 		else if (!strcmp(token, "nullsink"))
 			server_outputs |= LOG_SERVER_OUTPUT_NULL_SINK;
+		else if (!strcmp(token, "stdout"))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT;
 	}
 
 	return server_outputs;
@@ -1052,6 +1054,12 @@ bool pv_config_get_log_server_output_single_file()
 {
 	return pv_get_instance()->config.log.server.outputs &
 	       LOG_SERVER_OUTPUT_SINGLE_FILE;
+}
+
+bool pv_config_get_log_server_output_stdout()
+{
+	return pv_get_instance()->config.log.server.outputs &
+	       LOG_SERVER_OUTPUT_STDOUT;
 }
 
 int pv_config_get_libthttp_loglevel()

--- a/config.h
+++ b/config.h
@@ -132,6 +132,7 @@ typedef enum {
 	LOG_SERVER_OUTPUT_NULL_SINK = 1 << 0,
 	LOG_SERVER_OUTPUT_SINGLE_FILE = 1 << 1,
 	LOG_SERVER_OUTPUT_FILE_TREE = 1 << 2,
+	LOG_SERVER_OUTPUT_STDOUT = 1 << 3,
 	LOG_SERVER_OUTPUT_SIZE
 } log_server_output_mask_t;
 
@@ -301,6 +302,7 @@ int pv_config_get_libthttp_loglevel(void);
 int pv_config_get_log_server_outputs(void);
 bool pv_config_get_log_server_output_file_tree(void);
 bool pv_config_get_log_server_output_single_file(void);
+bool pv_config_get_log_server_output_stdout(void);
 
 int pv_config_get_lxc_loglevel(void);
 bool pv_config_get_control_remote(void);

--- a/log.h
+++ b/log.h
@@ -54,8 +54,6 @@ enum log_level {
 
 void __log(char *module, int level, const char *fmt, ...);
 
-void __log_to_console(char *module, int level, const char *fmt, ...);
-
 /*
  * Don't free the return value!
  */


### PR DESCRIPTION
- Removes log_to_consoles from log.c
- Add stdout output in config
- Make `log.stdout` working with Logserver 
