### PR TITLE
feature: disable/enable ssh server through user-meta

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -43,7 +43,8 @@ LOCAL_CODECHECK_C := clang
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/utils/
 
-LOCAL_SRC_FILES := init.c \
+LOCAL_SRC_FILES := debug.c \
+			init.c \
 			loop.c \
 			log.c \
 			logserver.c \

--- a/config.c
+++ b/config.c
@@ -635,6 +635,8 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config,
 	write_config_tuple_string(fd, "creds.tpm.key", config->creds.tpm.key);
 	write_config_tuple_string(fd, "creds.tpm.cert", config->creds.tpm.cert);
 
+	write_config_tuple_int(fd, "debug.ssh", config->debug.ssh);
+
 	write_config_tuple_int(fd, "updater.interval",
 			       config->updater.interval);
 	write_config_tuple_int(fd, "updater.network_timeout",
@@ -720,6 +722,8 @@ void pv_config_override_value(const char *key, const char *value)
 		pv->config.metadata.devmeta_interval = atoi(value);
 	else if (!strcmp(key, "metadata.usrmeta.interval"))
 		pv->config.metadata.usrmeta_interval = atoi(value);
+	else if (!strcmp(key, "debug.ssh"))
+		pv->config.debug.ssh = atoi(value);
 }
 
 void pv_config_free()

--- a/debug.c
+++ b/debug.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021-2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+
+#include <linux/limits.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+#include "debug.h"
+#include "config.h"
+#include "paths.h"
+
+#include "utils/tsh.h"
+
+#define MODULE_NAME "debug"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#include "log.h"
+
+static pid_t db_pid = -1;
+static pid_t shell_pid = -1;
+
+#ifdef PANTAVISOR_DEBUG
+void pv_debug_start_shell()
+{
+	char c[64] = { 0 };
+	int t = 5;
+	int con_fd;
+
+	if (shell_pid > -1)
+		return;
+
+	con_fd = open("/dev/console", O_RDWR);
+	if (con_fd < 0) {
+		printf("Unable to open /dev/console\n");
+		return;
+	}
+
+	dprintf(con_fd, "Press [d] for debug ash shell... ");
+	fcntl(con_fd, F_SETFL, fcntl(con_fd, F_GETFL) | O_NONBLOCK);
+	while (t && (read(con_fd, &c, sizeof(c)) < 0)) {
+		dprintf(con_fd, "%d ", t);
+		fflush(NULL);
+		sleep(1);
+		t--;
+	}
+	dprintf(con_fd, "\n");
+
+	if (c[0] == 'd' || pv_config_get_debug_shell_autologin())
+		shell_pid =
+			tsh_run("/sbin/getty -n -l /bin/sh 0 console", 0, NULL);
+}
+
+void pv_debug_wait_shell()
+{
+	if (shell_pid > -1) {
+		pv_log(WARN, "waiting for debug shell with pid %d to exit",
+		       shell_pid);
+		waitpid(shell_pid, NULL, 0);
+	}
+}
+
+#define DBCMD "dropbear -F -p 0.0.0.0:8222 -n %s -R -c /usr/bin/fallbear-cmd"
+
+void pv_debug_start_ssh()
+{
+	char *dbcmd;
+	char path[PATH_MAX];
+
+	if (db_pid > -1)
+		return;
+
+	pv_paths_pv_usrmeta_key(path, PATH_MAX, SSH_KEY_FNAME);
+	dbcmd = calloc(sizeof(DBCMD) + strlen(path) + 1, sizeof(char));
+	sprintf(dbcmd, DBCMD, path);
+
+	tsh_run("ifconfig lo up", 0, NULL);
+	db_pid = tsh_run(dbcmd, 0, NULL);
+
+	free(dbcmd);
+}
+
+void pv_debug_stop_ssh()
+{
+	if (db_pid > -1) {
+		kill(db_pid, SIGKILL);
+		db_pid = -1;
+	}
+}
+
+void pv_debug_check_ssh_running()
+{
+	if (pv_config_get_debug_ssh())
+		pv_debug_start_ssh();
+	else
+		pv_debug_stop_ssh();
+}
+
+bool pv_debug_is_ssh_pid(pid_t pid)
+{
+	return (pid != -1) && (pid == db_pid);
+}
+#else
+void pv_debug_start_shell()
+{
+}
+void pv_debug_wait_shell()
+{
+}
+void pv_debug_start_ssh()
+{
+}
+void pv_debug_stop_ssh()
+{
+}
+void pv_debug_check_ssh_running()
+{
+}
+
+bool pv_debug_is_ssh_pid(pid_t pid)
+{
+	return false;
+}
+#endif

--- a/debug.h
+++ b/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2021-2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,49 +19,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef PV_PANTAVISOR_H
-#define PV_PANTAVISOR_H
+#ifndef PV_DEBUG_H
+#define PV_DEBUG_H
 
 #include <stdbool.h>
+#include <unistd.h>
 
-#include "config.h"
+void pv_debug_start_shell(void);
+void pv_debug_wait_shell(void);
 
-#include "utils/system.h"
+void pv_debug_start_ssh(void);
+void pv_debug_stop_ssh(void);
+void pv_debug_check_ssh_running(void);
+bool pv_debug_is_ssh_pid(pid_t pid);
 
-#define RUNLEVEL_DATA 0
-#define RUNLEVEL_ROOT 1
-#define RUNLEVEL_PLATFORM 2
-#define RUNLEVEL_APP 3
-
-// pantavisor.h
-
-extern char pv_user_agent[4096];
-
-#define PV_USER_AGENT_FMT "Pantavisor/2 (Linux; %s) PV/%s Date/%s"
-
-struct pantavisor {
-	struct pv_update *update;
-	struct pv_state *state;
-	struct pv_cmd *cmd;
-	struct pantavisor_config config;
-	struct trail_remote *remote;
-	struct pv_metadata *metadata;
-	struct pv_connection *conn;
-	char *cmdline;
-	bool remote_mode;
-	bool online;
-	bool unclaimed;
-	bool synced;
-	bool loading_objects;
-	bool hard_poweroff;
-	cgroup_version_t cgroupv;
-	int ctrl_fd;
-};
-
-void pv_init(void);
-int pv_start(void);
-void pv_stop(void);
-
-struct pantavisor *pv_get_instance(void);
-
-#endif
+#endif // PV_DEBUG_H

--- a/volumes.c
+++ b/volumes.c
@@ -313,6 +313,7 @@ int pv_volume_mount(struct pv_volume *v)
 	int loop_fd = -1, file_fd = -1;
 	struct pantavisor *pv = pv_get_instance();
 	struct pv_state *s = pv->state;
+	struct pv_disk *d = v->disk;
 	char path[PATH_MAX], mntpoint[PATH_MAX];
 	char *fstype;
 	char *umount_cmd = NULL;
@@ -325,17 +326,14 @@ int pv_volume_mount(struct pv_volume *v)
 	char *command;
 	char *disk_name = NULL;
 
-	if (v->disk) {
-		disk_name = v->disk->name;
-	}
-
 	if (v->disk && !v->disk->def && !v->disk->mounted) {
 		ret = pv_disks_mount_handler(v->disk, "mount");
 		if (ret != 0) {
-			pv_log(ERROR, "disk %s mount failed", disk_name);
+			pv_log(ERROR, "disk %s mount failed", v->disk->name);
 			return ret;
 		}
 
+		disk_name = d->name;
 		v->disk->mounted = 1;
 	}
 


### PR DESCRIPTION
This PR introduces "debug.ssh" to user meta, so dropbear can be started and stopped on run time. It also refactors all debug code to debug.h and debug.c.

List of changes:
* config: override debug.ssh from step config and user-meta
* debug: module with ssh and shell code
* debug: store pids for dropbear and shell session
* debug: functions to start and wait for shell
* debug: functions to start, stop and toggle ssh
* init: all debug related code moved to debug module
* pantavisor: all debug related code moved to debug module