### PR TITLE
fix: excess found in error reply

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -378,7 +378,7 @@ static void pv_ctrl_write_error_response(int req_fd, pv_http_status_code_t code,
 	unsigned int content_len, response_len;
 	char *response = NULL;
 
-	content_len = 12 + // {\"Error\":\"%s\"}
+	content_len = 15 + // {\"Error\":\"%s\"}\r\n\0
 		      strlen(message);
 
 	response_len = 93 + // HTTP/1.1...


### PR DESCRIPTION
An excess of bytes warning is showing when Pantavisor returns an error because the trail characters of the body (\r\n\0) were not taken into account when calculating the Content-Length header:

== Info: We are completely uploaded and fine
<= Recv header, 27 bytes (0x1b)
0000: 48 54 54 50 2f 31 2e 31 20 34 30 30 20 42 61 64 HTTP/1.1 400 Bad
0010: 20 52 65 71 75 65 73 74 20 0d 0a                 Request ..
<= Recv header, 20 bytes (0x14)
0000: 43 6f 6e 74 65 6e 74 2d 4c 65 6e 67 74 68 3a 20 Content-Length:
0010: 33 34 0d 0a                                     34..
<= Recv header, 47 bytes (0x2f)
0000: 43 6f 6e 74 65 6e 74 2d 54 79 70 65 3a 20 61 70 Content-Type: ap
0010: 70 6c 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 3b 20 plication/json;
0020: 63 68 61 72 73 65 74 3d 75 74 66 2d 38 0d 0a    charset=utf-8..
<= Recv header, 2 bytes (0x2)
0000: 0d 0a                                           ..
<= Recv data, 37 bytes (0x25)
0000: 7b 22 45 72 72 6f 72 22 3a 22 53 74 65 70 20 6e {"Error":"Step n
0010: 61 6d 65 20 68 61 73 20 62 61 64 20 6e 61 6d 65 ame has bad name
0020: 22 7d 0d 0a 00                                  "}...
== Info: Excess found in a read: excess = 3, size = 34, maxdownload = 34, bytecount = 0
== Info: Closing connection 0