### PR TITLE
refactor: move status goal timeout from groups into platform struct

### DIFF
--- a/group.c
+++ b/group.c
@@ -40,10 +40,9 @@ struct pv_group *pv_group_new(char *name, int timeout, plat_status_t status,
 	g = calloc(1, sizeof(struct pv_group));
 	if (g) {
 		g->name = strdup(name);
-		g->timeout.limit = timeout;
-		g->timeout.started = false;
 		g->default_status_goal = status;
 		g->default_restart_policy = restart;
+		g->default_status_goal_timeout = timeout;
 		dl_list_init(&g->platform_refs);
 	}
 
@@ -78,36 +77,21 @@ void pv_group_free(struct pv_group *g)
 	free(g);
 }
 
-groups_goals_state_t pv_group_check_goals(struct pv_group *g)
+plat_goal_state_t pv_group_check_goals(struct pv_group *g)
 {
-	if (dl_list_empty(&g->platform_refs))
-		return STATUS_GOAL_REACHED;
-
-	if (!g->timeout.started)
-		return STATUS_GOAL_WAITING;
-
-	struct timer_state tstate = timer_current_state(&g->timeout.timer_goal);
-
-	if (dl_list_empty(&g->platform_refs))
-		return STATUS_GOAL_UNKNOWN;
+	plat_goal_state_t g_goal_state = PLAT_GOAL_ACHIEVED;
+	plat_goal_state_t p_goal_state;
 
 	struct pv_platform_ref *pr, *tmp;
 	dl_list_for_each_safe(pr, tmp, &g->platform_refs,
 			      struct pv_platform_ref, list)
 	{
-		if (!pv_platform_check_goal(pr->ref)) {
-			if (tstate.fin) {
-				return STATUS_GOAL_FAILED;
-			} else {
-				pv_log(DEBUG,
-				       "platform '%s' from group '%s' status goal not achieved. %d seconds until timeout",
-				       pr->ref->name, g->name, tstate.sec);
-				return STATUS_GOAL_WAITING;
-			}
-		}
+		p_goal_state = pv_platform_check_goal(pr->ref);
+		if (p_goal_state > g_goal_state)
+			g_goal_state = p_goal_state;
 	}
 
-	return STATUS_GOAL_REACHED;
+	return g_goal_state;
 }
 
 static struct pv_platform_ref *
@@ -190,12 +174,4 @@ void pv_group_add_json(struct pv_json_ser *js, struct pv_group *g)
 
 		pv_json_ser_object_pop(js);
 	}
-}
-
-void pv_group_start_timer(struct pv_group *g)
-{
-	pv_log(DEBUG, "starting timer for group %s (%d seconds)", g->name,
-	       g->timeout.limit);
-	timer_start(&g->timeout.timer_goal, g->timeout.limit, 0, RELATIV_TIMER);
-	g->timeout.started = true;
 }

--- a/group.h
+++ b/group.h
@@ -28,24 +28,11 @@
 #include "utils/json.h"
 #include "utils/timer.h"
 
-typedef enum {
-	STATUS_GOAL_UNKNOWN,
-	STATUS_GOAL_REACHED,
-	STATUS_GOAL_WAITING,
-	STATUS_GOAL_FAILED
-} groups_goals_state_t;
-
-struct timeout {
-	int limit;
-	bool started;
-	struct timer timer_goal;
-};
-
 struct pv_group {
 	char *name;
 	plat_status_t default_status_goal;
 	restart_policy_t default_restart_policy;
-	struct timeout timeout;
+	int default_status_goal_timeout;
 	struct dl_list platform_refs; // pv_platform_ref
 	struct dl_list list; // pv_group
 };
@@ -57,8 +44,7 @@ void pv_group_free(struct pv_group *g);
 
 void pv_group_add_platform(struct pv_group *g, struct pv_platform *p);
 
-groups_goals_state_t pv_group_check_goals(struct pv_group *g);
+plat_goal_state_t pv_group_check_goals(struct pv_group *g);
 void pv_group_add_json(struct pv_json_ser *js, struct pv_group *g);
-void pv_group_start_timer(struct pv_group *g);
 
 #endif // PV_GROUP_H

--- a/platforms.h
+++ b/platforms.h
@@ -30,6 +30,7 @@
 
 #include "utils/list.h"
 #include "utils/json.h"
+#include "utils/timer.h"
 
 typedef enum {
 	PLAT_NONE,
@@ -42,6 +43,13 @@ typedef enum {
 	PLAT_STOPPING,
 	PLAT_STOPPED
 } plat_status_t;
+
+typedef enum {
+	PLAT_GOAL_NONE,
+	PLAT_GOAL_ACHIEVED,
+	PLAT_GOAL_UNACHIEVED,
+	PLAT_GOAL_TIMEDOUT,
+} plat_goal_state_t;
 
 typedef enum {
 	DRIVER_REQUIRED = (1 << 0),
@@ -90,6 +98,7 @@ struct pv_platform {
 	int roles;
 	restart_policy_t restart_policy;
 	bool updated;
+	struct timer timer_status_goal;
 	struct dl_list drivers;
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
@@ -113,7 +122,7 @@ int pv_platform_start(struct pv_platform *p);
 int pv_platform_stop(struct pv_platform *p);
 void pv_platform_force_stop(struct pv_platform *p);
 
-int pv_platform_check_running(struct pv_platform *p);
+bool pv_platform_check_running(struct pv_platform *p);
 
 void pv_platform_set_installed(struct pv_platform *p);
 void pv_platform_set_mounted(struct pv_platform *p);
@@ -132,7 +141,7 @@ bool pv_platform_is_stopped(struct pv_platform *p);
 bool pv_platform_is_updated(struct pv_platform *p);
 
 void pv_platform_set_status_goal(struct pv_platform *p, plat_status_t goal);
-bool pv_platform_check_goal(struct pv_platform *p);
+plat_goal_state_t pv_platform_check_goal(struct pv_platform *p);
 
 void pv_platform_set_restart_policy(struct pv_platform *p,
 				    restart_policy_t policy);

--- a/state.h
+++ b/state.h
@@ -48,7 +48,6 @@ struct pv_state {
 	char *rev;
 	state_spec_t spec;
 	struct pv_bsp bsp;
-	struct pv_group *cur_group;
 	struct dl_list platforms; // pv_platform
 	struct dl_list volumes; // pv_volume
 	struct dl_list disks; // pv_disks
@@ -86,8 +85,8 @@ int pv_state_stop_force(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
-groups_goals_state_t pv_state_check_goals(struct pv_state *s,
-					  struct pv_platform *p);
+plat_goal_state_t pv_state_check_goals(struct pv_state *s,
+				       struct pv_platform *p);
 
 int pv_state_interpret_signal(struct pv_state *s, const char *name,
 			      const char *signal, const char *payload);


### PR DESCRIPTION
This refactor encapsulates the functionality of timeouts in the platform module. It also prepares the way for state status.