### PR TITLE
Fix ph_logger behavior

### DIFF
--- a/log.c
+++ b/log.c
@@ -47,7 +47,6 @@
 #include "init.h"
 #include "bootloader.h"
 #include "version.h"
-#include "ph_logger.h"
 #include "buffer.h"
 #include "paths.h"
 #include "logserver.h"

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -23,6 +23,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <string.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <logger.h>
 #include <libgen.h>
@@ -30,9 +31,9 @@
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/xattr.h>
 
 #include "pvlogger.h"
-#include "ph_logger.h"
 #include "platforms.h"
 #include "pvctl_utils.h"
 #include "json.h"
@@ -101,7 +102,8 @@ static int set_logger_xattr(struct log *log)
 		return 0;
 	SNPRINTF_WTRUNC(place_holder, sizeof(place_holder), "%" PRId64, pos);
 
-	return pv_fs_file_set_xattr(fname, PV_LOGGER_POS_XATTR, place_holder);
+	return setxattr(fname, PV_LOGGER_POS_XATTR, place_holder,
+			strlen(place_holder), 0);
 }
 
 static int pvlogger_flush(struct log *log, char *buf, int buflen)
@@ -172,7 +174,7 @@ static int get_logger_xattr(struct log *log)
 	char buf[32];
 	const char *fname = pv_logger_get_logfile(pv_log_info);
 
-	if (pv_fs_file_get_xattr(buf, 32, fname, PV_LOGGER_POS_XATTR) < 0) {
+	if (getxattr(fname, PV_LOGGER_POS_XATTR, buf, 32) < 0) {
 		pv_log(DEBUG, "Attribute %s not present", PV_LOGGER_POS_XATTR);
 	} else {
 		sscanf(buf, "%" PRId64, &stored_pos);

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/xattr.h>
 #include <unistd.h>
 
 static void close_fd(int *fd)
@@ -311,25 +310,6 @@ off_t pv_fs_path_get_size(const char *path)
 		return -1;
 
 	return st.st_size;
-}
-
-int pv_fs_file_get_xattr(char *value, ssize_t size, const char *fname,
-			 const char *attr)
-{
-	ssize_t cur_size = getxattr(fname, attr, value, size);
-	return cur_size == size ? 0 : -1;
-}
-
-int pv_fs_file_set_xattr(const char *fname, const char *attr, const char *value)
-{
-	ssize_t size = getxattr(fname, attr, NULL, 0);
-
-	int flag = XATTR_REPLACE;
-	if (size < 0 && errno == ENODATA)
-		flag = XATTR_CREATE;
-
-	size = setxattr(fname, attr, value, strlen(value), flag);
-	return size > 0 ? 0 : -1;
 }
 
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size)

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -43,12 +43,6 @@ int pv_fs_file_copy(const char *src, const char *dst, mode_t mode);
 // This function doesn't perform sync
 ssize_t pv_fs_file_copy_fd(int src, int dst, bool close_src);
 
-// Returns 0 on success -1 on error. Check errno for details
-int pv_fs_file_get_xattr(char *value, ssize_t size, const char *fname,
-			 const char *attr);
-int pv_fs_file_set_xattr(const char *fname, const char *attr,
-			 const char *value);
-
 // This function doesn't perform sync
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
 ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);


### PR DESCRIPTION
Replace functions to set and get xattr from utils/fs with setxattr and getxattr
The functions on utils/fs try to mimic a behavior already present on the standard function, so they were replaced