### PR TITLE
Improve WONTGO status message

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -93,6 +93,8 @@
 static const size_t HTTP_REQ_BUFFER_SIZE = 4096;
 static const unsigned int HTTP_REQ_NUM_HEADERS = 8;
 
+static const unsigned int HTTP_ERROR_RESPONSE_MSG_SIZE = 256;
+
 typedef enum {
 	HTTP_STATUS_BAD_REQ,
 	HTTP_STATUS_FORBIDDEN,
@@ -837,6 +839,7 @@ pv_ctrl_process_endpoint_and_reply(int req_fd, const char *method,
 	char *driverkey = NULL, *drivervalue = NULL;
 	char *drivername = NULL;
 	char *driverop = NULL;
+	char msg[HTTP_ERROR_RESPONSE_MSG_SIZE];
 	struct pv_platform *p = pv_ctrl_get_sender_plat(pname);
 	struct stat st;
 
@@ -1088,12 +1091,13 @@ pv_ctrl_process_endpoint_and_reply(int req_fd, const char *method,
 						     expect_continue,
 						     file_path) < 0)
 				goto out;
-			if (!pv_storage_verify_state_json(file_name)) {
+			if (!pv_storage_verify_state_json(
+				    file_name, msg,
+				    HTTP_ERROR_RESPONSE_MSG_SIZE)) {
 				pv_log(ERROR, "state verification went wrong");
 				pv_ctrl_write_error_response(
 					req_fd,
-					HTTP_STATUS_UNPROCESSABLE_ENTITY,
-					"State verification has failed");
+					HTTP_STATUS_UNPROCESSABLE_ENTITY, msg);
 				pv_storage_rm_rev(file_name);
 				goto out;
 			}

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -225,7 +225,7 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	} else {
 		// after a reboot...
 		json = pv_storage_get_state_json(pv_bootloader_get_rev());
-		if (!pv_signature_verify(json)) {
+		if (pv_signature_verify(json) != SIGN_STATE_OK) {
 			pv_log(ERROR,
 			       "state signature verification went wrong");
 			goto out;

--- a/signature.h
+++ b/signature.h
@@ -24,6 +24,15 @@
 
 #include "state.h"
 
-bool pv_signature_verify(const char *json);
+typedef enum {
+	SIGN_STATE_OK = 0,
+	SIGN_STATE_NOK_INTERNAL,
+	SIGN_STATE_NOK_UNCOVERED,
+	SIGN_STATE_NOK_VALIDATION
+} sign_state_res_t;
+
+const char *pv_signature_sign_state_str(sign_state_res_t sres);
+
+sign_state_res_t pv_signature_verify(const char *json);
 
 #endif // PV_SIGNATURE_H

--- a/storage.h
+++ b/storage.h
@@ -36,7 +36,8 @@ struct pv_path {
 };
 
 char *pv_storage_get_state_json(const char *rev);
-bool pv_storage_verify_state_json(const char *rev);
+bool pv_storage_verify_state_json(const char *rev, char *msg,
+				  unsigned int msg_len);
 
 void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev);
 void pv_storage_set_rev_progress(const char *rev, const char *progress);

--- a/updater.h
+++ b/updater.h
@@ -30,6 +30,8 @@
 #define DEVICE_STEP_ENDPOINT_FMT "/trails/%s/steps/%s/progress"
 #define DEVICE_STEP_STATUS_FMT                                                 \
 	"{ \"status\" : \"%s\", \"status-msg\" : \"%s\", \"progress\" : %d }"
+#define DEVICE_STEP_STATUS_WONTGO_FMT                                          \
+	"{ \"status\" : \"WONTGO\", \"status-msg\" : \"%s: %s\", \"progress\" : %d }"
 #define DEVICE_STEP_STATUS_FMT_WITH_DATA                                       \
 	"{ \"status\" : \"%s\", \"status-msg\" : \"%s\", \"progress\" : %d ,\"data\":\"%d\"}"
 #define DEVICE_STEP_STATUS_FMT_PROGRESS_DATA                                   \
@@ -54,7 +56,7 @@
 
 #define UPDATE_PROGRESS_FREQ (3) /*3 seconds for update*/
 
-enum update_state {
+enum update_status {
 	UPDATE_INIT,
 	UPDATE_ABORTED,
 	UPDATE_QUEUED,
@@ -68,7 +70,8 @@ enum update_state {
 	UPDATE_DONE,
 	UPDATE_FAILED,
 	UPDATE_NO_DOWNLOAD,
-	UPDATE_NO_SIGNATURE,
+	UPDATE_NO_SPACE,
+	UPDATE_BAD_SIGNATURE,
 	UPDATE_NO_PARSE,
 	UPDATE_RETRY_DOWNLOAD,
 	UPDATE_TESTING_REBOOT,
@@ -86,7 +89,7 @@ struct object_update {
 };
 
 struct pv_update {
-	enum update_state status;
+	enum update_status status;
 	char *endpoint;
 	int progress_size;
 	struct timer retry_timer;
@@ -124,6 +127,6 @@ bool pv_update_is_transitioning(struct pv_update *u);
 bool pv_update_is_trying(struct pv_update *u);
 bool pv_update_is_testing(struct pv_update *u);
 
-int pv_update_set_status(struct pantavisor *pv, enum update_state status);
+int pv_update_set_status(struct pantavisor *pv, enum update_status status);
 
 #endif


### PR DESCRIPTION
This is the first delivery in the [improvements of update error reports](https://hackmd.io/33RAIpSSS6SOGj2lDTyAfQ).

Here, we are expand the information given in status-msg in the progress JSON, which can be accessed by `pvcontrol steps show-progress` and `pvcontrol post` commands, following this table:

| Before | After |
| ------ | ----- |
State signatures cannot be verified | Secureboot: State not fully covered by signatures |
State signatures cannot be verified | Secureboot: Signature validation failed |
State cannot be parsed | Parser: State JSON has bad format |
Update aborted | PH Client: Update aborted |
Unable to download and/or install update | PH Client: Max download retries reached |
Space required X B, available Y B | PH Client: Space required X B, available Y B |