### PR TITLE
load config policies after pantavisor.config

### DIFF
--- a/config.h
+++ b/config.h
@@ -185,6 +185,7 @@ struct pantavisor_metadata {
 };
 
 struct pantavisor_config {
+	char *policy;
 	struct pantavisor_system sys;
 	struct pantavisor_debug debug;
 	struct pantavisor_cache cache;
@@ -223,6 +224,7 @@ void pv_config_set_creds_id(char *id);
 void pv_config_set_creds_prn(char *prn);
 void pv_config_set_creds_secret(char *secret);
 
+char *pv_config_get_policy(void);
 init_mode_t pv_config_get_system_init_mode(void);
 char *pv_config_get_system_libdir(void);
 char *pv_config_get_system_etcdir(void);

--- a/log.c
+++ b/log.c
@@ -173,6 +173,7 @@ static int pv_log_early_init(struct pv_init *this)
 	pv_log(INFO, "                                                 ");
 	pv_log(INFO, "Pantavisor (TM) (%s) - pantavisor.io", pv_build_version);
 	pv_log(INFO, "                                                 ");
+	pv_log(INFO, "policy = '%s'", pv_config_get_policy());
 	pv_log(INFO, "storage.path = '%s'", pv_config_get_storage_path());
 	pv_log(INFO, "storage.fstype = '%s'", pv_config_get_storage_fstype());
 	pv_log(INFO, "storage.opts = '%s'", pv_config_get_storage_opts());

--- a/paths.c
+++ b/paths.c
@@ -370,11 +370,18 @@ void pv_paths_lib_lxc_lxcpath(char *buf, size_t size)
 }
 
 #define PV_ETC_PATHF "%s/%s"
+#define PV_ETC_POLICY_PATHF "%s/pantavisor/policies/%s.config"
 
 void pv_paths_etc_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, pv_config_get_system_etcdir(),
 			name);
+}
+
+void pv_paths_etc_policy_file(char *buf, size_t size, const char *name)
+{
+	SNPRINTF_WTRUNC(buf, size, PV_ETC_POLICY_PATHF,
+			pv_config_get_system_etcdir(), name);
 }
 
 #define PV_CONFIGS_PATHF "%s/%s"

--- a/paths.h
+++ b/paths.h
@@ -141,6 +141,7 @@ void pv_paths_writable(char *buf, size_t size);
 #define PVS_CERT_FNAME PVS_DNAME "/certs/ca.pem"
 
 void pv_paths_etc_file(char *buf, size_t size, const char *name);
+void pv_paths_etc_policy_file(char *buf, size_t size, const char *name);
 
 void pv_paths_configs_file(char *buf, size_t size, const char *name);
 


### PR DESCRIPTION
Pantavisor can now load different policies at boot time. A policy is a configuration file following the same format as pantavisor.config. The files are located in /etc/pantavisor/policies/, so they can be added to each platform from vendor/stepskel/etc/pantavisor/policies/. The policy is set in the first stages of configuration (pantavisor.config or cmdline) and then loaded before the latest stages (initrdconfig or metadata config).

For example, if we wanted to load this policy from vendor:

```
vendor/stepskel/etc/pantavisor/policies/prod.config
```

We would have to set this key in cmdline:

```
pv_policy=prod
```

Another thing that would work is to set it in pantavisor.config

```
policy=prod
```

List of changes:
* config: add new "policy" key to pantavisor.config, overridable with pv_ suffix in cmdline
* config: new "policy" key is a string without '/' characters
* path: add new dynamic path for policies