### PR TITLE
Fixes logs on non reboot updates for singlefile and filetree outputs

### DIFF
--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -155,6 +155,7 @@ static int pv_log(int level, char *msg, ...)
 			.tnano = 0,
 			.plat = MODULE_NAME,
 			.src = "logserver",
+			.rev = NULL,
 			.data.buf = NULL,
 			.data.len = 0,
 		};
@@ -181,6 +182,7 @@ static int pv_log(int level, char *msg, ...)
 			.tsec = timer_get_current_time_sec(RELATIV_TIMER),
 			.plat = PV_PLATFORM_STR,
 			.src = "logserver",
+			.rev = logserver.rev,
 			.data.buf = buf,
 			.data.len = buf_len
 		};
@@ -252,6 +254,7 @@ static int logserver_msg_parse_data(struct logserver_msg *msg,
 		log->plat = msg->buf + strlen(msg->buf) + 1;
 		bytes_read += strlen(log->plat) + 1;
 		log->src = log->plat + strlen(log->plat) + 1;
+		log->rev = logserver.rev;
 		bytes_read += strlen(log->src) + 1;
 
 		log->data.buf = log->src + strlen(log->src) + 1;
@@ -534,6 +537,7 @@ static void logserver_consume_fd(int fd)
 			.tsec = timer_get_current_time_sec(RELATIV_TIMER),
 			.plat = lfd->platform,
 			.src = lfd->src,
+			.rev = logserver.rev,
 			.data.buf = buffer->buf,
 			.data.len = size,
 		};

--- a/logserver/logserver_filetree.c
+++ b/logserver/logserver_filetree.c
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "paths.h"
 #include "utils/fs.h"
-#include "bootloader.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -37,9 +36,16 @@
 
 static char *create_dir(const struct logserver_log *log, bool is_pv)
 {
+	if (!log->rev) {
+		WARN_ONCE(
+			"Log with no revision (null) arrives to filetree output: %s",
+			log->data.buf);
+		return NULL;
+	}
+
 	char path[PATH_MAX];
-	pv_paths_pv_log_file(path, sizeof(path), pv_bootloader_get_rev(),
-			     log->plat, is_pv ? "pantavisor.log" : log->src);
+	pv_paths_pv_log_file(path, sizeof(path), log->rev, log->plat,
+			     is_pv ? "pantavisor.log" : log->src);
 
 	char *dup_path = strdup(path);
 	char *fname = dirname(path);

--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -55,6 +55,7 @@ struct logserver_log {
 	uint32_t tnano;
 	char *plat;
 	char *src;
+	char *rev;
 	struct logserver_data data;
 };
 

--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "paths.h"
 #include "utils/fs.h"
-#include "bootloader.h"
 
 #include <string.h>
 #include <linux/limits.h>
@@ -35,14 +34,20 @@
 
 static char *create_dir(const struct logserver_log *log)
 {
+	if (!log->rev) {
+		WARN_ONCE(
+			"Log with no revision (null) arrives to singlefile output: %s",
+			log->data.buf);
+		return NULL;
+	}
+
 	char path[PATH_MAX];
-	pv_paths_pv_log(path, sizeof(path), pv_bootloader_get_rev());
+	pv_paths_pv_log(path, sizeof(path), log->rev);
 
 	if (pv_fs_mkdir_p(path, 0755))
 		return NULL;
 
-	pv_paths_pv_log_plat(path, sizeof(path), pv_bootloader_get_rev(),
-			     "pv.log");
+	pv_paths_pv_log_plat(path, sizeof(path), log->rev, "pv.log");
 
 	return strdup(path);
 }


### PR DESCRIPTION
Problems: 
- logs aren't written in the right file
- the folder for the new revision are not created, but link to current was updated (and broken)

Now logserver_log include the revision, so the outputs don't need any logic to figure out the current rev.