### PR TITLE
Modular logserver outputs

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -48,7 +48,13 @@ LOCAL_SRC_FILES := debug.c \
 			loop.c \
 			logger.c \
 			log.c \
-			logserver.c \
+			logserver/logserver_utils.c \
+			logserver/logserver_out.c \
+			logserver/logserver_singlefile.c \
+			logserver/logserver_filetree.c \
+			logserver/logserver_stdout.c \
+			logserver/logserver_null.c \
+			logserver/logserver.c \
 			config_parser.c \
 			config.c \
 			pantavisor.c \

--- a/config.h
+++ b/config.h
@@ -134,8 +134,7 @@ typedef enum {
 	LOG_SERVER_OUTPUT_NULL_SINK = 1 << 0,
 	LOG_SERVER_OUTPUT_SINGLE_FILE = 1 << 1,
 	LOG_SERVER_OUTPUT_FILE_TREE = 1 << 2,
-	LOG_SERVER_OUTPUT_STDOUT = 1 << 3,
-	LOG_SERVER_OUTPUT_SIZE
+	LOG_SERVER_OUTPUT_STDOUT = 1 << 3
 } log_server_output_mask_t;
 
 struct pantavisor_log_server {

--- a/log.c
+++ b/log.c
@@ -49,7 +49,7 @@
 #include "version.h"
 #include "buffer.h"
 #include "paths.h"
-#include "logserver.h"
+#include "logserver/logserver.h"
 
 #define MODULE_NAME "log"
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)

--- a/logserver/logserver.h
+++ b/logserver/logserver.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_H
+#define LOGSERVER_H
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include "pantavisor.h"
+
+#define PV_PLATFORM_STR "pantavisor"
+
+void pv_logserver_toggle(struct pantavisor *pv, const char *rev);
+
+int pv_logserver_init(void);
+
+int pv_logserver_send_log(bool is_platform, char *platform, char *src,
+			  int level, const char *msg, ...);
+int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
+			   int level, const char *msg, va_list args);
+
+void pv_logserver_degrade(void);
+void pv_logserver_reload(void);
+void pv_logserver_stop(void);
+int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src,
+			      int loglevel);
+int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
+
+#endif /* LOGSERVER_H */

--- a/logserver/logserver_filetree.c
+++ b/logserver/logserver_filetree.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_filetree.h"
+#include "logserver_utils.h"
+#include "config.h"
+#include "paths.h"
+#include "utils/fs.h"
+#include "bootloader.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#include <libgen.h>
+
+#define MAIN_PLATFORM "pantavisor"
+
+static char *create_dir(const struct logserver_log *log, bool is_pv)
+{
+	char path[PATH_MAX];
+	pv_paths_pv_log_file(path, sizeof(path), pv_bootloader_get_rev(),
+			     log->plat, is_pv ? "pantavisor.log" : log->src);
+
+	char *dup_path = strdup(path);
+	char *fname = dirname(path);
+
+	// Create directory for logged item according to platform and source.
+	if (pv_fs_mkdir_p(fname, 0755) != 0) {
+		free(dup_path);
+		return NULL;
+	}
+
+	return dup_path;
+}
+
+static int add_log(struct logserver_out *out, const struct logserver_log *log)
+{
+	if (log->lvl > pv_config_get_log_loglevel())
+		return 0;
+
+	bool is_pv = !strncmp(log->plat, MAIN_PLATFORM, strlen(MAIN_PLATFORM));
+
+	char *path = create_dir(log, is_pv);
+	if (!path)
+		return -1;
+
+	int fd = logserver_utils_open_logfile(path);
+
+	if (fd < 0) {
+		WARN_ONCE("Error opening file %s/%s, errno = %d\n", platform,
+			  source, errno);
+
+		free(path);
+		return -1;
+	}
+
+	int len = 0;
+
+	if (is_pv)
+		len = logserver_utils_print_pvfmt(fd, log, "pantavisor", true);
+	else
+		len = dprintf(fd, "%.*s", log->data.len, log->data.buf);
+
+	close(fd);
+	free(path);
+
+	return len;
+}
+
+struct logserver_out *logserver_filetree_new()
+{
+	return logserver_out_new(LOG_SERVER_OUTPUT_FILE_TREE, "filetree",
+				 add_log, NULL, NULL);
+}

--- a/logserver/logserver_filetree.h
+++ b/logserver/logserver_filetree.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_FILETREE_H
+#define LOGSERVER_FILETREE_H
+
+#include "logserver_out.h"
+
+struct logserver_out *logserver_filetree_new(void);
+
+#endif

--- a/logserver/logserver_null.c
+++ b/logserver/logserver_null.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_null.h"
+#include "config.h"
+
+static int add_log(struct logserver_out *out, const struct logserver_log *log)
+{
+	return 0;
+}
+
+struct logserver_out *logserver_null_new()
+{
+	return logserver_out_new(LOG_SERVER_OUTPUT_NULL_SINK, "nullsink",
+				 add_log, NULL, NULL);
+}

--- a/logserver/logserver_null.h
+++ b/logserver/logserver_null.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Pantacor Ltd.
+ * Copyright (c) 2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,30 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef LOGSERVER_H
-#define LOGSERVER_H
 
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdarg.h>
-#include "pantavisor.h"
+#ifndef LOGSERVER_NULL_H
+#define LOGSERVER_NULL_H
 
-#define PV_PLATFORM_STR "pantavisor"
+#include "logserver_out.h"
 
-void pv_logserver_toggle(struct pantavisor *pv, const char *rev);
+struct logserver_out *logserver_null_new(void);
 
-int pv_logserver_init(void);
-
-int pv_logserver_send_log(bool is_platform, char *platform, char *src,
-			  int level, const char *msg, ...);
-int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
-			   int level, const char *msg, va_list args);
-
-void pv_logserver_degrade(void);
-void pv_logserver_reload(void);
-void pv_logserver_stop(void);
-int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src,
-			      int loglevel);
-int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
-
-#endif /* LOGSERVER_H */
+#endif

--- a/logserver/logserver_out.c
+++ b/logserver/logserver_out.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_out.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct logserver_out *logserver_out_new(
+	int id, const char *name,
+	int (*add)(struct logserver_out *out, const struct logserver_log *log),
+	void (*free)(struct logserver_out *out), void *opaque)
+{
+	if (!add)
+		return NULL;
+
+	struct logserver_out *out = calloc(1, sizeof(struct logserver_out));
+	if (!out)
+		return NULL;
+
+	out->name = strdup(name);
+	if (!out->name) {
+		free(out);
+		return NULL;
+	}
+
+	out->id = id;
+	out->add = add;
+	out->free = free;
+	out->opaque = opaque;
+	dl_list_init(&out->list);
+
+	return out;
+}
+
+void logserver_out_free(struct logserver_out *out)
+{
+	if (!out)
+		return;
+
+	if (out->name)
+		free(out->name);
+
+	if (out->free)
+		out->free(out);
+
+	free(out);
+}

--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_OUT_H
+#define LOGSERVER_OUT_H
+
+#include "utils/list.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define LOGSERVER_LOG_PROTOCOL_V1 0
+
+#ifdef DEBUG
+#define WARN_ONCE(msg, args...)                                                \
+	do {                                                                   \
+		static bool __warned = false;                                  \
+		if (!__warned) {                                               \
+			printf(msg, ##args);                                   \
+			__warned = true;                                       \
+		}                                                              \
+	} while (0)
+#else
+#define WARN_ONCE(msg, args...)
+#endif
+
+struct logserver_data {
+	char *buf;
+	int len;
+};
+
+struct logserver_log {
+	int ver;
+	int lvl;
+	uint64_t tsec;
+	uint32_t tnano;
+	char *plat;
+	char *src;
+	struct logserver_data data;
+};
+
+struct logserver_out {
+	int id;
+	char *name;
+	int (*add)(struct logserver_out *out, const struct logserver_log *log);
+	void (*free)(struct logserver_out *out);
+	void *opaque;
+	struct dl_list list;
+};
+
+struct logserver_out *logserver_out_new(
+	int id, const char *name,
+	int (*add)(struct logserver_out *out, const struct logserver_log *log),
+	void (*free)(struct logserver_out *out), void *opaque);
+
+void logserver_out_free(struct logserver_out *out);
+
+#endif

--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_singlefile.h"
+#include "logserver_utils.h"
+#include "config.h"
+#include "paths.h"
+#include "utils/fs.h"
+#include "bootloader.h"
+
+#include <string.h>
+#include <linux/limits.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <stdio.h>
+
+static char *create_dir(const struct logserver_log *log)
+{
+	char path[PATH_MAX];
+	pv_paths_pv_log(path, sizeof(path), pv_bootloader_get_rev());
+
+	if (pv_fs_mkdir_p(path, 0755))
+		return NULL;
+
+	pv_paths_pv_log_plat(path, sizeof(path), pv_bootloader_get_rev(),
+			     "pv.log");
+
+	return strdup(path);
+}
+
+static int add_log(struct logserver_out *out, const struct logserver_log *log)
+{
+	if (log->lvl > pv_config_get_log_loglevel())
+		return 0;
+
+	char *path = create_dir(log);
+	if (!path)
+		return -1;
+
+	int fd = logserver_utils_open_logfile(path);
+	if (fd < 0) {
+		WARN_ONCE("Error opening file %s, errno = %d\n", path, errno);
+		free(path);
+
+		return -1;
+	}
+
+	char *json = logserver_utils_jsonify_log(log);
+	int len = dprintf(fd, "%s", json);
+
+	close(fd);
+	free(json);
+	free(path);
+
+	return len;
+}
+
+struct logserver_out *logserver_singlefile_new()
+{
+	return logserver_out_new(LOG_SERVER_OUTPUT_SINGLE_FILE, "singlefile",
+				 add_log, NULL, NULL);
+}

--- a/logserver/logserver_singlefile.h
+++ b/logserver/logserver_singlefile.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_SINGLEFILE_H
+#define LOGSERVER_SINGLEFILE_H
+
+#include "logserver_out.h"
+
+struct logserver_out *logserver_singlefile_new(void);
+
+#endif

--- a/logserver/logserver_stdout.c
+++ b/logserver/logserver_stdout.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_stdout.h"
+#include "logserver_utils.h"
+#include "config.h"
+
+#include <unistd.h>
+#include <libgen.h>
+#include <stdio.h>
+
+static int add_log(struct logserver_out *out, const struct logserver_log *log)
+{
+	if (log->lvl > pv_config_get_log_loglevel())
+		return 0;
+
+	int len = logserver_utils_print_pvfmt(STDOUT_FILENO, log,
+					      basename(log->src), false);
+	fflush(stdout);
+	return len;
+}
+
+struct logserver_out *logserver_stdout_new()
+{
+	return logserver_out_new(LOG_SERVER_OUTPUT_STDOUT, "stdout", add_log,
+				 NULL, NULL);
+}

--- a/logserver/logserver_stdout.h
+++ b/logserver/logserver_stdout.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_STDOUT_H
+#define LOGSERVER_STDOUT_H
+
+#include "logserver_out.h"
+
+struct logserver_out *logserver_stdout_new(void);
+
+#endif

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_utils.h"
+#include "config.h"
+#include "utils/fs.h"
+#include "log.h"
+#include "utils/json.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <inttypes.h>
+#include <fcntl.h>
+#include <glob.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+#include <libgen.h>
+
+#define LOGSERVER_JSON_FORMAT                                                  \
+	"{\"tsec\":%" PRId64 ", \"tnano\":%" PRId32 ", "                       \
+	"\"plat\":\"%s\", \"lvl\":\"%s\", \"src\":\"%s\", "                    \
+	"\"msg\": \"%.*s\"}\n"
+
+static int compress_log(const char *path)
+{
+	// TODO: this maybe could be configurable
+	const int LOGSERVER_MAXFILES = 3;
+
+	char pattern[PATH_MAX] = { 0 };
+	snprintf(pattern, PATH_MAX, "%s.*.gz", path);
+
+	glob_t glist;
+	int r = glob(pattern, 0, NULL, &glist);
+	if (r != 0 && r != GLOB_NOMATCH)
+		return -1;
+
+	// looking for the newest file
+	size_t max = 0;
+	for (size_t i = 0; i < glist.gl_pathc; ++i) {
+		char str[PATH_MAX] = { 0 };
+		strncpy(str, glist.gl_pathv[i], PATH_MAX - 1);
+		str[strlen(str) - 3] = '\0';
+		size_t n = strtoumax(strrchr(str, '.') + 1, NULL, 10);
+		if (n > max)
+			max = n;
+	}
+	// next file
+	++max;
+
+	// only keep maxfile files
+	if ((int)glist.gl_pathc >= LOGSERVER_MAXFILES) {
+		char delete_path[PATH_MAX] = { 0 };
+		snprintf(delete_path, PATH_MAX, "%s.%zd.gz", path,
+			 max - LOGSERVER_MAXFILES);
+		pv_fs_path_remove(delete_path, false);
+	}
+
+	globfree(&glist);
+
+	char path_gz[PATH_MAX] = { 0 };
+	snprintf(path_gz, PATH_MAX, "%s.%zd", path, max);
+	pv_fs_file_gzip(path, path_gz);
+
+	return 0;
+}
+
+int logserver_utils_open_logfile(const char *path)
+{
+	if (!path)
+		return -1;
+
+	int fd = open(path, O_CREAT | O_SYNC | O_RDWR | O_APPEND, 0644);
+
+	struct stat st;
+	if (fstat(fd, &st) != 0)
+		return fd;
+
+	if (st.st_size < pv_config_get_log_logmax())
+		return fd;
+
+	if (compress_log(path) == 0) {
+		ftruncate(fd, 0);
+		lseek(fd, 0, SEEK_SET);
+	}
+
+	return fd;
+}
+
+int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
+				const char *src, bool lf)
+{
+	const char *util_src = src ? src : log->src;
+
+	char *fmt = NULL;
+	if (lf)
+		fmt = "[%s] %" PRId64 " %s\t -- [%s]: %.*s\n";
+	else
+		fmt = "[%s] %" PRId64 " %s\t -- [%s]: %.*s";
+
+	return dprintf(fd, fmt, log->plat, log->tsec,
+		       pv_log_level_name(log->lvl), util_src, log->data.len,
+		       log->data.buf);
+}
+
+char *logserver_utils_jsonify_log(const struct logserver_log *log)
+{
+	struct logserver_log js = {
+		.ver = log->ver,
+		.lvl = log->lvl,
+		.tsec = log->tsec,
+		.plat = pv_json_format(log->plat, strlen(log->plat)),
+		.src = pv_json_format(log->src, strlen(log->src)),
+		.data.buf = pv_json_format(log->data.buf, log->data.len)
+	};
+
+	size_t len = snprintf(NULL, 0, LOGSERVER_JSON_FORMAT, js.tsec, js.tnano,
+			      js.plat, pv_log_level_name(js.lvl), js.src,
+			      (int)strlen(js.data.buf),
+			      js.data.buf) +
+		     1; // 0 byte
+
+	char *json = calloc(1, len);
+	if (!json)
+		return NULL;
+
+	snprintf(json, len, LOGSERVER_JSON_FORMAT, js.tsec, js.tnano, js.plat,
+		 pv_log_level_name(js.lvl), js.src, (int)strlen(js.data.buf),
+		 js.data.buf);
+
+	free(js.plat);
+	free(js.src);
+	free(js.data.buf);
+
+	return json;
+}
+
+char *logserver_utils_output_to_str(int out_type)
+{
+	switch (out_type) {
+	case LOG_SERVER_OUTPUT_NULL_SINK:
+		return "nullsink";
+	case LOG_SERVER_OUTPUT_STDOUT:
+		return "stdout";
+	case LOG_SERVER_OUTPUT_FILE_TREE:
+		return "filetree";
+	case LOG_SERVER_OUTPUT_SINGLE_FILE:
+		return "singlefile";
+	}
+
+	return "unknown";
+}

--- a/logserver/logserver_utils.h
+++ b/logserver/logserver_utils.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_UTILS_H
+#define LOGSERVER_UTILS_H
+
+#include "logserver_out.h"
+
+#include <stdbool.h>
+
+int logserver_utils_open_logfile(const char *path);
+int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
+				const char *src, bool lf);
+char *logserver_utils_jsonify_log(const struct logserver_log *log);
+char *logserver_utils_output_to_str(int out_type);
+
+#endif

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -58,7 +58,7 @@
 #include "signature.h"
 #include "paths.h"
 #include "ph_logger.h"
-#include "logserver.h"
+#include "logserver/logserver.h"
 #include "mount.h"
 #include "debug.h"
 #include "cgroup.h"

--- a/platforms.c
+++ b/platforms.c
@@ -48,7 +48,7 @@ int setns(int nsfd, int nstype);
 #include "init.h"
 #include "state.h"
 #include "parser/parser.h"
-#include "logserver.h"
+#include "logserver/logserver.h"
 #include "utils/list.h"
 #include "utils/json.h"
 #include "utils/str.h"

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -41,7 +41,7 @@
 #include "utils/str.h"
 #include "utils/math.h"
 #include "paths.h"
-#include "logserver.h"
+#include "logserver/logserver.h"
 
 #define MODULE_NAME "pvlogger"
 #include "log.h"

--- a/volumes.c
+++ b/volumes.c
@@ -43,7 +43,7 @@
 #include "state.h"
 #include "tsh.h"
 #include "init.h"
-#include "logserver.h"
+#include "logserver/logserver.h"
 #include "utils/fs.h"
 #include "utils/str.h"
 #include "utils/tsh.h"


### PR DESCRIPTION
Creates a new system to allow modular outputs in logserver. The new system uses a base struct to define an output and internally logserver use a list to store the needed outputs (following the configuration).

The current PR includes:
* define a base structure for new outputs (logserver_out)
* rewrite all old outputs using the new system
* creates a small "utils" lib for common functions