### PR TITLE
fix: cgroup deny not allowed in unified

### DIFF
--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -207,6 +207,28 @@ static int pv_setup_config_bindmounts(struct lxc_container *c, char *srcdir,
 	return 1;
 }
 
+static void pv_setup_lxc_container_cgroup(struct lxc_container *c)
+{
+	// only for cgroup unified
+	if (__pv_get_instance()->cgroupv != CGROUP_UNIFIED)
+		return;
+
+	// XXX: this might change with LXC 5.0, as we might be able to support the original lxc.conf
+
+	char value[PATH_MAX];
+
+	// remove all ilegacy cgroup allow and deny config
+	while (c->get_config_item(c, "lxc.cgroup.devices.allow", value, PATH_MAX) > 0) {
+		c->set_config_item(c, "lxc.cgroup.devices.allow", NULL);
+	}
+	while (c->get_config_item(c, "lxc.cgroup.devices.deny", value, PATH_MAX) > 0) {
+		c->set_config_item(c, "lxc.cgroup.devices.deny", NULL);
+	}
+
+	// substitute it with cgroup2 allow a
+	c->set_config_item(c, "lxc.cgroup2.devices.allow", "a");
+}
+
 static void pv_setup_lxc_container(struct lxc_container *c,
 				   struct pv_platform *p, const char *rev)
 {
@@ -228,12 +250,7 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 			 pv_lxc_get_lxc_log_level());
 		c->set_config_item(c, "lxc.log.level", log_level);
 	}
-	// cgroup version lxc config
-	c->get_config_item(c, "lxc.cgroup.devices.allow", path, PATH_MAX);
-	if ((__pv_get_instance()->cgroupv == CGROUP_UNIFIED) && strlen(path)) {
-		c->set_config_item(c, "lxc.cgroup.devices.allow", NULL);
-		c->set_config_item(c, "lxc.cgroup2.devices.allow", path);
-	}
+	pv_setup_lxc_container_cgroup(c);
 	// role specific lxc config
 	if (p->roles & PLAT_ROLE_MGMT) {
 		__pv_paths_pv_file(path, PATH_MAX, "");


### PR DESCRIPTION
This is a workaround to get some lxc configs work in cgroup v2. Traditionally, we were just switching from lxc.cgroup.devices.allow = a to lxc.cgroup2.devices.allow = a from the lxc plugin. This does not work well with lxc.cgroup.devices.deny = a, as lxc.cgroup2.devices.deny = a does not work well.

With this patch, only in case of cgroup v2, we remove all lxc.cgroup.devices.deny and lxc.cgroup.devices.allow we find, and substitute it with lxc.cgroup.devices.allow= a.

This might change after the LXC 5.0 upgrade, as this issue sugges that it could fix it https://github.com/lxc/lxc/issues/4293