### PR TITLE
Remove all strcpy and some strcat from Pantavisor

### DIFF
--- a/grub.c
+++ b/grub.c
@@ -111,7 +111,7 @@ static int read_grubenv(char *path, char *buf, int writable)
 
 static char *grub_get_env_key(char *key)
 {
-	int fd, len, klen, vlen;
+	int fd, len, klen;
 	char buf[1024];
 	char *next, *value = NULL;
 
@@ -130,9 +130,7 @@ static char *grub_get_env_key(char *key)
 		buf[i] = '\0';
 
 		if (!strncmp(next, key, klen)) {
-			vlen = strlen(next + klen + 1);
-			value = calloc(vlen + 1, sizeof(char));
-			strcpy(value, next + klen + 1);
+			value = strdup(next + klen + 1);
 			break;
 		}
 		next = buf + i + 1;

--- a/logserver.c
+++ b/logserver.c
@@ -178,7 +178,7 @@ static int logserver_openlog(const char *path)
 	size_t max = 0;
 	for (size_t i = 0; i < glist.gl_pathc; ++i) {
 		char str[PATH_MAX] = { 0 };
-		strcpy(str, glist.gl_pathv[i]);
+		strncpy(str, glist.gl_pathv[i], PATH_MAX - 1);
 		str[strlen(str) - 3] = '\0';
 		size_t n = strtoumax(strrchr(str, '.') + 1, NULL, 10);
 		if (n > max)

--- a/metadata.c
+++ b/metadata.c
@@ -1009,7 +1009,7 @@ static int on_factory_meta_iterate(char *key, char *value, void *opaque)
 	char file[PATH_MAX];
 	char *fname = NULL;
 
-	strcpy(file, json_buf->factory_file);
+	strncpy(file, json_buf->factory_file, PATH_MAX - 1);
 	fname = basename(file);
 	SNPRINTF_WTRUNC(abs_key, sizeof(abs_key), "factory/%s/%s", fname, key);
 	formatted_key = pv_json_format(abs_key, strlen(abs_key));

--- a/network.c
+++ b/network.c
@@ -132,18 +132,24 @@ void pv_network_update_meta(struct pantavisor *pv)
 				family == AF_INET ? "ipv4" : "ipv6");
 		size = sizeof(IFACE_FMT) + strlen(ifn) + strlen(ifaddrs);
 		buf = calloc(size, sizeof(char));
+
+		size_t prev_len = len;
+
 		len += snprintf(buf, size, IFACE_FMT, ifn, ifaddrs);
 		len++;
 		ifaces = realloc(ifaces, len);
-		strcat(ifaces, buf);
+
+		if (ifa->ifa_next)
+			snprintf(ifaces + prev_len, size + 1, "%s,", buf);
+		else
+			snprintf(ifaces + prev_len, size + 1, "%s,", buf);
+
 		free(buf);
-		if (ifa->ifa_next != NULL)
-			strcat(ifaces, ",");
 	}
 	free(ifaddrs);
 
 	ifaces = realloc(ifaces, len + 1);
-	strcat(ifaces, "}");
+	ifaces[len] = '}';
 
 	pv_metadata_add_devmeta(DEVMETA_KEY_INTERFACES, ifaces);
 

--- a/pantahub.c
+++ b/pantahub.c
@@ -463,7 +463,7 @@ err:
 int pv_ph_device_is_owned(struct pantavisor *pv, char **c)
 {
 	int ret = 0;
-	char *owner = 0, *challenge = 0;
+	char *owner = 0;
 	trest_request_ptr req = 0;
 	trest_response_ptr res = 0;
 
@@ -495,17 +495,13 @@ int pv_ph_device_is_owned(struct pantavisor *pv, char **c)
 			goto out;
 		}
 
-		challenge = pv_json_get_value(res->body, "challenge",
-					      res->json_tokv, res->json_tokc);
-
-		strcpy(*c, challenge);
+		*c = pv_json_get_value(res->body, "challenge", res->json_tokv,
+				       res->json_tokc);
 	}
 
 out:
 	if (owner)
 		free(owner);
-	if (challenge)
-		free(challenge);
 	if (req)
 		trest_request_free(req);
 	if (res)

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -352,8 +352,6 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 	timer_start(&timer_updater_interval, pv_config_get_updater_interval(),
 		    0, RELATIV_TIMER);
 
-	c = calloc(128, sizeof(char));
-
 	pv_config_load_unclaimed_creds();
 
 	if (pv_config_get_creds_id() && strcmp(pv_config_get_creds_id(), "") &&
@@ -365,8 +363,6 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 					ph_state_string(PH_STATE_REGISTER));
 		if (!pv_ph_register_self(pv)) {
 			pv_ph_release_client(pv);
-			if (c)
-				free(c);
 			return PV_STATE_WAIT;
 		}
 		pv_config_save_creds();

--- a/pvctl_utils.c
+++ b/pvctl_utils.c
@@ -60,7 +60,7 @@ try_again:
 	memset(&addr, 0, sizeof(addr));
 	addr.sun_family = AF_UNIX;
 
-	strcpy(addr.sun_path, path);
+	strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
 
 	ret = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret < 0) {

--- a/uboot.c
+++ b/uboot.c
@@ -161,9 +161,7 @@ static char *uboot_get_env_key(char *key)
 			continue;
 
 		if (!strncmp(buf + k, key, n)) {
-			len = strlen(buf + k + n + 1);
-			value = calloc(len + 1, sizeof(char));
-			strcpy(value, buf + k + n + 1);
+			value = strdup(buf + k + n + 1);
 			break;
 		}
 		k = i + 1;

--- a/updater.c
+++ b/updater.c
@@ -106,16 +106,17 @@ static char *unescape_utf8_to_apvii(char *buf, char *code, char c)
 	int pos = 0, replaced = 0;
 	char *tmp;
 
-	tmp = malloc(strlen(buf) + strlen(code) + 1);
-	strcpy(tmp, buf);
-	strcat(tmp, code);
+	size_t tmp_sz = strlen(buf) + strlen(code) + 1;
+	tmp = calloc(tmp_sz, sizeof(char));
+	snprintf(tmp, tmp_sz, "%s%s", buf, code);
+
 	old = tmp;
 
 	p = strstr(tmp, code);
 	while (p) {
 		*p = '\0';
 		new = realloc(new, pos + strlen(tmp) + 2);
-		strcpy(new + pos, tmp);
+		snprintf(new + pos, strlen(tmp) + 1, "%s", tmp);
 		pos = pos + strlen(tmp);
 		new[pos] = c;
 		pos += 1;

--- a/utils/tsh.c
+++ b/utils/tsh.c
@@ -159,11 +159,9 @@ pid_t tsh_run_io(char *cmd, int wait, int *status, int stdin_p[],
 	char **args;
 	char *vcmd;
 
-	vcmd = malloc(strlen(cmd) + 1);
+	vcmd = strdup(cmd);
 	if (!vcmd)
 		return -1;
-
-	strcpy(vcmd, cmd);
 
 	args = _tsh_split_cmd(vcmd);
 	if (!args)
@@ -204,11 +202,9 @@ int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 	memset(outfd, -1, sizeof(outfd));
 	memset(errfd, -1, sizeof(errfd));
 
-	vcmd = malloc(strlen(cmd) + 1);
+	vcmd = strdup(cmd);
 	if (!vcmd)
 		goto out;
-
-	strcpy(vcmd, cmd);
 
 	args = _tsh_split_cmd(vcmd);
 	if (!args)


### PR DESCRIPTION
Replaces all `strcpy` calls with functions who provide boundaries check 