### PR TITLE
fix: logserver not shutting down for appengine

### DIFF
--- a/log.c
+++ b/log.c
@@ -153,8 +153,10 @@ void pv_log_umount(void)
 	char path[PATH_MAX];
 
 	pv_paths_pv_log(path, PATH_MAX, "");
+	pv_log(DEBUG, "unmounting '%s'", path);
+
 	if (umount(path))
-		pv_log(ERROR, "Error unmounting pv_log %s", strerror(errno));
+		pv_log(ERROR, "cannot unmount '%s': %s", path, strerror(errno));
 }
 
 static int pv_log_early_init(struct pv_init *this)

--- a/logserver.c
+++ b/logserver.c
@@ -1226,6 +1226,7 @@ static void pv_logserver_close(void)
 	}
 
 	if (logserver_g.epfd >= 0) {
+		pv_log(DEBUG, "closing epfd...");
 		close(logserver_g.epfd);
 		logserver_g.epfd = -1;
 	}
@@ -1233,17 +1234,17 @@ static void pv_logserver_close(void)
 
 void pv_logserver_stop(void)
 {
-	pv_logserver_close();
-
 	// kill pid
 	if (logserver_g.pid > 0) {
-		pv_log(DEBUG, "stopping logserver service...");
+		pv_log(DEBUG, "stopping logserver service with pid %d...",
+		       logserver_g.pid);
 		pv_system_kill_lenient(logserver_g.pid);
 		pv_system_kill_force(logserver_g.pid);
-		pv_log(DEBUG, "stopped logserver service with pid %d",
-		       logserver_g.pid);
 		logserver_g.pid = -1;
+		pv_log(DEBUG, "stopped logserver service");
 	}
+
+	pv_logserver_close();
 }
 
 static int logserver_send_subs_msg(int type, int fd, const char *platform,

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -876,8 +876,6 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 	// give it a final sync here...
 	sync();
 
-	pv_volumes_umount_firmware_modules();
-
 	// stop childs leniently
 	pv_state_stop_lenient(pv->state);
 	ph_logger_stop_lenient();
@@ -891,10 +889,12 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 
 	// stop all logs but stdout
 	pv_logserver_degrade();
-	pv_log_umount();
 
 	pv_debug_stop_ssh();
+	pv_logserver_stop();
 
+	pv_volumes_umount_firmware_modules();
+	pv_log_umount();
 	pv_mount_umount();
 	pv_metadata_umount();
 
@@ -910,13 +910,12 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 
 	// at this point, we can shutdown if not in appengine
 	if (initmode != IM_APPENGINE) {
-		pv_log(INFO, "shutdown complete, rebooting in 2 second ...");
+		pv_log(INFO, "shutdown complete, rebooting in 2 second...");
 		sleep(2);
 		pv_remove(pv);
 		reboot(shutdown_type_reboot_cmd(t));
 	} else {
-		pv_log(INFO, "shutdown complete ...");
-		pv_logserver_stop();
+		pv_log(INFO, "shutdown complete...");
 		pv_remove(pv);
 	}
 

--- a/volumes.c
+++ b/volumes.c
@@ -608,11 +608,21 @@ int pv_volumes_umount_firmware_modules()
 	int ret = 0;
 	struct utsname uts;
 	char path_lib[PATH_MAX];
+	struct pantavisor *pv = pv_get_instance();
+
+	if (!pv || !pv->state)
+		return ret;
+
+	if (!pv->state->bsp.firmware)
+		goto modules;
 
 	ret = umount(FW_PATH);
-
 	if (ret < 0)
 		pv_log(WARN, "cannot umount firmware path %s", FW_PATH);
+
+modules:
+	if (!pv->state->bsp.modules)
+		goto out;
 
 	if (!uname(&uts)) {
 		pv_paths_lib_modules(path_lib, PATH_MAX, uts.release);
@@ -624,6 +634,7 @@ int pv_volumes_umount_firmware_modules()
 		pv_log(WARN, "cannot get utsinfo %s", strerror(errno));
 	}
 
+out:
 	return ret;
 }
 


### PR DESCRIPTION
Logserver pid being killed after the socket closing was causing an error while closing, because they were still in use. The order of shutting down logserver has been rearranged so we first close sockets, then kill pids, then unmount stuff.

Besides that, we also have changed the unmounting of firmware and modules so we don't try them and thus show a WARN log when we are not using them (appengine).