### PR TITLE
Add basic clang-tidy config file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,50 @@
+---
+# TODO: some check could be added:
+# preformance-*
+# cert-* (?)
+# readability-* (?)
+#
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,clang-diagnostic-*,bugprone-*,clang-analyzer-*,-*,clang-analyzer-*,-clang-analyzer.cplusplus,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
+WarningsAsErrors: 'true'
+HeaderFilterRegex: './*.h'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+


### PR DESCRIPTION
This PR add a basic but completely functional clang-tidy config file. The file was generated using the `-dump-config` option in order to get the best `CheckOptions`.
It's important to bear in mind that this addition will show a lot of errors, and maybe it's important to solve it before landing to do it in a clean way.
The config file set several configurations related to security issues but, as is suggested in a comment inside, some others checks could be enabled (not enabled now to avoid more warnings and errors):
* performance-*: to check performance improvements.
* cert-*: to check CERT secure coding guidelines (not sure about this one).
* readability-*: this one needs to be tested to check if it fits with our code guidelines.

At the same time, the configuration manages warnings as errors and includes a regular expression to find the header files