### PR TITLE
new config key to disable missing drivers failure

### DIFF
--- a/config.c
+++ b/config.c
@@ -211,6 +211,22 @@ static int config_get_value_sb_mode_type(struct dl_list *config_list, char *key,
 	return value;
 }
 
+static drivers_mode_t config_get_value_d_mode_type(struct dl_list *config_list, char *key, drivers_mode_t default_value)
+{
+	char *item = config_get_value(config_list, key);
+	drivers_mode_t value = default_value;
+
+	if (!item)
+		return value;
+
+	if (!strcmp(item, "audit"))
+		value = D_AUDIT;
+	else if (!strcmp(item, "strict"))
+		value = D_STRICT;
+
+	return value;
+}
+
 static void config_override_value_string(struct dl_list *config_list, char *key,
 					 char **out)
 {
@@ -458,6 +474,9 @@ static int pv_config_load_file(char *path, struct pantavisor_config *config)
 		&config_list, "secureboot.checksum", true);
 	config->secureboot.handlers = config_get_value_bool(
 		&config_list, "secureboot.handlers", true);
+
+	config->drivers.mode = config_get_value_d_mode_type(
+		&config_list, "drivers.mode", D_STRICT);
 
 	config_iterate_items_prefix(&config_list, config_sysctl_apply,
 				    "sysctl.", NULL);
@@ -1228,6 +1247,11 @@ int pv_config_get_metadata_devmeta_interval()
 int pv_config_get_metadata_usrmeta_interval()
 {
 	return pv_get_instance()->config.metadata.usrmeta_interval;
+}
+
+drivers_mode_t pv_config_get_drivers_mode()
+{
+	return pv_get_instance()->config.drivers.mode;
 }
 
 char *pv_config_get_json()

--- a/config.h
+++ b/config.h
@@ -186,6 +186,15 @@ struct pantavisor_metadata {
 	int usrmeta_interval;
 };
 
+typedef enum {
+	D_AUDIT,
+	D_STRICT
+} drivers_mode_t;
+
+struct pantavisor_drivers {
+	drivers_mode_t mode;
+};
+
 struct pantavisor_config {
 	char *policy;
 	struct pantavisor_system sys;
@@ -205,6 +214,7 @@ struct pantavisor_config {
 	struct pantavisor_libthttp libthttp;
 	struct pantavisor_secureboot secureboot;
 	struct pantavisor_metadata metadata;
+	struct pantavisor_drivers drivers;
 };
 
 int pv_config_init(char *path);
@@ -326,6 +336,8 @@ bool pv_config_get_secureboot_handlers(void);
 
 int pv_config_get_metadata_devmeta_interval(void);
 int pv_config_get_metadata_usrmeta_interval(void);
+
+drivers_mode_t pv_config_get_drivers_mode(void);
 
 char *pv_config_get_json(void);
 void pv_config_print(void);

--- a/state.c
+++ b/state.c
@@ -565,7 +565,8 @@ static int pv_state_start_platform(struct pv_state *s, struct pv_platform *p)
 	if (pv_platform_load_drivers(p, NULL,
 				     DRIVER_REQUIRED | DRIVER_OPTIONAL) < 0) {
 		pv_log(ERROR, "failed to load drivers");
-		return -1;
+		if (pv_config_get_drivers_mode() == D_STRICT)
+			return -1;
 	}
 
 	if (pv_platform_start(p)) {


### PR DESCRIPTION
This new config key is named "drivers.mode" and has two possible values: "strict" (default) or "audit". The first one will keep the behavior as it was, while the second will show driver errors in logs but will continue with the revision starting process.