### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -105,6 +105,8 @@ static int pv_buffer_init_cache(int items, int size, struct dl_list *head)
 			free(item);
 		}
 	}
+
+	dl_list_init(head);
 	while (items > 0) {
 		struct buffer *buffer = NULL;
 

--- a/ctrl.c
+++ b/ctrl.c
@@ -602,11 +602,14 @@ out:
 		close(obj_fd);
 }
 
-static char *pv_ctrl_get_file_name(const char *path, int buf_index,
+static char *pv_ctrl_get_file_name(const char *path, size_t buf_index,
 				   size_t path_len)
 {
 	int len;
 	char *file_name;
+
+	if (buf_index > path_len)
+		return NULL;
 
 	len = path_len - buf_index;
 
@@ -1368,8 +1371,8 @@ static struct pv_cmd *pv_ctrl_read_parse_request(int req_fd)
 
 		// if character is 3 (old code for json command), it is non-HTTP
 		if (buf[0] == 3) {
-			pv_ctrl_process_cmd(
-				req_fd, HTTP_REQ_BUFFER_SIZE - 1, &cmd);
+			pv_ctrl_process_cmd(req_fd, HTTP_REQ_BUFFER_SIZE - 1,
+					    &cmd);
 			goto out;
 		} else if (buf[0] == 2) {
 			write(req_fd, UNSUPPORTED_LOG_COMMAND_FMT,

--- a/log.h
+++ b/log.h
@@ -30,7 +30,7 @@
 #include "pantavisor.h"
 #include <stdarg.h>
 
-void exit_error(int err, char *msg);
+void exit_error(int err, char *msg) __attribute__((__noreturn__));
 
 enum log_level {
 	FATAL, // 0

--- a/logserver.c
+++ b/logserver.c
@@ -374,6 +374,7 @@ static int pv_log(int level, char *msg, ...)
 			return 1;
 		vsnprintf(msg_data.data, msg_data.data_len, msg, args);
 		logserver_log_msg_data_stdout(&msg_data);
+		free(msg_data.data);
 
 	} else if (logserver_g.pid == 0) {
 		struct buffer *pv_buffer = pv_buffer_get(true);
@@ -565,7 +566,7 @@ static void logserver_fd_free(struct logserver_fd *lfd)
 
 static bool logserver_list_exists(struct dl_list *lst, int fd)
 {
-	struct logserver_fd *it, *tmp;
+	struct logserver_fd *it = NULL, *tmp = NULL;
 
 	dl_list_for_each_safe(it, tmp, lst, struct logserver_fd, list)
 	{
@@ -934,7 +935,8 @@ static void logserver_drop_fds(struct dl_list *lst)
 	struct logserver_fd *it, *tmp;
 	dl_list_for_each_safe(it, tmp, lst, struct logserver_fd, list)
 	{
-		logserver_remove_fd(it->fd);
+		logserver_epoll_del(it->fd);
+		dl_list_del(&it->list);
 		logserver_fd_free(it);
 	}
 }

--- a/mount.c
+++ b/mount.c
@@ -93,7 +93,7 @@ void pv_mount_umount(void)
 static int pv_mount_init(struct pv_init *this)
 {
 	struct stat st;
-	struct blkid_info dev_info;
+	struct blkid_info dev_info = { 0 };
 	char path[PATH_MAX];
 	int ret = -1;
 

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -280,6 +280,7 @@ struct pv_state *multi1_parse(struct pv_state *this, const char *buf)
 		goto out;
 	}
 	free(value);
+	value = NULL;
 
 	keys = jsmnutil_get_object_keys(buf, tokv);
 	k = keys;

--- a/signature.c
+++ b/signature.c
@@ -117,6 +117,7 @@ static void pv_signature_free_cert_raw(struct pv_signature_cert_raw *cert_raw)
 
 	if (cert_raw->content)
 		free(cert_raw->content);
+	free(cert_raw);
 }
 
 static void pv_signature_free_certs_raw(struct dl_list *certs_raw)
@@ -429,8 +430,6 @@ static bool pv_signature_get_certs_raw(const char *x5c,
 	int tokc, size;
 	jsmntok_t *tokv, *t;
 	struct pv_signature_cert_raw *cert_raw;
-
-	dl_list_init(certs_raw);
 
 	// x5c field is optional
 	if (!x5c)
@@ -841,6 +840,8 @@ static bool pv_signature_verify_pvs(struct pv_signature *signature,
 	struct pv_signature_headers *headers = NULL;
 	struct dl_list certs_raw; // pv_signature_cert_raw
 	mbedtls_md_type_t mdtype = MBEDTLS_MD_NONE;
+
+	dl_list_init(&certs_raw);
 
 	headers = pv_signature_parse_protected(signature->protected);
 	if (!headers) {

--- a/utils/base64.c
+++ b/utils/base64.c
@@ -82,6 +82,9 @@ int pv_base64_decode(const char *src, char **dst, size_t *olen)
 	ilen = strlen(src);
 	len = ((4 * ilen / 3) + 3) & ~3;
 
+	if (len < 1)
+		goto err;
+
 	*dst = calloc(len, sizeof(char));
 	if (!*dst)
 		goto err;


### PR DESCRIPTION
Different types of problems are included, problems with memory already freed, uninitialized variables, etc 