### PR TITLE
fix: crypt script checking if x--pv-dcp-tool exists

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -140,7 +140,6 @@ do_dm_sanity()
 		[ ! -f /usr/sbin/dmsetup ] && exit 111
 		[ ! -f /bin/keyctl ] && exit 111
 	elif [ $dm_type == "dcp" ]; then
-		[ ! -f x--pv-dcp-tool ] && exit 111
 		[ ! -f /usr/sbin/cryptsetup ] && exit 111
 	elif [ $dm_type == "versatile" ]; then
 		[ ! -f /usr/sbin/cryptsetup ] && exit 111


### PR DESCRIPTION
No need to check this anymore as it is shipped along the crypt script