### PR TITLE
Fix/clang tidy logger.c

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -152,9 +152,10 @@ int log_init(struct log *log, const char *backing_file)
 out:
 	if (ret == LOG_NOK) {
 		close(tmp_fd);
-		if (log->has_tmp_backing_file)
+		if (log->has_tmp_backing_file && log->path_backing_file)
 			unlink(log->path_backing_file);
 	}
+
 	if (log->do_start_log) {
 		ret = log->do_start_log(log, ret);
 	}

--- a/logger.c
+++ b/logger.c
@@ -105,10 +105,9 @@ int log_init(struct log *log, const char *backing_file)
 {
 	int ret = LOG_OK;
 	int tmp_fd = -1;
-	if (!log) {
-		ret = LOG_NOK;
-		goto out;
-	}
+	if (!log)
+		return LOG_NOK;
+
 	log->truncate = 0;
 	log->path_backing_file = (char *)calloc(1, PATH_MAX);
 	if (!log->path_backing_file) {


### PR DESCRIPTION
- Fix null pointer dereference
- Avoid pass null pointer to unlink