### PR TITLE
add wdt startup and always operation modes

### DIFF
--- a/config.h
+++ b/config.h
@@ -119,8 +119,16 @@ struct pantavisor_bootloader {
 	char *ovl;
 };
 
+typedef enum {
+	WDT_DISABLED,
+	WDT_SHUTDOWN,
+	WDT_STARTUP,
+	WDT_ALWAYS,
+} wdt_mode_t;
+
 struct pantavisor_watchdog {
 	bool enabled;
+	wdt_mode_t mode;
 	int timeout;
 };
 
@@ -292,6 +300,7 @@ bool pv_config_get_bl_mtd_only(void);
 char *pv_config_get_bl_mtd_path(void);
 
 bool pv_config_get_watchdog_enabled(void);
+wdt_mode_t pv_config_get_watchdog_mode(void);
 int pv_config_get_watchdog_timeout(void);
 
 char *pv_config_get_network_brdev(void);

--- a/wdt.h
+++ b/wdt.h
@@ -25,6 +25,8 @@
 #include "pantavisor.h"
 
 int pv_wdt_start(struct pantavisor *pv);
+void pv_wdt_stop(struct pantavisor *pv);
+
 void pv_wdt_kick(struct pantavisor *pv);
 
 #endif // PV_WDT_H


### PR DESCRIPTION
This PR adds a new config key named "wdt.mode" with four possible options:
* disabled: same as old wdt.enabled=0
* shutdown (default): same as old wdt.enabled=1
* startup: the watchdog will be pinged from initialization till the first container is started
* always: the watchdog will be pinged during all Pantavisor operation

This relies on this old kick call that is performed before progressing to any state:

```
static pv_state_t _pv_run_state(pv_state_t state, struct pantavisor *pv)                                              
{
    pv_wdt_kick(pv);
    return state_table[state](pv);                                                                                    
}
```

And assumes that wdt.timeout will be configured with a value that is bigger than any possible state transition.

