### PR TITLE
Add error handling to avoid problems with closed o bad fds

### DIFF
--- a/utils/fs.c
+++ b/utils/fs.c
@@ -349,7 +349,7 @@ ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size)
 		if (cur_read < 0) {
 			if (errno == EINTR)
 				continue;
-			break;
+			return total_read == 0 ? cur_read : total_read;
 		}
 		if (cur_read == 0)
 			break;


### PR DESCRIPTION
* Add function to remove and unsubscribe fds (logserver_remove_fd)
* Add error handling to catch bad fds on epoll
* Add error handling to remove bad on read functions
* Replace calls to close fds with logserver_remove_fd
* Fix unsubscription mechanism adding a new header to subscribe or unsubscribe