### PR TITLE
fix: crypt LD_LIBRARY_PATH for appengine

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -37,7 +37,7 @@ MNT_OPTS_EXT4=${MNT_OPTS_EXT4:-"-o noatime"}
 PATH=$PATH:/lib/pv/:/lib/pv/volmount/crypt/
 export PATH
 
-export LD_LIBRARY_PATH=/x86_64-linux-gnu
+export LD_LIBRARY_PATH="/x86_64-linux-gnu:$LD_LIBRARY_PATH"
 
 # do the same as losetup -f but also return the path of loop device on stdout
 # if successful.


### PR DESCRIPTION
In appengine, lib paths might vary, so this patch fixes the LD_LIBRARY_PATH assignation we make in the crypt script.