### PR TITLE
alow empty aliases in bsp/drivers.json

### DIFF
--- a/drivers.c
+++ b/drivers.c
@@ -247,17 +247,18 @@ static int _pv_drivers_set(char *match, mod_action_t action)
 		if (changed != len) {
 			pv_log(WARN,
 			       "not all modules were loaded/unloaded correctly");
-			changed = false;
+			return -1;
 		}
 		if (!changed)
-			continue;
+			return 0;
 		if (action == MOD_LOAD)
 			d->loaded = true;
 		else
 			d->loaded = false;
+		return changed;
 	}
 
-	return changed;
+	return 0;
 }
 
 int pv_drivers_load(char *match)

--- a/platforms.c
+++ b/platforms.c
@@ -675,8 +675,7 @@ int pv_platform_load_drivers(struct pv_platform *p, char *namematch,
 
 		switch (d->type) {
 		case DRIVER_REQUIRED:
-			d->loaded = pv_drivers_load(d->match);
-			if (!d->loaded) {
+			if (pv_drivers_load(d->match) < 0) {
 				pv_log(ERROR,
 				       "unable to load required driver '%s'",
 				       d->match);
@@ -684,11 +683,10 @@ int pv_platform_load_drivers(struct pv_platform *p, char *namematch,
 			}
 			break;
 		case DRIVER_OPTIONAL:
-			d->loaded = pv_drivers_load(d->match);
+			pv_drivers_load(d->match);
 			break;
 		case DRIVER_MANUAL:
-			d->loaded = pv_drivers_load(d->match);
-			if (!d->loaded) {
+			if (pv_drivers_load(d->match) < 0) {
 				pv_log(ERROR,
 				       "unable to load manual driver '%s'",
 				       d->match);


### PR DESCRIPTION
With this patch, we allow empty aliases en drivers.json:
* pv_drivers_load iterates over the aliases and only evaluates the one that matches, stopping the loop after that
* pv_drivers_load now returns -1 in case of mismatch in the number of loaded and required
* pv_drivers_load can return valid counts from 0 to N
* parser does not fail if bsp/run.json is present in appengine mode
* parser still does not parse the contents of bsp/run.json, but can parse drivers.json
Before this PR, empty aliases would fail if required from a run.json:
```
{
  ...
    "drivers": {
    "manual": [
      "wifi",
      "wireguard"
    ],
    "optional": [],
    "required": [
      "bluetooth"
    ]
  },
  ...
}
```
In drivers.json:
```
{
  "#spec": "driver-aliases@1",
  "all": {
    "bluetooth": [],
    "usbncm": [],
    "usbnet": [],
    "wifi": [],
    "wireguard": []
  },
  "dtb:all": {}
}
```
That would make _pv_drivers_set return 0 and thus fail