### PR TITLE
fix: cgroup stays untouched after pantavisor shutdown

### DIFF
--- a/cgroup.h
+++ b/cgroup.h
@@ -43,4 +43,6 @@ void pv_cgroup_umount(void);
 
 char *pv_cgroup_get_process_name(pid_t pid);
 
+void pv_cgroup_destroy(const char *name);
+
 #endif /* UTILS_CGROUP_H_ */

--- a/platforms.c
+++ b/platforms.c
@@ -926,6 +926,7 @@ void pv_platform_force_stop(struct pv_platform *p)
 	pv_log(DEBUG, "force stopping platform '%s'", p->name);
 	kill(p->init_pid, SIGKILL);
 	pv_platform_set_status(p, PLAT_STOPPED);
+	pv_cgroup_destroy(p->name);
 }
 
 void pv_platform_set_installed(struct pv_platform *p)


### PR DESCRIPTION
I appengine, it has been observed that the cgroup that lxc created are sometimes left hanging after we shut it down from the lxc api. This provokes that the next time that container is  started, lxc assigns the same name with a suffix (for example, pvr-sdk-1). To solve this, we can check if the dir is still there after stopping a container and remove it manually as stated in cgroup docs https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#processes.

For now, this is limited to appengine and to cgroup unified, as those are the conditions under the problem was discovered, but it could be expanded in the future if in happens outside of either appengine or unified.

