### PR TITLE
fix: various unnecesary WARN messages in pv logs

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -984,7 +984,8 @@ static int do_action_for_roles_array(struct json_key_action *jka, char *value)
 	       (*bundle->platform)->name);
 	if (!strcmp(value, "mgmt"))
 		pv_platform_set_role(*bundle->platform, PLAT_ROLE_MGMT);
-	else
+	// we allow "nobody" as a role, does not need further action
+	else if (strcmp(value, "nobody"))
 		pv_log(WARN, "invalid role value '%s'", value);
 
 	ret = 0;

--- a/platforms.c
+++ b/platforms.c
@@ -578,7 +578,7 @@ void pv_platforms_add_all_loggers(struct pv_state *s)
 		}
 
 		if (plat_needs_default_logger) {
-			char logger_name[32] = { 0 };
+			char logger_name[64] = { 0 };
 			/*
 			 * The name key is at index 3
 			 * */
@@ -1027,9 +1027,10 @@ plat_goal_state_t pv_platform_check_goal(struct pv_platform *p)
 {
 	if (p->status.current == p->status.goal)
 		return PLAT_GOAL_ACHIEVED;
-
-	if (p->status.current < PLAT_STARTING)
+	else if (p->status.current < PLAT_STARTING)
 		return PLAT_GOAL_UNACHIEVED;
+	else if (p->status.current >= p->status.goal)
+		return PLAT_GOAL_NONE;
 
 	struct timer_state tstate = timer_current_state(&p->timer_status_goal);
 	if (tstate.fin) {

--- a/storage.c
+++ b/storage.c
@@ -568,7 +568,7 @@ bool pv_storage_is_revision_local(const char *rev)
 	}
 
 	if (strncmp(rev, PREFIX_LOCAL_REV, pre_len)) {
-		pv_log(WARN, "revision name does not start with %s",
+		pv_log(INFO, "revision name does not start with %s",
 		       PREFIX_LOCAL_REV);
 		goto out;
 	}


### PR DESCRIPTION
List of changes:
* HTTP CONTINUE wrongly logging response not sent
* "nobody" now is accepted as a valid role by parser
* platforms do not check goal timeout after READY
* allocated bigger buffer for logger_name
* revision not starting with /locals is now just an INFO log
* pv_ctrl_flush_req renamed to pv_ctrl_consume_req