### PR TITLE
Remove useless assignments from several files

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -254,7 +254,6 @@ err:
 static struct pv_cmd *pv_ctrl_parse_command(char *buf)
 {
 	int tokc;
-	uint8_t ret = -1;
 	jsmntok_t *tokv;
 	char *op_string = NULL;
 	struct pv_cmd *cmd = NULL;
@@ -284,8 +283,6 @@ static struct pv_cmd *pv_ctrl_parse_command(char *buf)
 		pv_log(WARN, "unable to get payload value from command");
 		goto err;
 	}
-
-	ret = 0;
 
 	goto out;
 
@@ -1331,7 +1328,7 @@ static struct pv_cmd *pv_ctrl_read_parse_request(int req_fd)
 {
 	char buf[HTTP_REQ_BUFFER_SIZE];
 	char *pname;
-	int buf_index = 0, res = -1;
+	int buf_index = 0;
 	const char *method, *path;
 	size_t method_len, path_len, num_headers = HTTP_REQ_NUM_HEADERS,
 				     content_length;
@@ -1361,7 +1358,7 @@ static struct pv_cmd *pv_ctrl_read_parse_request(int req_fd)
 
 		// if character is 3 (old code for json command), it is non-HTTP
 		if (buf[0] == 3) {
-			res = pv_ctrl_process_cmd(
+			pv_ctrl_process_cmd(
 				req_fd, HTTP_REQ_BUFFER_SIZE - 1, &cmd);
 			goto out;
 		} else if (buf[0] == 2) {

--- a/drivers.c
+++ b/drivers.c
@@ -42,7 +42,7 @@
 static char *_sub_meta_values(char *str)
 {
 	// find key for meta from ${user-meta:KEY} component of string
-	int _start = 0, _end = 0, type;
+	int _start = 0, _end = 0;
 	char *_tok, *_t, *_at, *new;
 	char *_var, *_param, *_tstr;
 	int _nt = 0;
@@ -65,13 +65,8 @@ static char *_sub_meta_values(char *str)
 		_nt = _nt + (_at - (str + _end));
 		_var = strchr(_t, '}');
 		_end = _var - (str);
-		_start = _at - (str + _start);
 		_tstr = strdup(_t);
-		_tok = strtok(_tstr, "{:}");
-		if (!strcmp(_tok, USER_META_KEY))
-			type = USER_META;
-		else if (!strcmp(_tok, DEV_META_KEY))
-			type = DEVICE_META;
+		strtok(_tstr, "{:}");
 		_tok = strtok(NULL, "{:}");
 		_param = pv_metadata_get_usermeta(_tok);
 		if (_param) {

--- a/grub.c
+++ b/grub.c
@@ -234,7 +234,6 @@ static int grub_set_env_key(char *key, char *value)
 
 	// write new key/value pair to destination
 	memcpy(d, v, strlen(v));
-	d += strlen(v);
 
 	lseek(fd, 0, SEEK_SET);
 	ret = write(fd, new, sizeof(new));

--- a/logserver.c
+++ b/logserver.c
@@ -703,7 +703,6 @@ static void logserver_remove_fd(int fd)
 
 	logserver_epoll_del(fd);
 	close(fd);
-	fd = -1;
 }
 
 static void logserver_consume_log_data(int fd)

--- a/loop.c
+++ b/loop.c
@@ -86,14 +86,11 @@ out:
 
 static int bind_loop_dev(char *devname, char *file, int *loop_fd, int *file_fd)
 {
-	int loopfd = *loop_fd;
-	int filefd = *file_fd;
-
-	loopfd = open(devname, O_RDWR);
+	int loopfd = open(devname, O_RDWR);
 	if (loopfd < 0)
 		return -1;
 
-	filefd = open(file, O_RDWR);
+	int filefd = open(file, O_RDWR);
 	if (filefd < 0)
 		return -1;
 

--- a/metadata.c
+++ b/metadata.c
@@ -686,7 +686,7 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 	char *um, *key, *value;
 
 	// parse user metadata json
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 	um = pv_json_get_value(buf, "user-meta", tokv, tokc);
 
 	if (!um) {
@@ -813,13 +813,13 @@ int pv_metadata_rm_devmeta(const char *key)
 
 void pv_metadata_parse_devmeta(const char *buf)
 {
-	int ret = 0, tokc, n;
+	int tokc, n;
 	jsmntok_t *tokv = NULL;
 	jsmntok_t **key = NULL;
 	char *metakey = NULL, *metavalue = NULL;
 
 	// parse device metadata json
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 	key = jsmnutil_get_object_keys(buf, tokv);
 
 	if (!key)

--- a/network.c
+++ b/network.c
@@ -73,7 +73,7 @@ static int _set_netmask(int skfd, char *intf, char *newmask)
 void pv_network_update_meta(struct pantavisor *pv)
 {
 	struct ifaddrs *ifaddr, *ifa;
-	int family, s, n, len, ilen = 0;
+	int family, n, len, ilen = 0;
 	int size;
 	char host[NI_MAXHOST], ifn[IFNAMSIZ + 5], iff[IFNAMSIZ + 5];
 	char *t, *buf, *ifaces = 0, *ifaddrs = 0;
@@ -94,11 +94,10 @@ void pv_network_update_meta(struct pantavisor *pv)
 		if (family == AF_PACKET)
 			continue;
 
-		s = getnameinfo(ifa->ifa_addr,
-				(family == AF_INET) ?
-					      sizeof(struct sockaddr_in) :
-					      sizeof(struct sockaddr_in6),
-				host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+		getnameinfo(ifa->ifa_addr,
+			    (family == AF_INET) ? sizeof(struct sockaddr_in) :
+							sizeof(struct sockaddr_in6),
+			    host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 
 		SNPRINTF_WTRUNC(iff, sizeof(iff), "%s.%s", ifa->ifa_name,
 				family == AF_INET ? "ipv4" : "ipv6");

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -69,7 +69,6 @@ static unsigned long ns_share_flag(char *key)
 
 static int parse_pantavisor(struct pv_state *s, char *value, int n)
 {
-	int c;
 	int ret = 0, tokc, size;
 	char *str, *buf;
 	jsmntok_t *tokv;
@@ -99,7 +98,6 @@ static int parse_pantavisor(struct pv_state *s, char *value, int n)
 	key = jsmnutil_get_object_keys(buf, tokv);
 	key_i = key;
 	while (*key_i) {
-		c = (*key_i)->end - (*key_i)->start;
 		if (strncmp("addons", buf + (*key_i)->start,
 			    strlen("addons"))) {
 			key_i++;
@@ -120,7 +118,6 @@ static int parse_pantavisor(struct pv_state *s, char *value, int n)
 	key = jsmnutil_get_object_keys(buf, tokv);
 	key_i = key;
 	while (*key_i) {
-		c = (*key_i)->end - (*key_i)->start;
 		if (strncmp("platforms", buf + (*key_i)->start,
 			    strlen("platforms"))) {
 			key_i++;
@@ -141,7 +138,6 @@ static int parse_pantavisor(struct pv_state *s, char *value, int n)
 	key = jsmnutil_get_object_keys(buf, tokv);
 	key_i = key;
 	while (*key_i) {
-		c = (*key_i)->end - (*key_i)->start;
 		if (strncmp("volumes", buf + (*key_i)->start,
 			    strlen("volumes"))) {
 			key_i++;
@@ -175,13 +171,13 @@ out:
 static int parse_platform(struct pv_state *s, char *buf, int n)
 {
 	int i;
-	int tokc, ret, size;
+	int tokc, size;
 	jsmntok_t *tokv, *t;
 	char *name, *str;
 	char *configs, *shares;
 	struct pv_platform *this;
 
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 	name = pv_json_get_value(buf, "name", tokv, tokc);
 
 	this = pv_state_fetch_platform(s, name);
@@ -204,7 +200,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		tokv = 0;
 	}
 
-	ret = jsmnutil_parse_json(configs, &tokv, &tokc);
+	jsmnutil_parse_json(configs, &tokv, &tokc);
 	size = jsmnutil_array_count(buf, tokv);
 	t = tokv + 1;
 	this->configs = calloc(size + 1, sizeof(char *));
@@ -225,7 +221,7 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 		tokv = 0;
 	}
 
-	ret = jsmnutil_parse_json(shares, &tokv, &tokc);
+	jsmnutil_parse_json(shares, &tokv, &tokc);
 	size = jsmnutil_array_count(shares, tokv);
 	t = tokv + 1;
 	this->ns_share = 0;
@@ -257,13 +253,13 @@ out:
 
 struct pv_state *multi1_parse(struct pv_state *this, const char *buf)
 {
-	int tokc, ret, count, n;
+	int tokc, count, n;
 	char *key = 0, *value = 0, *ext = 0;
 	jsmntok_t *tokv;
 	jsmntok_t **k, **keys;
 
 	// Parse full state json
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 
 	count = pv_json_get_key_count(buf, "pantavisor.json", tokv, tokc);
 	if (!count || (count > 1)) {

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -68,7 +68,7 @@ static int parse_one_driver(struct pv_state *s, char *buf)
 	if (!buf)
 		return 0;
 
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 
 	keys = jsmnutil_get_object_keys(buf, tokv);
 	if (!keys) {
@@ -311,7 +311,6 @@ out:
 
 static int parse_bsp(struct pv_state *s, char *value, int n)
 {
-	int c;
 	int ret = 0, tokc, size;
 	char *str, *buf;
 	struct pv_volume *v;
@@ -322,7 +321,7 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 	buf = calloc(n + 1, sizeof(char));
 	buf = memcpy(buf, value, n);
 
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 
 	s->bsp.img.ut.fit = pv_json_get_value(buf, "fit", tokv, tokc);
 	if (!s->bsp.img.ut.fit) {
@@ -366,7 +365,6 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 
 	key_i = key;
 	while (*key_i) {
-		c = (*key_i)->end - (*key_i)->start;
 		if (strncmp("addons", buf + (*key_i)->start,
 			    strlen("addons"))) {
 			key_i++;
@@ -396,7 +394,7 @@ out:
 
 static int parse_storage(struct pv_state *s, struct pv_platform *p, char *buf)
 {
-	int tokc, n, ret;
+	int tokc, n;
 	char *key, *value, *pt, *disk;
 	jsmntok_t *tokv;
 	jsmntok_t *tokv_t;
@@ -405,7 +403,7 @@ static int parse_storage(struct pv_state *s, struct pv_platform *p, char *buf)
 	if (!buf)
 		return 0;
 
-	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	jsmnutil_parse_json(buf, &tokv, &tokc);
 
 	keys = jsmnutil_get_object_keys(buf, tokv);
 	if (!keys) {
@@ -427,7 +425,7 @@ static int parse_storage(struct pv_state *s, struct pv_platform *p, char *buf)
 		value = malloc(n + 1);
 		snprintf(value, n + 1, "%s", buf + (*k + 1)->start);
 
-		ret = jsmnutil_parse_json(value, &tokv_t, &tokc);
+		jsmnutil_parse_json(value, &tokv_t, &tokc);
 		pt = pv_json_get_value(value, "persistence", tokv_t, tokc);
 		disk = pv_json_get_value(value, "disk", tokv_t, tokc);
 

--- a/ph_logger.c
+++ b/ph_logger.c
@@ -356,7 +356,6 @@ static int ph_logger_push_from_file(const char *filename, char *platform,
 				 * The reason being we can't differentiate between a slow
 				 * growing file and a file that doesn't grow at all.
 				 */
-				bytes_read = 0;
 				break;
 			}
 		}

--- a/signature.c
+++ b/signature.c
@@ -461,7 +461,7 @@ out:
 static char *pv_signature_get_json_files(struct dl_list *json_pairs)
 {
 	char *out;
-	int len, num_pairs, i = 0;
+	int len, i = 0;
 	struct pv_signature_pair *pair, *tmp;
 
 	len = 2;
@@ -471,7 +471,6 @@ static char *pv_signature_get_json_files(struct dl_list *json_pairs)
 
 	strcpy(out, "{");
 
-	num_pairs = dl_list_len(json_pairs);
 	dl_list_for_each_safe(pair, tmp, json_pairs, struct pv_signature_pair,
 			      list)
 	{

--- a/storage.c
+++ b/storage.c
@@ -137,7 +137,6 @@ int pv_storage_get_subdir(const char *path, const char *prefix,
 	struct dirent **dirs = NULL;
 	struct pv_path *subdir;
 
-	len = strlen(path) + strlen(prefix) + 1;
 	SNPRINTF_WTRUNC(basedir, sizeof(basedir), "%s%s", path, prefix);
 
 	n = scandir(basedir, &dirs, NULL, alphasort);

--- a/trestclient.c
+++ b/trestclient.c
@@ -47,7 +47,6 @@ static struct trest_response *external_login_handler(trest_ptr self, void *data)
 {
 	char loginhandler_cmd[PATH_MAX];
 	int fd_outerr[2];
-	int rv;
 	struct trest_response *response;
 	struct pantavisor *pv;
 	char buf[PV_TRESTCLIENT_MAX_READ];
@@ -77,8 +76,7 @@ static struct trest_response *external_login_handler(trest_ptr self, void *data)
 			PANTAVISOR_EXTERNAL_LOGIN_HANDLER_FMT,
 			pv_config_get_creds_type());
 
-	rv = pipe(fd_outerr);
-	if (rv < 0) {
+	if (pipe(fd_outerr) < 0) {
 		pv_log(ERROR,
 		       "unable to setup pipe for reading login handler output: %s",
 		       strerror(errno));
@@ -132,7 +130,6 @@ static struct trest_response *external_login_handler(trest_ptr self, void *data)
 		// XXX: update auth status of response?
 		pv_log(ERROR, "error parsing login handler response %s",
 		       response->body);
-		rv = 0;
 		goto err;
 	}
 

--- a/uboot.c
+++ b/uboot.c
@@ -203,9 +203,7 @@ static int uboot_set_env_key(char *key, char *value)
 	close(fd);
 	pv_fs_path_sync(path);
 
-	len = 0;
 	d = (char *)new;
-	s = (char *)old;
 	for (uint16_t i = 0; i < res; i++) {
 		if ((old[i] == 0xFF && old[i + 1] == 0xFF) ||
 		    (old[i] == '\0' && old[i + 1] == '\0'))
@@ -221,13 +219,11 @@ static int uboot_set_env_key(char *key, char *value)
 			d += len + 1;
 		}
 		i += len;
-		len = 0;
 	}
 
 	SNPRINTF_WTRUNC(v, sizeof(v), "%s=%s\0", key, value);
 
 	memcpy(d, v, strlen(v) + 1);
-	d += strlen(v) + 1;
 
 	fd = open(path, O_RDWR);
 	if (fd < 0) {
@@ -249,7 +245,7 @@ static int uboot_set_env_key(char *key, char *value)
 			       strerror(errno));
 	}
 	lseek(fd, 0, SEEK_SET);
-	res = write(fd, new, sizeof(new));
+	write(fd, new, sizeof(new));
 	fsync(fd);
 	close(fd);
 	pv_fs_path_sync(path);

--- a/updater.c
+++ b/updater.c
@@ -221,16 +221,15 @@ err:
 static void object_update_json(struct object_update *object_update,
 			       char *buffer, ssize_t buflen)
 {
-	buflen -= snprintf(buffer, buflen,
-			   "{\"object_name\":\"%s\""
-			   ",\"object_id\":\"%s\""
-			   ",\"total_size\":%" PRIu64 ",\"start_time\":%" PRIu64
-			   ",\"current_time\":%" PRIu64
-			   ",\"total_downloaded\":%" PRIu64 "}",
-			   object_update->object_name, object_update->object_id,
-			   object_update->total_size, object_update->start_time,
-			   object_update->current_time,
-			   object_update->total_downloaded);
+	snprintf(buffer, buflen,
+		 "{\"object_name\":\"%s\""
+		 ",\"object_id\":\"%s\""
+		 ",\"total_size\":%" PRIu64 ",\"start_time\":%" PRIu64
+		 ",\"current_time\":%" PRIu64 ",\"total_downloaded\":%" PRIu64
+		 "}",
+		 object_update->object_name, object_update->object_id,
+		 object_update->total_size, object_update->start_time,
+		 object_update->current_time, object_update->total_downloaded);
 }
 
 static int trail_remote_set_status(struct pantavisor *pv,
@@ -1625,7 +1624,7 @@ static int trail_download_object(struct pantavisor *pv, struct pv_object *obj,
 	if (use_volatile_tmp) {
 		pv_log(INFO, "copying %s to tmp path (%s)",
 		       volatile_tmp_obj_path, mmc_tmp_obj_path);
-		bytes = pv_fs_file_copy_fd(volatile_tmp_fd, obj_fd, true);
+		pv_fs_file_copy_fd(volatile_tmp_fd, obj_fd, true);
 		fd = obj_fd;
 	}
 	pv_log(DEBUG, "downloaded object to tmp path (%s)", mmc_tmp_obj_path);

--- a/utils/tsh.c
+++ b/utils/tsh.c
@@ -254,7 +254,6 @@ int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 			safe_fd_set(errfd[0], &master, &max_fd);
 			if ((ret = pselect(max_fd + 1, &master, NULL, NULL, &ts,
 					   &orig_mask)) < 0) {
-				ret = -1;
 				break;
 			}
 			if (!ret) {
@@ -270,7 +269,6 @@ int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 					out_size -= res;
 					out_i += res;
 				} else if (res < 0 && errno != EAGAIN) {
-					ret = -1;
 					break;
 				}
 				if (res == 0) {
@@ -284,7 +282,6 @@ int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 					err_size -= res;
 					err_i += res;
 				} else if (res < 0 && errno != EAGAIN) {
-					ret = -1;
 					break;
 				} else if (res == 0) {
 					break;

--- a/wdt.c
+++ b/wdt.c
@@ -37,9 +37,6 @@ int fd = -1;
 
 int pv_wdt_start(struct pantavisor *pv)
 {
-	int timeout = pv_config_get_watchdog_timeout();
-	int interval = pv_config_get_updater_interval();
-
 	if (!pv_config_get_watchdog_enabled())
 		return 0;
 
@@ -52,6 +49,7 @@ int pv_wdt_start(struct pantavisor *pv)
 		return -1;
 	}
 
+	int timeout = pv_config_get_watchdog_timeout();
 	ioctl(fd, WDIOC_SETTIMEOUT, &timeout);
 	ioctl(fd, WDIOC_GETTIMEOUT, &timeout);
 
@@ -61,8 +59,6 @@ int pv_wdt_start(struct pantavisor *pv)
 	pv_wdt_kick(pv);
 
 	pv_log(DEBUG, "watchdog opened with %ds timeout", timeout);
-	interval = timeout / 2;
-	pv_log(INFO, "clamping PH update interval to wdt/2 (%ds)", interval);
 
 	return 0;
 }


### PR DESCRIPTION
Remove some assignments detected as "never read"
Files:
* ctrl.c
* drivers.c
* grub.c
* logserver
* loop.c
* metadata.c
* network.c
* parser/parser_multi1.c
* parser/parser_system1.c
* ph_logger.c
* signature.c
* storage.c
* trestclient.c
* uboot.c
* updater.c
* utils/tsh.c
* wdt.c
