### PR TITLE
support IM_APPENGINE mode as pid 1

### DIFF
--- a/init.c
+++ b/init.c
@@ -392,7 +392,8 @@ int main(int argc, char *argv[])
 	other_mounts();
 
 	// executed from shell and/or appengine mode
-	if (getpid() != 1) {
+	if (pv_config_get_system_init_mode() == IM_STANDALONE ||
+	    pv_config_get_system_init_mode() == IM_APPENGINE) {
 		// we are going to use this thread for pv
 		pv_pid = getpid();
 		signal(SIGINT, shell_handler);


### PR DESCRIPTION
Running an app in docker through Cmd or Entrypoint makes the process pid 1. This breaks appengine and this patch addresses that.

IM_STANDALONE is also supported for pid 1 for same reason