### PR TITLE
Add initial qos story for system and containers

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -10,7 +10,7 @@ LOCAL_MODULE := pv_lxc
 LOCAL_CFLAGS := -g -Wno-format-nonliteral -Wno-format-contains-nul -fPIC
 LOCAL_LDFLAGS := -Wl,--no-as-needed -lutil -Wl,--as-needed
 
-LOCAL_SRC_FILES := plugins/pv_lxc.c utils/fs.c utils/tsh.c
+LOCAL_SRC_FILES := plugins/pv_lxc.c utils/fs.c utils/tsh.c utils/system.c
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/config.c
+++ b/config.c
@@ -445,6 +445,11 @@ static int pv_config_load_file(char *path, struct pantavisor_config *config)
 	config_iterate_items_prefix(&config_list, config_sysctl_apply,
 				    "sysctl.", NULL);
 
+	config->vm.oom_qos_besteffort = config_get_value_int(
+		&config_list, "vm.oom_qos_besteffort", 1000);
+	config->vm.oom_qos_guaranteed = config_get_value_int(
+		&config_list, "vm.oom_qos_guaranteed", -997);
+
 	config_clear_items(&config_list);
 
 	return 0;
@@ -724,6 +729,10 @@ void pv_config_override_value(const char *key, const char *value)
 		pv->config.metadata.devmeta_interval = atoi(value);
 	else if (!strcmp(key, "metadata.usrmeta.interval"))
 		pv->config.metadata.usrmeta_interval = atoi(value);
+	else if (!strcmp(key, "vm.oom_qos_besteffort"))
+		pv->config.vm.oom_qos_besteffort = atoi(value);
+	else if (!strcmp(key, "vm.oom_qos_guaranteed"))
+		pv->config.vm.oom_qos_guaranteed = atoi(value);
 	else if (!strcmp(key, "debug.ssh"))
 		pv->config.debug.ssh = atoi(value);
 }
@@ -1201,6 +1210,16 @@ int pv_config_get_metadata_devmeta_interval()
 int pv_config_get_metadata_usrmeta_interval()
 {
 	return pv_get_instance()->config.metadata.usrmeta_interval;
+}
+
+int pv_config_get_vm_oom_qos_besteffort()
+{
+	return pv_get_instance()->config.vm.oom_qos_besteffort;
+}
+
+int pv_config_get_vm_oom_qos_guaranteed()
+{
+	return pv_get_instance()->config.vm.oom_qos_guaranteed;
 }
 
 char *pv_config_get_json()

--- a/config.h
+++ b/config.h
@@ -186,6 +186,11 @@ struct pantavisor_metadata {
 	int usrmeta_interval;
 };
 
+struct pantavisor_vm {
+	int oom_qos_besteffort;
+	int oom_qos_guaranteed;
+};
+
 struct pantavisor_config {
 	char *policy;
 	struct pantavisor_system sys;
@@ -195,6 +200,7 @@ struct pantavisor_config {
 	struct pantavisor_creds creds;
 	struct pantavisor_factory factory;
 	struct pantavisor_storage storage;
+	struct pantavisor_vm vm;
 	struct pantavisor_disk disk;
 	struct pantavisor_updater updater;
 	struct pantavisor_watchdog wdt;
@@ -325,6 +331,9 @@ bool pv_config_get_secureboot_checksum(void);
 
 int pv_config_get_metadata_devmeta_interval(void);
 int pv_config_get_metadata_usrmeta_interval(void);
+
+int pv_config_get_vm_oom_qos_besteffort(void);
+int pv_config_get_vm_oom_qos_guaranteed(void);
 
 char *pv_config_get_json(void);
 void pv_config_print(void);

--- a/init.c
+++ b/init.c
@@ -466,6 +466,21 @@ int main(int argc, char *argv[])
 
 	// create pv thread
 	pv_pid = fork();
+	if (pv_pid > 0 && getuid() == 0) {
+		if (pv_system_oom_adjust(
+			    pv_config_get_vm_oom_qos_guaranteed())) {
+			printf("ERROR: oom adjust failed: '%s'\n",
+			       strerror(errno));
+			return -1;
+		}
+	} else if (!pv_pid && getuid() == 0) {
+		if (pv_system_oom_adjust(
+			    pv_config_get_vm_oom_qos_guaranteed())) {
+			printf("ERROR: oom adjust failed: '%s'\n",
+			       strerror(errno));
+			return -1;
+		}
+	}
 	if (pv_pid > 0)
 		goto loop;
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -979,8 +979,10 @@ int pv_start()
 	if (fd < 0)
 		printf("open failed for /proc/sys/kernel/core_pattern: %s",
 		       strerror(errno));
-	else
+	else {
 		write(fd, path, strlen(path));
+		close(fd);
+	}
 
 	pv_state_t state = PV_STATE_INIT;
 

--- a/platforms.h
+++ b/platforms.h
@@ -63,6 +63,14 @@ typedef enum {
 	RESTART_CONTAINER
 } restart_policy_t;
 
+typedef enum {
+	QOS_NONE,
+	QOS_GUARANTEED,
+	QOS_BESTEFFORT,
+	QOS_BURSTABLE,
+	QOS_UNKNOWN
+} qos_policy_t;
+
 struct pv_platform_driver {
 	plat_driver_t type;
 	bool loaded;
@@ -96,6 +104,8 @@ struct pv_platform {
 	struct pv_group *group;
 	struct pv_state *state;
 	int roles;
+	qos_policy_t qos_policy;
+	char *qos_policy_oom_score_adj;
 	restart_policy_t restart_policy;
 	bool updated;
 	struct timer timer_status_goal;
@@ -142,6 +152,8 @@ bool pv_platform_is_updated(struct pv_platform *p);
 
 void pv_platform_set_status_goal(struct pv_platform *p, plat_status_t goal);
 plat_goal_state_t pv_platform_check_goal(struct pv_platform *p);
+
+void pv_platform_set_qos_policy(struct pv_platform *p, qos_policy_t policy);
 
 void pv_platform_set_restart_policy(struct pv_platform *p,
 				    restart_policy_t policy);

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -292,6 +292,13 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 			 PLATFORM_DEVICE_META_PATH + 1);
 		c->set_config_item(c, "lxc.mount.entry", entry);
 	}
+
+	// from https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/
+	if (p->qos_policy_oom_score_adj) {
+		c->set_config_item(c, "lxc.proc.oom_score_adj",
+				   p->qos_policy_oom_score_adj);
+	}
+
 	if (stat("/lib/firmware", &st) == 0)
 		c->set_config_item(c, "lxc.mount.entry",
 				   "/lib/firmware"
@@ -485,6 +492,7 @@ void *pv_start_container(struct pv_platform *p, const char *rev,
 
 	else if (child_pid) { /*Parent*/
 		pid_t container_pid = -1;
+
 		/*Parent would read*/
 		close(pipefd[1]);
 		while (read(pipefd[0], &container_pid, sizeof(container_pid)) <

--- a/utils/system.c
+++ b/utils/system.c
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -104,6 +105,29 @@ int get_cpu_model(char *buf, int buflen)
 	}
 out:
 	return ret;
+}
+
+int pv_system_oom_adjust(int score)
+{
+	return pv_system_oom_adjust_pid(getpid(), score);
+}
+
+int pv_system_oom_adjust_pid(pid_t pid, int score)
+{
+	char buf[128];
+	sprintf(buf, "/proc/%d/oom_score_adj", pid);
+	int fd = open(buf, O_WRONLY | O_SYNC);
+	if (fd < 0) {
+		printf("open failed for %s: %s", buf, strerror(errno));
+		return -2;
+	}
+
+	sprintf(buf, "%d", score);
+	int ret = write(fd, buf, strlen(buf) + 1);
+	close(fd);
+	if (ret > 0)
+		return 0;
+	return -3;
 }
 
 cgroup_version_t pv_system_get_cgroup_version(void)

--- a/utils/system.h
+++ b/utils/system.h
@@ -61,7 +61,8 @@ int get_dt_model(char *buf, int buflen);
 int get_cpu_model(char *buf, int buflen);
 cgroup_version_t pv_system_get_cgroup_version(void);
 const char *pv_system_cgroupv_string(cgroup_version_t cgroupv);
-
+int pv_system_oom_adjust(int score);
+int pv_system_oom_adjust_pid(pid_t pid, int score);
 void pv_system_kill_lenient(pid_t pid);
 void pv_system_kill_force(pid_t pid);
 

--- a/utils/tsh.c
+++ b/utils/tsh.c
@@ -36,6 +36,7 @@
 
 #include "tsh.h"
 #include "timer.h"
+#include "system.h"
 
 #define TSH_MAX_LENGTH 32
 #define TSH_DELIM " \t\r\n\a"


### PR DESCRIPTION
Add initial oom score adjustments to ensure that on pantavisor system pantavisor itself and the log facilities get killed last by oom handler