### PR TITLE
sync after every open with write permissions; use utils/fs remove

### DIFF
--- a/grub.c
+++ b/grub.c
@@ -31,7 +31,9 @@
 
 #include "paths.h"
 #include "bootloader.h"
+
 #include "utils/str.h"
+#include "utils/fs.h"
 
 #define MODULE_NAME "grub"
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
@@ -78,6 +80,7 @@ static int grub_init()
 
 	pv_log(INFO, "initialized grub environment block");
 	close(fd);
+	pv_fs_path_sync(grub_env);
 
 	return 0;
 }
@@ -179,6 +182,7 @@ static int grub_unset_env_key(char *key)
 	lseek(fd, 0, SEEK_SET);
 	ret = write(fd, new, sizeof(new));
 	close(fd);
+	pv_fs_path_sync(grub_env);
 	if (ret != 1024) {
 		pv_log(ERROR, "error writing grubenv");
 		return -1;
@@ -235,6 +239,7 @@ static int grub_set_env_key(char *key, char *value)
 	lseek(fd, 0, SEEK_SET);
 	ret = write(fd, new, sizeof(new));
 	close(fd);
+	pv_fs_path_sync(grub_env);
 	if (ret != 1024) {
 		pv_log(ERROR, "error writing grubenv");
 		return -1;

--- a/init.c
+++ b/init.c
@@ -104,7 +104,7 @@ static int early_mounts()
 	if (ret < 0)
 		exit_error(errno, "Could not mount /dev/pts");
 
-	remove("/dev/ptmx");
+	pv_fs_path_remove("/dev/ptmx", false);
 	mknod("/dev/ptmx", S_IFCHR | 0666, makedev(5, 2));
 
 	return 0;

--- a/metadata.c
+++ b/metadata.c
@@ -961,6 +961,7 @@ int pv_metadata_factory_meta(struct pantavisor *pv)
 		if (fd < 0)
 			pv_log(ERROR, "Unable to open file %s", path);
 		close(fd);
+		pv_fs_path_sync(path);
 	}
 	return upload_failed ? -1 : 0;
 }

--- a/pantahub.c
+++ b/pantahub.c
@@ -106,8 +106,10 @@ static void pv_ph_set_online(struct pantavisor *pv, bool online)
 	if (online) {
 		if (!hint) {
 			fd = open(path, O_CREAT | O_SYNC, 0400);
-			if (fd >= 0)
+			if (fd >= 0) {
 				close(fd);
+				pv_fs_path_sync(path);
+			}
 		}
 		pv_metadata_add_devmeta(DEVMETA_KEY_PH_ONLINE, "1");
 	} else {

--- a/storage.c
+++ b/storage.c
@@ -430,7 +430,7 @@ int pv_storage_validate_file_checksum(char *path, char *checksum)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0)
-		goto out;
+		return ret;
 
 	mbedtls_sha256_init(&sha256_ctx);
 	mbedtls_sha256_starts(&sha256_ctx, 0);
@@ -890,7 +890,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 		pv_paths_storage_trail_plat_file(src, PATH_MAX, s->rev, prefix,
 						 a->name);
 
-		remove(dst);
+		pv_fs_path_remove(dst, false);
 		if (link(src, dst) < 0)
 			goto err;
 	}
@@ -903,7 +903,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 		pv_paths_storage_trail_plat_file(src, PATH_MAX, s->rev, prefix,
 						 s->bsp.img.std.initrd);
 
-		remove(dst);
+		pv_fs_path_remove(dst, false);
 		if (link(src, dst) < 0)
 			goto err;
 
@@ -913,7 +913,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 		pv_paths_storage_trail_plat_file(src, PATH_MAX, s->rev, prefix,
 						 s->bsp.img.std.kernel);
 
-		remove(dst);
+		pv_fs_path_remove(dst, false);
 		if (link(src, dst) < 0)
 			goto err;
 
@@ -925,7 +925,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 							 prefix,
 							 s->bsp.img.std.fdt);
 
-			remove(dst);
+			pv_fs_path_remove(dst, false);
 			if (link(src, dst) < 0)
 				goto err;
 		}
@@ -936,7 +936,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 		pv_paths_storage_trail_plat_file(src, PATH_MAX, s->rev, prefix,
 						 s->bsp.img.ut.fit);
 
-		remove(dst);
+		pv_fs_path_remove(dst, false);
 		if (link(src, dst) < 0)
 			goto err;
 	}
@@ -1032,7 +1032,7 @@ void pv_storage_rm_usermeta(const char *key)
 	char *pname, *pkey;
 
 	pv_paths_pv_usrmeta_key(path, PATH_MAX, key);
-	remove(path);
+	pv_fs_path_remove(path, false);
 	pv_log(DEBUG, "removed usermeta in %s", path);
 
 	pname = strdup(key);
@@ -1041,7 +1041,7 @@ void pv_storage_rm_usermeta(const char *key)
 		*pkey = '\0';
 		pkey++;
 		pv_paths_pv_usrmeta_plat_key(path, PATH_MAX, pname, pkey);
-		remove(path);
+		pv_fs_path_remove(path, false);
 		pv_log(DEBUG, "removed usermeta in %s", path);
 	}
 
@@ -1084,7 +1084,7 @@ void pv_storage_rm_devmeta(const char *key)
 	char *pname, *pkey;
 
 	pv_paths_pv_devmeta_key(path, PATH_MAX, key);
-	remove(path);
+	pv_fs_path_remove(path, false);
 	pv_log(DEBUG, "removed devmeta in %s", path);
 
 	pname = strdup(key);
@@ -1093,7 +1093,7 @@ void pv_storage_rm_devmeta(const char *key)
 		*pkey = '\0';
 		pkey++;
 		pv_paths_pv_devmeta_plat_key(path, PATH_MAX, pname, pkey);
-		remove(path);
+		pv_fs_path_remove(path, false);
 		pv_log(DEBUG, "removed devmeta in %s", path);
 	}
 

--- a/uboot.c
+++ b/uboot.c
@@ -200,6 +200,7 @@ static int uboot_unset_env_key(char *key)
 	lseek(fd, 0, SEEK_SET);
 	ret = read(fd, old, len);
 	close(fd);
+	pv_fs_path_sync(path);
 
 	len = 0;
 	d = (char *)new;
@@ -277,6 +278,7 @@ static int uboot_set_env_key(char *key, char *value)
 	lseek(fd, 0, SEEK_SET);
 	res = read(fd, old, len);
 	close(fd);
+	pv_fs_path_sync(path);
 
 	len = 0;
 	d = (char *)new;
@@ -370,6 +372,7 @@ static int uboot_flush_env(void)
 		pv_log(DEBUG, "ioctl: MEMERASE errno=%s", strerror(errno));
 
 	close(fd);
+	pv_fs_path_sync(pv_env);
 
 	fd = open(pv_env, O_RDONLY);
 	if (fd < 0) {

--- a/updater.c
+++ b/updater.c
@@ -1607,18 +1607,18 @@ static int trail_download_object(struct pantavisor *pv, struct pv_object *obj,
 		pv_log(WARN,
 		       "'%s' could not be downloaded: could not be initialized",
 		       obj->id);
-		remove(mmc_tmp_obj_path);
+		pv_fs_path_remove(mmc_tmp_obj_path, false);
 		goto out;
 	} else if (!res->code) {
 		pv_log(WARN, "'%s' could not be downloaded: got no response",
 		       obj->id);
-		remove(mmc_tmp_obj_path);
+		pv_fs_path_remove(mmc_tmp_obj_path, false);
 		goto out;
 	} else if (res->code != THTTP_STATUS_OK) {
 		pv_log(WARN,
 		       "'%s' could not be downloaded: returned HTTP error (code=%d; body='%s')",
 		       obj->id, res->code, res->body);
-		remove(mmc_tmp_obj_path);
+		pv_fs_path_remove(mmc_tmp_obj_path, false);
 		goto out;
 	}
 


### PR DESCRIPTION
Another revision round of the missing sync through the code. In this case, the criteria has been:
* make sure we are using pv_fs_path_sync before closing an fd that was opened with writing permissions
* replace remove syscall with pv_fs_path_remove that uses pv_fs_path_sync internally
* make sure we are using pv_fs_path_rename that uses pv_fs_path_sync internally instead of rename syscall
* avoid closing unopened fds