### PR TITLE
Set all warnings as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,7 @@
 # readability-* (?)
 #
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,clang-diagnostic-*,bugprone-*,clang-analyzer-*,-*,clang-analyzer-*,-clang-analyzer.cplusplus,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.Uninitialized'
-WarningsAsErrors: 'true'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,-*,clang-diagnostic-*,bugprone-*,clang-analyzer-*,-*,clang-analyzer-*,-clang-analyzer.cplusplus,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.Uninitialized'
 HeaderFilterRegex: './*.h'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none


### PR DESCRIPTION
Provides warning-as-errors functionality, without this PR only errors will make the CI fail