### PR TITLE
handle sigterm for appengine; exit with status 3 in case of poweroff

### DIFF
--- a/init.c
+++ b/init.c
@@ -156,7 +156,7 @@ static void signal_handler(int signal)
 
 static void shell_handler(int signal)
 {
-	if (signal != SIGINT)
+	if ((signal != SIGINT) && (signal != SIGTERM))
 		return;
 
 	struct pantavisor *pv = pv_get_instance();
@@ -395,6 +395,7 @@ int main(int argc, char *argv[])
 		// we are going to use this thread for pv
 		pv_pid = getpid();
 		signal(SIGINT, shell_handler);
+		signal(SIGTERM, shell_handler);
 		pv_start();
 		pv_stop();
 		return 0;

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -910,17 +910,18 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 
 	// at this point, we can shutdown if not in appengine
 	if (initmode != IM_APPENGINE) {
-		pv_log(INFO, "shutdown complete, rebooting in 2 second...");
+		pv_log(INFO, "shutdown complete, performing '%s' in 2 second...", shutdown_type_string(t));
 		sleep(2);
 		pv_remove(pv);
+		sync();
 		reboot(shutdown_type_reboot_cmd(t));
 	} else {
 		pv_log(INFO, "shutdown complete...");
 		pv_remove(pv);
+		sync();
+		if (t == POWEROFF)
+			exit(3);
 	}
-
-	// give it a final sync here...
-	sync();
 
 	return PV_STATE_EXIT;
 }


### PR DESCRIPTION
These changes only affect appengine and are needed by the pantavisor script (the that acts as the bootloader for appengine) to leave the infinite loop that emulate the reboot of the device