### PR TITLE
Adds checks to only send stdout messages if stdout is set

### DIFF
--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -148,6 +148,10 @@ static int pv_log(int level, char *msg, ...)
 	va_start(args, msg);
 
 	if (logserver.pid < 0) {
+		if (!(pv_config_get_log_server_outputs() &
+		      LOG_SERVER_OUTPUT_STDOUT))
+			return 0;
+
 		struct logserver_log log = {
 			.ver = 0,
 			.lvl = level,
@@ -956,6 +960,10 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 	log.data.len = vsnprintf(log.data.buf, log.data.len, msg, args);
 
 	if (logserver.pid < 1) {
+		if (!(pv_config_get_log_server_outputs() &
+		      LOG_SERVER_OUTPUT_STDOUT))
+			return 0;
+
 		int len = logserver_utils_stdout(&log);
 		pv_buffer_drop(log_buf);
 		return len;


### PR DESCRIPTION
Changes the current behavior, now messages to stdout are sent only if stdout is set. In the current logserver implementation, if the server isn't present (still no active or already closed/killed) the messages are sent to stdout without check if stdout is active