### PR TITLE
set empty uboot var in boot.txt instead of deleting it; fix ssh enabling

### DIFF
--- a/init.c
+++ b/init.c
@@ -344,11 +344,11 @@ static void parse_commands(int argc, char *argv[])
 	if (is_arg(argc, argv, "pv_appengine"))
 		pv_config_set_system_init_mode(IM_APPENGINE);
 
-	if (is_arg(argc, argv, "pv_debug"))
+	if (is_arg(argc, argv, "pv_debug")) {
+		pv_config_set_debug_shell(true);
 		pv_config_set_debug_shell_autologin(true);
-
-	if (!is_arg(argc, argv, "splash"))
 		pv_config_set_debug_ssh(true);
+	}
 }
 
 // appengine should not do this, but continue put to stdout


### PR DESCRIPTION
This PR modifies uboot code so we set an empty var when unseting (only used for pv_rev=). It also fixes ssh activation, which was being set to true when the arg "splash" was not present. Now, besides being configurable, one can enable debug ssh and shell with the "pv_debug" arg.