### PR TITLE
add volumes to device.json; allow metadata in volume

### DIFF
--- a/init.c
+++ b/init.c
@@ -552,11 +552,10 @@ loop:
  * order.
  */
 struct pv_init *pv_init_tbl[] = {
-	&pv_init_mount,	     &pv_init_creds,	    &ph_init_mount,
-	&pv_init_bl,	     &pv_init_config_trail, &pv_init_log,
-	&pv_init_storage,    &pv_init_metadata,	    &pv_init_ctrl,
-	&pv_init_network,    &pv_init_volume,	    &pv_init_platform,
-	&pv_init_pantavisor,
+	&pv_init_mount,	  &pv_init_creds,	 &ph_init_mount,
+	&pv_init_bl,	  &pv_init_config_trail, &pv_init_log,
+	&pv_init_storage, &pv_init_ctrl,	 &pv_init_network,
+	&pv_init_volume,  &pv_init_platform,	 &pv_init_pantavisor,
 };
 
 int pv_do_execute_init()

--- a/metadata.h
+++ b/metadata.h
@@ -51,7 +51,6 @@ struct pv_metadata {
 	bool devmeta_uploaded;
 };
 
-int pv_metadata_mount(void);
 void pv_metadata_umount(void);
 
 int pv_metadata_factory_meta(struct pantavisor *pv);
@@ -68,6 +67,7 @@ int pv_metadata_add_devmeta(const char *key, const char *value);
 int pv_metadata_rm_devmeta(const char *key);
 void pv_metadata_parse_devmeta(const char *buf);
 
+int pv_metadata_init(void);
 void pv_metadata_remove(void);
 
 char *pv_metadata_get_user_meta_string(void);

--- a/paths.h
+++ b/paths.h
@@ -124,6 +124,10 @@ void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name);
 void pv_paths_lib_lxc_rootfs_mount(char *buf, size_t size);
 void pv_paths_lib_lxc_lxcpath(char *buf, size_t size);
 
+#define BSP_DNAME "bsp"
+#define USRMETAVOL_DNAME "pv--usrmeta"
+#define DEVMETAVOL_DNAME "pv--devmeta"
+
 void pv_paths_root_file(char *buf, size_t size, const char *path);
 void pv_paths_volumes_file(char *buf, size_t size, const char *name);
 void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat,

--- a/state.c
+++ b/state.c
@@ -253,6 +253,16 @@ void pv_state_print(struct pv_state *s)
 		pv_log(DEBUG, "  type: %d", v->type);
 		if (v->plat)
 			pv_log(DEBUG, "  platform: '%s'", v->plat->name);
+		if (v->disk)
+			pv_log(DEBUG, "  disk: '%s'", v->disk->name);
+	}
+	struct pv_disk *d, *tmp_d;
+	struct dl_list *disks = &s->disks;
+	dl_list_for_each_safe(d, tmp_d, disks, struct pv_disk, list)
+	{
+		pv_log(DEBUG, " disk: '%s'", d->name);
+		pv_log(DEBUG, "  default: %d", d->def);
+		pv_log(DEBUG, "  type: %d", d->type);
 	}
 	struct pv_addon *a, *tmp_a;
 	struct dl_list *addons = &s->addons;
@@ -418,8 +428,11 @@ static int pv_state_mount_bsp_volumes(struct pv_state *s)
 	dl_list_for_each_safe(v, tmp, &s->volumes, struct pv_volume, list)
 	{
 		if (!v->plat)
-			if (pv_volume_mount(v))
+			if (pv_volume_mount(v)) {
+				pv_log(ERROR, "bsp volume %s mount failed",
+				       v->name);
 				return -1;
+			}
 	}
 
 	return pv_volumes_mount_firmware_modules();


### PR DESCRIPTION
This PR allows metadata in crypt disks. The first thing that was needed for this change was to allow to set volumes in device.json. Having that, we can do a configuration like this:

```
  "disks": [
    {
      "name": "dm-internal-secrets",
          "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
          "type": "dm-crypt-versatile"
    }
  ],
  "volumes": {
    "pv--usrmeta": {
      "disk": "dm-internal-secrets",
      "persistence": "permanent"
    },
    "pv--devmeta": {
      "disk": "dm-internal-secrets",
      "persistence": "permanent"
    }
  }
```

Pantavisor will then check if pv--usrmeta and/or pv--devmeta are known volumes. If true, the volumes will be mounted on /pv/user-meta and /pv/dev-meta. If not true, the old behavior will follow, just mounting /storage/cache into /pv.

List of changes:
* init: remove metadata initialization from early init
* metadata: mount from /storage/cache or /volumes/bsp into /pv depending on the existence of pv--devmeta and pv--usrmeta volumes
* metadata: move remote devmeta set from state RUN into devmeta init
* metadata: get mount back to init
* pantavisor: move metadata init & mount after state is started to be able to check for volumes
* parser: add "volume" key to device.json, which expects the same format as "storage" in src.json
* paths: new devmeta and usrmeta constants
* state: better disk log traces
* volumes: better volume mount log traces