### PR TITLE
Fix timer start

### DIFF
--- a/group.h
+++ b/group.h
@@ -35,12 +35,17 @@ typedef enum {
 	STATUS_GOAL_FAILED
 } groups_goals_state_t;
 
+struct timeout {
+	int limit;
+	bool started;
+	struct timer timer_goal;
+};
+
 struct pv_group {
 	char *name;
-	int timeout;
 	plat_status_t default_status_goal;
 	restart_policy_t default_restart_policy;
-	struct timer timer_goal;
+	struct timeout timeout;
 	struct dl_list platform_refs; // pv_platform_ref
 	struct dl_list list; // pv_group
 };

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -315,7 +315,6 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	timer_start(&timer_commit, 0, 0, RELATIV_TIMER);
 	timer_start(&timer_rollback_remote,
 		    pv_config_get_updater_network_timeout(), 0, RELATIV_TIMER);
-	pv_state_start_groups_timer(pv->state);
 	timer_start(&timer_wait_delay, 0, 0, RELATIV_TIMER);
 	timer_start(&timer_usrmeta_interval, 0, 0, RELATIV_TIMER);
 	timer_start(&timer_devmeta_interval, 0, 0, RELATIV_TIMER);

--- a/state.h
+++ b/state.h
@@ -48,6 +48,7 @@ struct pv_state {
 	char *rev;
 	state_spec_t spec;
 	struct pv_bsp bsp;
+	struct pv_group *cur_group;
 	struct dl_list platforms; // pv_platform
 	struct dl_list volumes; // pv_volume
 	struct dl_list disks; // pv_disks
@@ -94,6 +95,5 @@ int pv_state_interpret_signal(struct pv_state *s, const char *name,
 void pv_state_print(struct pv_state *s);
 char *pv_state_get_containers_json(struct pv_state *s);
 char *pv_state_get_groups_json(struct pv_state *s);
-void pv_state_start_groups_timer(struct pv_state *s);
 
 #endif


### PR DESCRIPTION
Now group timers start only after each group finish its start process, that's mean that each group has the complete timeout to start.