### PR TITLE
introduce group and state status for logging

### DIFF
--- a/group.h
+++ b/group.h
@@ -26,10 +26,10 @@
 
 #include "utils/list.h"
 #include "utils/json.h"
-#include "utils/timer.h"
 
 struct pv_group {
 	char *name;
+	plat_status_t status;
 	plat_status_t default_status_goal;
 	restart_policy_t default_restart_policy;
 	int default_status_goal_timeout;
@@ -44,7 +44,9 @@ void pv_group_free(struct pv_group *g);
 
 void pv_group_add_platform(struct pv_group *g, struct pv_platform *p);
 
+void pv_group_eval_status(struct pv_group *g);
 plat_goal_state_t pv_group_check_goals(struct pv_group *g);
+
 void pv_group_add_json(struct pv_json_ser *js, struct pv_group *g);
 
 #endif // PV_GROUP_H

--- a/platforms.h
+++ b/platforms.h
@@ -155,7 +155,6 @@ const char *pv_platform_status_string(plat_status_t status);
 const char *pv_platforms_restart_policy_str(restart_policy_t policy);
 
 void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p);
-void pv_platform_add_goal_json(struct pv_json_ser *js, struct pv_platform *p);
 
 int pv_platforms_init_ctrl(struct pantavisor *pv);
 

--- a/state.h
+++ b/state.h
@@ -46,6 +46,7 @@ struct pv_bsp {
 
 struct pv_state {
 	char *rev;
+	plat_status_t status;
 	state_spec_t spec;
 	struct pv_bsp bsp;
 	struct dl_list platforms; // pv_platform
@@ -85,6 +86,7 @@ int pv_state_stop_force(struct pv_state *s);
 int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending);
 void pv_state_transition(struct pv_state *pending, struct pv_state *current);
 
+void pv_state_eval_status(struct pv_state *s);
 plat_goal_state_t pv_state_check_goals(struct pv_state *s,
 				       struct pv_platform *p);
 

--- a/utils/timer.c
+++ b/utils/timer.c
@@ -36,9 +36,16 @@ static clockid_t timer_type_clockid(timer_type_t type)
 	return 0;
 }
 
-static int get_current_time(struct timer *t, struct timespec *current_time)
+static int get_current_time(timer_type_t type, struct timespec *current_time)
 {
-	return clock_gettime(timer_type_clockid(t->type), current_time);
+	return clock_gettime(timer_type_clockid(type), current_time);
+}
+
+uint64_t timer_get_current_time_sec(timer_type_t type)
+{
+	struct timespec now;
+	get_current_time(type, &now);
+	return now.tv_sec;
 }
 
 struct timer_state timer_current_state(struct timer *t)
@@ -46,7 +53,7 @@ struct timer_state timer_current_state(struct timer *t)
 	struct timespec now;
 	struct timer_state tstate;
 
-	get_current_time(t, &now);
+	get_current_time(t->type, &now);
 
 	tstate.fin = (now.tv_sec > t->timeout.tv_sec) ||
 		     (now.tv_sec == t->timeout.tv_sec &&
@@ -79,7 +86,7 @@ int timer_start(struct timer *t, time_t sec, long nsec, timer_type_t type)
 	struct timespec now;
 
 	if (type == RELATIV_TIMER) {
-		get_current_time(t, &now);
+		get_current_time(t->type, &now);
 
 		t->timeout.tv_sec = now.tv_sec + sec;
 		t->timeout.tv_nsec = now.tv_nsec + nsec;

--- a/utils/timer.h
+++ b/utils/timer.h
@@ -28,6 +28,8 @@
 
 typedef enum { RELATIV_TIMER, ABSOLUTE_TIMER } timer_type_t;
 
+uint64_t timer_get_current_time_sec(timer_type_t type);
+
 struct timer {
 	timer_type_t type;
 	struct timespec timeout;
@@ -50,7 +52,6 @@ struct timer_state {
 };
 
 int timer_start(struct timer *t, time_t sec, long nsec, timer_type_t type);
-
 struct timer_state timer_current_state(struct timer *t);
 
 #endif // TIMER_H


### PR DESCRIPTION
This PR introduces status for groups. This allows us to monitor and log status changes, so we know when a group is STARTED or READY, for example.

The status of a group is always READY, except when any of the platforms that form the group have not achieved their status goals. In that case, the status of the group corresponds with the platform with the lower status.

It also adds status of the state revision. This status is calculated the same way as the group status, but having into account all platforms in the revision instead.
