### PR TITLE
fix: pantavisor trying to load unexisting unclaimed.config

### DIFF
--- a/config.h
+++ b/config.h
@@ -208,7 +208,7 @@ struct pantavisor_config {
 
 int pv_config_init(char *path);
 
-int pv_config_load_creds(void);
+int pv_config_load_unclaimed_creds(void);
 int pv_config_save_creds(void);
 
 void pv_config_override_value(const char *key, const char *value);

--- a/pantahub.c
+++ b/pantahub.c
@@ -386,23 +386,14 @@ static int pv_ph_register_self_builtin(struct pantavisor *pv)
 
 static int pv_ph_register_self_ext(struct pantavisor *pv, char *cmd)
 {
-	int ret = 0;
 	int status = -1;
 
 	if (tsh_run(cmd, 1, &status) < 0) {
 		pv_log(ERROR, "registration attempt with cmd: %s", cmd);
-		goto exit;
+		return 0;
 	}
 
-	// If registered, override in-memory PantaHub credentials
-	if (pv_config_load_creds()) {
-		pv_log(ERROR, "error loading updated config file");
-		goto exit;
-	}
-
-	ret = 1;
-exit:
-	return ret;
+	return 1;
 }
 
 #define PANTAVISOR_EXTERNAL_REGISTER_HANDLER_FMT "/btools/%s.register"

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -344,7 +344,7 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 
 	c = calloc(128, sizeof(char));
 
-	pv_config_load_creds();
+	pv_config_load_unclaimed_creds();
 
 	if (pv_config_get_creds_id() && strcmp(pv_config_get_creds_id(), "") &&
 	    pv_ph_device_exists(pv))


### PR DESCRIPTION
This PR fixes a regression introduced with the pantahub.config only in non-remote patch. With this change, the load/saves are like this:
1. pantahub.config is always loaded if remote=1
2. if pantahub.config does not contain the credentials, try to load unclaimed.config
3. if unclaimed.config does not contain the credentials, try to register, save to unclaimed.config after registering
4. if unclaimed.config contains the credentials, try to claim, save to pantahub.config after claiming