### PR TITLE
Add system.mdev option to load drivers using mdev

### DIFF
--- a/config.c
+++ b/config.c
@@ -350,6 +350,8 @@ static int pv_config_load_file(char *path, struct pantavisor_config *config)
 		&config_list, "system.mediadir", "/media");
 	config->sys.confdir = config_get_value_string(
 		&config_list, "system.confdir", "/configs");
+	config->sys.auto_load_drivers = config_get_value_bool(
+		&config_list, "system.drivers.load_early.auto", false);
 
 	config->policy = config_get_value_policy(&config_list, "policy", NULL);
 	if (pv_config_load_policy(config->policy, &config_list))
@@ -933,6 +935,11 @@ char *pv_config_get_system_confdir()
 	return pv_get_instance()->config.sys.confdir;
 }
 
+bool pv_config_get_system_early_driver_load()
+{
+	return pv_get_instance()->config.sys.auto_load_drivers;
+}
+
 bool pv_config_get_debug_shell()
 {
 	return pv_get_instance()->config.debug.shell;
@@ -1279,6 +1286,8 @@ char *pv_config_get_json()
 		pv_json_ser_string(&js, pv_config_get_system_mediadir());
 		pv_json_ser_key(&js, "system.confdir");
 		pv_json_ser_string(&js, pv_config_get_system_confdir());
+		pv_json_ser_key(&js, "system.drivers.load_early.auto");
+		pv_json_ser_bool(&js, pv_config_get_system_early_driver_load());
 		pv_json_ser_key(&js, "debug.shell");
 		pv_json_ser_bool(&js, pv_config_get_debug_shell());
 		pv_json_ser_key(&js, "debug.shell.autologin");
@@ -1446,6 +1455,8 @@ void pv_config_print()
 	pv_log(INFO, "system.usrdir = '%s'", pv_config_get_system_usrdir());
 	pv_log(INFO, "system.mediadir = '%s'", pv_config_get_system_mediadir());
 	pv_log(INFO, "system.configdir = '%s'", pv_config_get_system_confdir());
+	pv_log(INFO, "system.drivers.load_early.auto = %d",
+	       pv_config_get_system_early_driver_load());
 	pv_log(INFO, "debug.shell = %d", pv_config_get_debug_shell());
 	pv_log(INFO, "debug.shell.autologin = %d",
 	       pv_config_get_debug_shell_autologin());

--- a/config.h
+++ b/config.h
@@ -37,6 +37,7 @@ struct pantavisor_system {
 	char *rundir;
 	char *mediadir;
 	char *confdir;
+	bool auto_load_drivers;
 };
 
 struct pantavisor_debug {
@@ -241,6 +242,7 @@ char *pv_config_get_system_usrdir(void);
 char *pv_config_get_system_rundir(void);
 char *pv_config_get_system_mediadir(void);
 char *pv_config_get_system_confdir(void);
+bool pv_config_get_system_early_driver_load(void);
 
 bool pv_config_get_debug_shell(void);
 bool pv_config_get_debug_shell_autologin(void);

--- a/drivers.h
+++ b/drivers.h
@@ -45,6 +45,7 @@ int pv_drivers_state(char *match);
 char *pv_drivers_state_all(struct pv_platform *p);
 int pv_drivers_load(char *match);
 int pv_drivers_unload(char *match);
+void pv_drivers_load_early(void);
 
 struct pv_driver *pv_drivers_add(struct pv_state *s, char *alias, int len,
 				 char **modules);

--- a/init.c
+++ b/init.c
@@ -51,6 +51,7 @@
 #include "debug.h"
 #include "cgroup.h"
 #include "wdt.h"
+#include "drivers.h"
 
 #include "utils/tsh.h"
 #include "utils/math.h"
@@ -376,6 +377,12 @@ int main(int argc, char *argv[])
 
 	// this might override the configuration
 	parse_commands(argc, argv);
+
+	// loading drivers for both modes
+	if (pv_config_get_system_init_mode() == IM_EMBEDDED ||
+	    pv_config_get_system_init_mode() == IM_STANDALONE) {
+		pv_drivers_load_early();
+	}
 
 	// in case of standalone is set, we only start debugging tools up in main thread
 	if (pv_config_get_system_init_mode() == IM_STANDALONE) {

--- a/volumes.c
+++ b/volumes.c
@@ -556,8 +556,10 @@ int pv_volumes_mount_firmware_modules()
 	if (!firmware)
 		goto modules;
 
-	if ((stat(FW_PATH, &st) < 0) && errno == ENOENT)
-		pv_fs_mkdir_p(FW_PATH, 0755);
+	if (pv_fs_path_remove(FW_PATH, true) != 0)
+		pv_log(WARN, "couldn't remove initial firmware");
+
+	pv_fs_mkdir_p(FW_PATH, 0755);
 
 	if (strchr(firmware, '/')) {
 		pv_paths_root_file(path_volumes, PATH_MAX,
@@ -602,6 +604,9 @@ modules:
 
 	if (!uname(&uts) && (stat(path_volumes, &st) == 0)) {
 		pv_paths_lib_modules(path_lib, PATH_MAX, uts.release);
+		if (pv_fs_path_remove(path_lib, true) != 0)
+			pv_log(WARN, "couldn't remove initial modules");
+
 		pv_fs_mkdir_p(path_lib, 0755);
 		ret = mount_bind(path_volumes, path_lib);
 		pv_log(DEBUG, "bind mounted %s modules to %s", path_volumes,


### PR DESCRIPTION
- Adds interface to load/unload a single driver
- Adds support to load drivers on early stage for standalone and embedded modes
- Cleans initial modules and fw

