### PR TITLE
add pvcrash handler and stop forcefully registering core_pattern the old way

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -101,6 +101,7 @@ LOCAL_COPY_FILES := scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
 	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
 	scripts/hooks_lxc-mount.d/remount.sh:lib/pv/hooks_lxc-mount.d/remount.sh \
 	scripts/JSON.sh:lib/pv/JSON.sh \
+	scripts/pvcrash:lib/pv/pvcrash \
 	defaults/groups.json:etc/pantavisor/defaults/groups.json
 
 include $(BUILD_EXECUTABLE)

--- a/config.c
+++ b/config.c
@@ -48,6 +48,16 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #include "log.h"
 
+static bool config_has_value(struct dl_list *config_list, char *key)
+{
+	char *item = config_get_value(config_list, key);
+
+	if (!item || !strlen(item))
+		return false;
+
+	return true;
+}
+
 static char *config_get_value_string(struct dl_list *config_list, char *key,
 				     char *default_value)
 {
@@ -444,6 +454,11 @@ static int pv_config_load_file(char *path, struct pantavisor_config *config)
 
 	config_iterate_items_prefix(&config_list, config_sysctl_apply,
 				    "sysctl.", NULL);
+
+	if (!config_has_value(&config_list, "sysctl.kernel.core_pattern")) {
+		config_sysctl_apply("sysctl.kernel.core_pattern",
+				    "|/lib/pv/pvcrash --skip", NULL);
+	}
 
 	config_clear_items(&config_list);
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -953,7 +953,6 @@ static pv_state_t _pv_run_state(pv_state_t state, struct pantavisor *pv)
 
 int pv_start()
 {
-	char path[PATH_MAX];
 	struct pantavisor *pv = pv_get_instance();
 	if (!pv)
 		return 1;
@@ -969,14 +968,6 @@ int pv_start()
 	core_limit.rlim_max = RLIM_INFINITY;
 
 	setrlimit(RLIMIT_CORE, &core_limit);
-
-	pv_paths_storage_file(path, PATH_MAX, COREPV_FNAME);
-	int fd = open("/proc/sys/kernel/core_pattern", O_WRONLY | O_SYNC);
-	if (fd < 0)
-		printf("open failed for /proc/sys/kernel/core_pattern: %s",
-		       strerror(errno));
-	else
-		write(fd, path, strlen(path));
 
 	pv_state_t state = PV_STATE_INIT;
 

--- a/scripts/pvcrash
+++ b/scripts/pvcrash
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+usage() {
+
+	echo "CMD [options] <outdir>" 
+	echo " -c <corelimit %c>"
+	echo " -d <mode %d>"
+	echo " -e <comm %e>"
+	echo " -E <path %E"
+	echo " -g <real GID %g>"
+	echo " -h <hostname %h>"
+	echo " -i <TID in pidns %i>"
+	echo " -I <TID in hostns %I>"
+	echo " -p <PID in pidns %p>"
+	echo " -P <PID in hostns %P"
+	echo " -s <signal crashed %s>"
+	echo " -t <timeofdump %t>"
+	echo " -u <uid %u"
+
+	echo ""
+	echo "See: core(5) manpage for details"
+}
+
+ensure() {
+	if [ -z "$2" ]; then
+		echo "ERROR: missing $1 parameter; see usage"
+		usage
+	fi
+	exit 125
+}
+
+
+while [ -n "$1" ]; do
+	case $1 in
+		--skip)
+			echo "SKIPPING core dump processing as requested."
+			exit 0
+			;;
+		-c)
+			shift; corelimit=$1; ensure corelimit $corelimit
+			;;
+		-d)
+			shift; mode=$1; ensure mode $mode
+			;;
+		-e)
+			shift; comm=$1; ensure comm $comm
+			;;
+		-E)
+			shift; path=$1; ensure path $path
+			;;
+		-g)
+			shift; realgid=$1; ensure realgid $realgid
+			;;
+		-h)
+			shift; hostname=$1; ensure hostname $hostname
+			;;
+		-i)
+			shift; tidns=$1; ensure tidns $tidns
+			;;
+		-I)
+			shift; tid=$1; ensure tid $tid
+			;;
+		-p)
+			shift; pidns=$1; ensure pidns $pidns
+			;;
+		-P)
+			shift; pid=$1; ensure pid $pid
+			;;
+		-s)
+			shift; signal=$1; ensure signal $signal
+			;;
+		-t)
+			shift; timeofdump=$1; ensure timeofdump $timeofdumpl
+			;;
+		-u)
+			shift; uid=$1; ensure uid $uid
+			;;
+		--help)
+			usage
+			exit 123
+			;;
+		*)
+			outdir=$1; ensure outdir $outdir
+			;;
+	esac
+	shift
+done
+
+ensure outdir $outdir
+mkdir -p $outdir
+
+dump_crash() {
+
+	fname=$outdir/pvcrash.1.crash
+	mname=$fname.manifest
+	if [ -f $fname ]; then
+		echo "not overwriting existing crash; delete it first."
+		exit 2
+	fi
+
+	echo > $fname
+	echo > $mname
+
+	echo "corelimit: $corelimit" >> $mname
+	echo "mode: $mode" >> $mname
+	echo "comm: $comm" >> $mname
+	echo "path: $path" >> $mname
+	echo "realgid: $realgid" >> $mname
+	echo "hostname: $hostname" >> $mname
+	echo "tidns: $tidns" >> $mname
+	echo "pidns: $pidns" >> $mname
+	echo "pid: $pid" >> $mname
+	echo "signal: $signal" >> $mname
+	echo "timeofdump: $timeofdump" >> $mname
+	echo "uid: $uid" >> $mname
+
+	# cat the coredump to fname
+	cat > $fname
+}
+
+dump_crash
+


### PR DESCRIPTION
You can now use pantavisor.config sysctl.kernel.core_pattern=|/lib/pv/pvcrash /storage/crash/ to enable crash dumps to /storage/crash/