### PR TITLE
improve scripts/volmount/crypt/crypt to be more robust against corruption

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -62,16 +62,13 @@ do_crypt_init()
 		cat /data/caam/$keyname | /bin/keyctl padd logon logkey: @u
 		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to load key" && exit 1
 	elif [ $dm_type == "dcp" ]; then
-		key_value=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32`
-		keyfile=`/bin/mktemp`
-		echo $key_value > $keyfile
-		/lib/pv/volmount/crypt/dcp-tool enc $keyfile $dir/$keyname.bb 64
-		[ $? -ne 0 ] && echo "ERROR: DCP: Unable to create black blob" && exit 1
-		rm -f $keyfile
+		dd if=/dev/random bs=32 count=1 | /lib/pv/volmount/crypt/x--pv-dcp-tool \
+			encrypt $dir/$keyname.new
+		sync
+		mv $dir/$keyname.new $dir/$keyname
+		[ $? -ne 0 ] && echo "ERROR: DCP: Unable to create grey blob" && exit 1
 	elif [ $dm_type == "versatile" ]; then
-		key_value=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32`
-		echo $key_value >$dir/$keyname.txt
-		echo $key_value >$dir/$keyname.bb
+		dd if=/dev/random of=$dir/keyname.txt bs=32 count=1
 	else
 		echo "Unknown device mapper target"
 		exit 1
@@ -95,7 +92,10 @@ do_crypt_init()
 	if [ $dm_type == "caam" ]; then
 		/usr/sbin/dmsetup -v create $device_name --table "0 $(/sbin/blockdev --getsz $CAAM_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $CAAM_LOOP 0 1 sector_size:512"
 	elif [ $dm_type == "dcp" ]; then
-		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$dir/$keyname.bb $dir/$img_file $device_name
+		keyfile=`mktemp`
+		/lib/pv/volmount/crypt/x--pv-dcp-tool decrypt $dir/$keyname > $keyfile
+		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$keyfile $dir/$img_file $device_name
+		rm -f $keyfile
 	elif [ $dm_type == "versatile" ]; then
 		/usr/sbin/cryptsetup open -s 256 -c "aes-cbc-essiv:sha256" --type plain --key-file=$dir/$keyname.txt $dir/$img_file $device_name
 	else
@@ -134,7 +134,7 @@ do_dm_sanity()
 		[ ! -f /usr/sbin/dmsetup ] && exit 111
 		[ ! -f /bin/keyctl ] && exit 111
 	elif [ $dm_type == "dcp" ]; then
-		[ ! -f /lib/pv/volmount/crypt/dcp-tool ] && exit 111
+		[ ! -f /lib/pv/volmount/crypt/x--pv-dcp-tool ] && exit 111
 		[ ! -f /usr/sbin/cryptsetup ] && exit 111
 	elif [ $dm_type == "versatile" ]; then
 		[ ! -f /usr/sbin/cryptsetup ] && exit 111
@@ -163,7 +163,7 @@ do_mount_disk()
 	dir=`dirname $2`
 
 	keyname=`echo $base | awk '{split($0,a,","); print a[3]}'`
-	[ ! -f $dir/$keyname.init_done ] && do_crypt_init $2
+	[ ! -f $dir/$keyname.init_done ] && [ ! -f $dir/$keyname ] && do_crypt_init $2
 
 	cd $dir
 	if [ $dm_type == "caam" ]; then
@@ -187,7 +187,10 @@ do_mount_disk()
 	if [ $dm_type == "caam" ]; then
 		/usr/sbin/dmsetup create $device_name --table "0 $(/sbin/blockdev --getsz $CAAM_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $CAAM_LOOP 0 1 sector_size:512"
 	elif [ $dm_type == "dcp" ]; then
-		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$dir/$keyname.bb $dir/$img_file $device_name
+		keyfile=`mktemp`
+		/lib/pv/volmount/crypt/x--pv-dcp-tool decrypt $dir/$keyname > $keyfile
+		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$keyfile $dir/$img_file $device_name
+		rm -f $keyfile
 	elif [ $dm_type == "versatile" ]; then
 		/usr/sbin/cryptsetup open -s 256 -c "aes-cbc-essiv:sha256" --type plain --key-file=$dir/$keyname.txt $dir/$img_file $device_name
 	else

--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -30,14 +30,6 @@ mntpath=$4
 
 CAAM_KEYGEN=/usr/bin/caam-keygen
 
-do_find_free_loop()
-{
-	FREE_LOOP=`/sbin/losetup -f`
-	if [ -n "$FREE_LOOP" ]; then
-		return 0;
-	fi
-}
-
 do_crypt_init()
 {
 	base=`basename $1`
@@ -66,17 +58,23 @@ do_crypt_init()
 		exit 1
 	fi
 
+	# sync after keyname files got created
+	sync
+
 	img_file=`echo $base | awk '{split($0,a,","); print a[1]}'`
 	img_size=`echo $base | awk '{split($0,a,","); print a[2]}'`
 	/bin/dd if=/dev/zero of=$dir/$img_file bs=1M count=$img_size
-	do_find_free_loop
 
-	/sbin/losetup -f $dir/$img_file
-	[ $? -ne 0 ] && echo "ERROR: Unable to loop setup" && exit 1
+	if [ $dm_type == "caam" ]; then
+		if ! CAAM_LOOP=`/sbin/losetup -f $dir/$img_file`; then
+			echo "ERROR: Unable to loop setup"
+			exit 1
+		fi
+	fi
 
 	device_name=`echo $img_file | awk '{split($0,a,"."); print a[1]}'`
 	if [ $dm_type == "caam" ]; then
-		/usr/sbin/dmsetup -v create $device_name --table "0 $(/sbin/blockdev --getsz $FREE_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $FREE_LOOP 0 1 sector_size:512"
+		/usr/sbin/dmsetup -v create $device_name --table "0 $(/sbin/blockdev --getsz $CAAM_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $CAAM_LOOP 0 1 sector_size:512"
 	elif [ $dm_type == "dcp" ]; then
 		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$dir/$keyname.bb $dir/$img_file $device_name
 	elif [ $dm_type == "versatile" ]; then
@@ -90,11 +88,13 @@ do_crypt_init()
 	/usr/sbin/mkfs.ext4 /dev/mapper/$device_name
 	[ $? -ne 0 ] && echo "ERROR: Unable to format to ext4" && exit 1
 
+	sync
 	if [ $dm_type == "caam" ]; then
 		/usr/sbin/dmsetup remove $device_name
 		/bin/keyctl clear @u
 		/bin/keyctl purge @u
 		rm -rf /data
+		/sbin/losetup -d $CAAM_LOOP
 	elif [ $dm_type == "dcp" ]; then
 		/usr/sbin/cryptsetup close $device_name
 	elif [ $dm_type == "versatile" ]; then
@@ -104,7 +104,8 @@ do_crypt_init()
 		exit 1
 	fi
 
-	/sbin/losetup -d $FREE_LOOP
+	sync
+	touch $dir/$keyname.init_done
 }
 
 do_dm_sanity()
@@ -134,11 +135,16 @@ do_mount_disk()
 {
 	do_dm_sanity
 
+	dm_type=$1
+	path=$2
+	mntpath=$3
+	specialrun=$4
+
 	base=`basename $2`
 	dir=`dirname $2`
 
 	keyname=`echo $base | awk '{split($0,a,","); print a[3]}'`
-	[ ! -f $dir/$keyname.bb ] && do_crypt_init $2
+	[ ! -f $dir/$keyname.init_done ] && do_crypt_init $2
 
 	cd $dir
 	if [ $dm_type == "caam" ]; then
@@ -152,15 +158,15 @@ do_mount_disk()
 	fi
 
 	img_file=`echo $base | awk '{split($0,a,","); print a[1]}'`
-	do_find_free_loop
-	if ! /sbin/losetup -f $dir/$img_file; then
+	cp -f $dir/$img_file $dir/$img_file.prebak
+	if ! CAAM_LOOP=`/sbin/losetup -f $dir/$img_file`; then
 		echo "ERROR: could not loosetup"
 		return 1;
 	fi
 
 	device_name=`echo $img_file | awk '{split($0,a,"."); print a[1]}'`
 	if [ $dm_type == "caam" ]; then
-		/usr/sbin/dmsetup create $device_name --table "0 $(/sbin/blockdev --getsz $FREE_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $FREE_LOOP 0 1 sector_size:512"
+		/usr/sbin/dmsetup create $device_name --table "0 $(/sbin/blockdev --getsz $CAAM_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $CAAM_LOOP 0 1 sector_size:512"
 	elif [ $dm_type == "dcp" ]; then
 		/usr/sbin/cryptsetup open -s 256 -c "capi:cbc(aes)-essiv:sha256" --type plain --key-file=$dir/$keyname.bb $dir/$img_file $device_name
 	elif [ $dm_type == "versatile" ]; then
@@ -169,18 +175,52 @@ do_mount_disk()
 		echo "Unknown device mapper target"
 		exit 1
 	fi
-	[ $? -ne 0 ] && echo "ERROR: $dm_type: Unable to create/open crypt device" && exit 1
+	if [ $? -ne 0 ]; then
+		echo "ERROR: $dm_type: Unable to create/open crypt device"
+		exit 1
+	fi
 
 	if [ ! -b /dev/mapper/$device_name ]; then
-		echo "ERROR: could not crypt mapper"
-		return 2;
+		echo "ERROR: could not find the matching crypt mapper device /dev/mapper/$device_name"
+		return 2
 	fi
 
 	mkdir -p $3
-	if ! mount /dev/mapper/$device_name $3; then
-		echo "ERROR: could not setup dm-crypt volume"
-		return 3;
+	if mount /dev/mapper/$device_name $3; then
+		# only backup if a clean run success
+		[ -z "$specialrun" ] && cp -f $dir/$img_file.prebak $dir/$img_file.goodbak
+		sync
+		return 0
 	fi
+
+	echo "ERROR: could not setup dm-crypt volume"
+	if [ "$specialrun" == "fsck" ] && [ -f $dir/$img_file.goodbak ]; then
+		echo "Specialrun $specialrun did not succeed ... trying from goodbackup"
+		cp -f $dir/$img_file.goodbak $dir/$img_file
+		/usr/sbin/cryptsetup close $device_name || true
+		if ! do_mount_disk "$dm_type" "$path" "$mntpath" bak; then
+			return $?;
+		fi
+		echo "do_mount_disk from backup suceeded..."
+		return 0
+	elif [ "$specialrun" == "fsck" ]; then
+		# later here we could remove .init_done file to trigger full reinit on next powercycle
+		echo "do_mount_disk failed, no backup available, giving up!"
+		return 5
+	elif [ "$specialrun" == "bak" ]; then
+		# later here we could remove .init_done file to trigger full reinit on next powercycle
+		echo "do_mount_disk specialrun 'bak' failed. giving up ..."
+		return 6
+	fi
+
+	echo "Trying fsck ...."
+	/usr/sbin/fsck.ext4 -y /dev/mapper/$device_name || true
+	/usr/sbin/cryptsetup close $device_name || true
+	sync
+	if ! do_mount_disk "$dm_type" "$path" "$mntpath" fsck; then
+		return $?
+	fi
+	return 0
 }
 
 do_umount_disk()

--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -216,7 +216,7 @@ do_mount_disk()
 	mkdir -p $3
 	if mount /dev/mapper/$device_name $3; then
 		# only backup if a clean run success
-		[ -z "$specialrun" ] && cp -f $dir/$img_file.prebak $dir/$img_file.goodbak
+		[ -z "$specialrun" ] && [ ! -f $dir/$img_file.goodbak ] && cp -f $dir/$img_file.prebak $dir/$img_file.goodbak
 		sync
 		return 0
 	fi

--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -30,6 +30,24 @@ mntpath=$4
 
 CAAM_KEYGEN=/usr/bin/caam-keygen
 
+MKFS_OPTS_EXT4=${MKFS_OPTS_EXT4:-"-O ^has_journal"}
+
+# do the same as losetup -f but also return the path of loop device on stdout
+# if successful.
+atomic_losetup()
+{
+	_imgfile=$1
+	if ! /sbin/losetup -f $dir/$img_file; then
+		echo "ERROR: unable to setup loop device for $_imgfile"
+		return 122
+	fi
+	if ! _l=`/sbin/losetup -a | grep ${imgfile}$ | tail -n 1`; then
+		echo "ERROR: unable to setup loop device for $_imgfile"
+		return 122
+	fi
+	echo $_l | sed -e 's/: [0-9][0-9]* .*//'
+}
+
 do_crypt_init()
 {
 	base=`basename $1`
@@ -45,10 +63,11 @@ do_crypt_init()
 		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to load key" && exit 1
 	elif [ $dm_type == "dcp" ]; then
 		key_value=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32`
-		echo $key_value >$dir/$keyname.txt
-		/lib/pv/volmount/crypt/dcp-tool enc $dir/$keyname.txt $dir/$keyname.bb 64
+		keyfile=`/bin/mktemp`
+		echo $key_value > $keyfile
+		/lib/pv/volmount/crypt/dcp-tool enc $keyfile $dir/$keyname.bb 64
 		[ $? -ne 0 ] && echo "ERROR: DCP: Unable to create black blob" && exit 1
-		rm -rf $dir/$keyname.txt
+		rm -f $keyfile
 	elif [ $dm_type == "versatile" ]; then
 		key_value=`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32`
 		echo $key_value >$dir/$keyname.txt
@@ -66,7 +85,7 @@ do_crypt_init()
 	/bin/dd if=/dev/zero of=$dir/$img_file bs=1M count=$img_size
 
 	if [ $dm_type == "caam" ]; then
-		if ! CAAM_LOOP=`/sbin/losetup -f $dir/$img_file`; then
+		if ! CAAM_LOOP=`atomic_losetup $dir/$img_file`; then
 			echo "ERROR: Unable to loop setup"
 			exit 1
 		fi
@@ -85,7 +104,7 @@ do_crypt_init()
 	fi
 	[ $? -ne 0 ] && echo "ERROR: $dm_type: Unable to create/open crypt device" && exit 1
 
-	/usr/sbin/mkfs.ext4 /dev/mapper/$device_name
+	/usr/sbin/mkfs.ext4 $MKFS_OPTS_EXT4 /dev/mapper/$device_name
 	[ $? -ne 0 ] && echo "ERROR: Unable to format to ext4" && exit 1
 
 	sync
@@ -111,22 +130,22 @@ do_crypt_init()
 do_dm_sanity()
 {
 	if [ $dm_type == "caam" ]; then
-		[ ! -f $CAAM_KEYGEN ] && exit 1
-		[ ! -f /usr/sbin/dmsetup ] && exit 1
-		[ ! -f /bin/keyctl ] && exit 1
+		[ ! -f $CAAM_KEYGEN ] && exit 111
+		[ ! -f /usr/sbin/dmsetup ] && exit 111
+		[ ! -f /bin/keyctl ] && exit 111
 	elif [ $dm_type == "dcp" ]; then
-		[ ! -f /lib/pv/volmount/crypt/dcp-tool ] && exit 1
-		[ ! -f /usr/sbin/cryptsetup ] && exit 1
+		[ ! -f /lib/pv/volmount/crypt/dcp-tool ] && exit 111
+		[ ! -f /usr/sbin/cryptsetup ] && exit 111
 	elif [ $dm_type == "versatile" ]; then
-		[ ! -f /usr/sbin/cryptsetup ] && exit 1
+		[ ! -f /usr/sbin/cryptsetup ] && exit 111
 	else
 		echo "Unknown device mapper target"
-		exit 1
+		exit 111
 	fi
 
-	[ ! -f /sbin/losetup ] && exit 1
-	[ ! -f /bin/dd ] && exit 1
-	[ ! -f /usr/sbin/mkfs.ext4 ] && exit 1
+	[ ! -f /sbin/losetup ] && exit 111
+	[ ! -f /bin/dd ] && exit 111
+	[ ! -f /usr/sbin/mkfs.ext4 ] && exit 111
 
 	export LD_LIBRARY_PATH=/x86_64-linux-gnu
 }
@@ -151,15 +170,15 @@ do_mount_disk()
 		mkdir -p /data/caam
 		cp $keyname* /data/caam
 		$CAAM_KEYGEN import $keyname.bb $keyname.import
-		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to import black blob" && exit 1
+		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to import black blob" && exit 2
 
 		cat /data/caam/$keyname.import | /bin/keyctl padd logon logkey: @u
-		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to load key" && exit 1
+		[ $? -ne 0 ] && echo "ERROR: CAAM: Unable to load key" && exit 2
 	fi
 
 	img_file=`echo $base | awk '{split($0,a,","); print a[1]}'`
 	cp -f $dir/$img_file $dir/$img_file.prebak
-	if ! CAAM_LOOP=`/sbin/losetup -f $dir/$img_file`; then
+	if ! CAAM_LOOP=`atomic_losetup $dir/$img_file`; then
 		echo "ERROR: could not loosetup"
 		return 1;
 	fi
@@ -173,13 +192,19 @@ do_mount_disk()
 		/usr/sbin/cryptsetup open -s 256 -c "aes-cbc-essiv:sha256" --type plain --key-file=$dir/$keyname.txt $dir/$img_file $device_name
 	else
 		echo "Unknown device mapper target"
-		exit 1
+		exit 2
 	fi
 	if [ $? -ne 0 ]; then
 		echo "ERROR: $dm_type: Unable to create/open crypt device"
-		exit 1
+		exit 3
 	fi
 
+	for i in 1 2 3; do
+		if [ -b /dev/mapper/$device_name ]; then
+			break
+		fi
+		sleep 1
+	done
 	if [ ! -b /dev/mapper/$device_name ]; then
 		echo "ERROR: could not find the matching crypt mapper device /dev/mapper/$device_name"
 		return 2
@@ -241,7 +266,7 @@ do_umount_disk()
 		/usr/sbin/cryptsetup close $device_name
 	else
 		echo "Unknown device mapper target"
-		exit 1
+		exit 4
 	fi
 	loop_dev=`/sbin/losetup -a | grep $img_file | awk '{split($0,a,":"); print a[1]}'`
 	/sbin/losetup -d $loop_dev
@@ -256,6 +281,6 @@ case $op in
 		;;
 	*)
 		echo "WRONG command line"
-		exit 1
+		exit 5
 		;;
 esac

--- a/volumes.c
+++ b/volumes.c
@@ -193,7 +193,7 @@ struct pv_disk *pv_disk_add(struct pv_state *s)
 
 static int pv_volume_mount_handler(struct pv_volume *v, char *action)
 {
-#define DM_CRYPT_BUFSIZE (2 * 1024)
+#define DM_CRYPT_BUFSIZE (128 * 1024)
 	struct pv_disk *d = v->disk;
 	char path[PATH_MAX];
 	char out_log[DM_CRYPT_BUFSIZE] = { 0 };
@@ -237,7 +237,7 @@ static int pv_volume_mount_handler(struct pv_volume *v, char *action)
 
 	ret = tsh_run_output(command, 5, out_log, sizeof(out_log), err_log,
 			     sizeof(err_log));
-	if (ret < 0)
+	if (ret != 0)
 		pv_log(ERROR, "command: %s error: %s", command, err_log);
 
 	pv_log(DEBUG, "command: %s output: %s", command, out_log);
@@ -268,7 +268,7 @@ int pv_volume_mount(struct pv_volume *v)
 
 	if (v->disk && !v->disk->def) {
 		ret = pv_volume_mount_handler(v, "mount");
-		if (ret < 0)
+		if (ret != 0)
 			return ret;
 
 		disk_name = d->name;


### PR DESCRIPTION
1. we will move to explicit .init_done marker file that we only place if whole do_crypt_init function has succeeded with changes synched to disk
2. we only do losetup logic for dm_type caam
3. we create a .goodbak copy of the image file every time we successfully finish with do_mount_disk; we are extra careful and create a .prebak copy of the image file before the mounting happens.
4. we make do_mount_disk try the following before giving up: - mount crypt disk as usual - if fails run an fsk.ext4 -y on that /dev/mapper/ device - if that fails we put back the .goodbak file (if such exist) at code we do this through recursive invocation of the do_mount_disk function with a 4th parameter 'specialrun' mode