### PR TITLE
Adds timestamp in singlefile json log

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -48,6 +48,7 @@ LOCAL_SRC_FILES := debug.c \
 			loop.c \
 			logger.c \
 			log.c \
+			logserver/logserver_timestamp.c \
 			logserver/logserver_utils.c \
 			logserver/logserver_out.c \
 			logserver/logserver_singlefile.c \

--- a/config.c
+++ b/config.c
@@ -468,6 +468,12 @@ static int pv_config_load_file(char *path, struct pantavisor_config *config)
 				     &config->log.logdir);
 	config->log.dmesg =
 		config_get_value_bool(&config_list, "log.capture.dmesg", false);
+	config->log.ts_filetree_fmt = config_get_value_string(
+		&config_list, "log.filetree.timestamp.format", NULL);
+	config->log.ts_singlefile_fmt = config_get_value_string(
+		&config_list, "log.singlefile.timestamp.format", NULL);
+	config->log.ts_stdout_fmt = config_get_value_string(
+		&config_list, "log.stdout.timestamp.format", NULL);
 
 	config->libthttp.loglevel =
 		config_get_value_int(&config_list, "libthttp.log.level", 3);
@@ -818,6 +824,13 @@ void pv_config_free()
 
 	if (pv->config.log.logdir)
 		free(pv->config.log.logdir);
+
+	if (pv->config.log.ts_filetree_fmt)
+		free(pv->config.log.ts_filetree_fmt);
+	if (pv->config.log.ts_singlefile_fmt)
+		free(pv->config.log.ts_singlefile_fmt);
+	if (pv->config.log.ts_stdout_fmt)
+		free(pv->config.log.ts_stdout_fmt);
 
 	if (pv->config.net.brdev)
 		free(pv->config.net.brdev);
@@ -1200,6 +1213,18 @@ bool pv_config_get_log_stdout()
 {
 	return pv_get_instance()->config.log.std_out;
 }
+char *pv_config_get_log_filetree_timestamp_format()
+{
+	return pv_get_instance()->config.log.ts_filetree_fmt;
+}
+char *pv_config_get_log_singlefile_timestamp_format()
+{
+	return pv_get_instance()->config.log.ts_singlefile_fmt;
+}
+char *pv_config_get_log_stdout_timestamp_format()
+{
+	return pv_get_instance()->config.log.ts_stdout_fmt;
+}
 int pv_config_get_log_server_outputs()
 {
 	return pv_get_instance()->config.log.server.outputs;
@@ -1445,6 +1470,15 @@ char *pv_config_get_json()
 		pv_json_ser_bool(&js, pv_config_get_log_loggers());
 		pv_json_ser_key(&js, "log.stdout");
 		pv_json_ser_bool(&js, pv_config_get_log_stdout());
+		pv_json_ser_key(&js, "log.filetree.timestamp.format");
+		pv_json_ser_string(
+			&js, pv_config_get_log_filetree_timestamp_format());
+		pv_json_ser_key(&js, "log.singlefile.timestamp.format");
+		pv_json_ser_string(
+			&js, pv_config_get_log_singlefile_timestamp_format());
+		pv_json_ser_key(&js, "log.stdout.timestamp.format");
+		pv_json_ser_string(&js,
+				   pv_config_get_log_stdout_timestamp_format());
 		pv_json_ser_key(&js, "log.server.outputs");
 		pv_json_ser_number(&js, pv_config_get_log_server_outputs());
 		pv_json_ser_key(&js, "libthttp.log.level");
@@ -1574,6 +1608,13 @@ void pv_config_print()
 	       pv_config_get_log_capture_dmesg());
 	pv_log(INFO, "log.loggers = %d", pv_config_get_log_loggers());
 	pv_log(INFO, "log.stdout = %d", pv_config_get_log_stdout());
+
+	pv_log(INFO, "log.filetree.timestamp.format = %s",
+	       pv_config_get_log_filetree_timestamp_format());
+	pv_log(INFO, "log.singlefile.timestamp.format = %s",
+	       pv_config_get_log_singlefile_timestamp_format());
+	pv_log(INFO, "log.stdout.timestamp.format = %s",
+	       pv_config_get_log_stdout_timestamp_format());
 	pv_log(INFO, "log.server.outputs = %d",
 	       pv_config_get_log_server_outputs());
 	pv_log(INFO, "libthttp.loglevel = %d",

--- a/config.h
+++ b/config.h
@@ -161,6 +161,9 @@ struct pantavisor_log {
 	bool dmesg;
 	bool loggers;
 	bool std_out;
+	char *ts_filetree_fmt;
+	char *ts_singlefile_fmt;
+	char *ts_stdout_fmt;
 	struct pantavisor_log_server server;
 };
 
@@ -319,6 +322,9 @@ bool pv_config_get_log_push(void);
 bool pv_config_get_log_capture(void);
 bool pv_config_get_log_loggers(void);
 bool pv_config_get_log_stdout(void);
+char *pv_config_get_log_filetree_timestamp_format(void);
+char *pv_config_get_log_singlefile_timestamp_format(void);
+char *pv_config_get_log_stdout_timestamp_format(void);
 
 char *pv_config_get_libthttp_certdir(void);
 int pv_config_get_libthttp_loglevel(void);

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -153,6 +153,7 @@ static int pv_log(int level, char *msg, ...)
 			.lvl = level,
 			.tsec = timer_get_current_time_sec(RELATIV_TIMER),
 			.tnano = 0,
+			.time = time(NULL),
 			.plat = MODULE_NAME,
 			.src = "logserver",
 			.rev = NULL,
@@ -181,6 +182,7 @@ static int pv_log(int level, char *msg, ...)
 			.code = LOG_PROTOCOL_LEGACY,
 			.lvl = level,
 			.tsec = timer_get_current_time_sec(RELATIV_TIMER),
+			.time = time(NULL),
 			.plat = PV_PLATFORM_STR,
 			.src = "logserver",
 			.rev = logserver.rev,
@@ -251,7 +253,7 @@ static int logserver_msg_parse_data(struct logserver_msg *msg,
 		log->data.len = msg->len - bytes_read;
 		log->tsec = timer_get_current_time_sec(RELATIV_TIMER);
 		log->tnano = 0;
-		ret = 0;
+		log->time = time(NULL), ret = 0;
 		break;
 	default:
 		pv_log(WARN, "got unkown logserver message version %d",
@@ -558,6 +560,7 @@ static void logserver_consume_fd(int fd)
 			.code = LOG_PROTOCOL_LEGACY,
 			.lvl = lfd->lvl,
 			.tsec = timer_get_current_time_sec(RELATIV_TIMER),
+			.time = time(NULL),
 			.plat = lfd->platform,
 			.src = lfd->src,
 			.rev = logserver.rev,
@@ -960,6 +963,7 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 		.lvl = level,
 		.tsec = timer_get_current_time_sec(RELATIV_TIMER),
 		.tnano = 0,
+		.time = time(NULL),
 		.plat = platform,
 		.src = src,
 	};

--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <time.h>
 
 #define LOGSERVER_LOG_PROTOCOL_V1 0
 
@@ -58,6 +59,7 @@ struct logserver_log {
 	int lvl;
 	uint64_t tsec;
 	uint32_t tnano;
+	time_t time;
 	char *plat;
 	char *src;
 	char *rev;

--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -70,7 +70,7 @@ static int add_log(struct logserver_out *out, const struct logserver_log *log)
 	}
 
 	char *json = logserver_utils_jsonify_log(log);
-	int len = dprintf(fd, "%s", json);
+	int len = dprintf(fd, "%s\n", json);
 
 	close(fd);
 	free(json);

--- a/logserver/logserver_timestamp.c
+++ b/logserver/logserver_timestamp.c
@@ -1,0 +1,54 @@
+#include "logserver_timestamp.h"
+
+#include <string.h>
+
+struct time_format {
+	char *name;
+	char *fmt;
+};
+
+struct time_format formats[] = {
+	{ "golang:Layout", "%m/%d %H:%M:%S%p '%y %z" },
+	{ "golang:RubyDate", "%a %b %d %T %z %Y" },
+	{ "golang:ANSIC", "%a %b _%d %T %Y" },
+	{ "golang:RFC822Z", "%d %b %y %H:%M %z" },
+	{ "golang:RFC1123Z", "%a, %d %b %Y %T %z" },
+};
+
+#define LOGSERVER_TS_FMT_LIST_SIZE sizeof(formats) / sizeof(struct time_format)
+#define LOGSERVER_TS_STR_MAX_SIZE 128
+#define LOGSERVER_TS_STRFTIME_PREFIX "strftime"
+
+static const char *get_fmt(const char *name)
+{
+	if (!name)
+		return NULL;
+
+	if (!strncmp(name, LOGSERVER_TS_STRFTIME_PREFIX,
+		     strlen(LOGSERVER_TS_STRFTIME_PREFIX))) {
+		return name + strlen(LOGSERVER_TS_STRFTIME_PREFIX) + 1;
+	}
+
+	for (size_t i = 0; i < LOGSERVER_TS_FMT_LIST_SIZE; ++i) {
+		if (!strcmp(name, formats[i].name))
+			return formats[i].fmt;
+	}
+	return NULL;
+}
+
+int logserver_timestamp_get_formated(char *buf, int buf_size,
+				     const time_t *time, const char *name)
+{
+	const char *fmt = get_fmt(name);
+	if (!fmt)
+		goto err;
+
+	if (strftime(buf, buf_size, fmt, localtime(time)) == 0)
+		goto err;
+
+	return 0;
+
+err:
+	buf[0] = '\0';
+	return -1;
+}

--- a/logserver/logserver_timestamp.h
+++ b/logserver/logserver_timestamp.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LOGSERVER_TIMESTAMP_H
+#define LOGSERVER_TIMESTAMP_H
+
+#include <time.h>
+
+int logserver_timestamp_get_formated(char *buf, int buf_size,
+				     const time_t *time, const char *name);
+
+#endif


### PR DESCRIPTION
- Adds `log.timestamp.format`
- Adds some shorthand for well known timestamp format (WIP)
- Change how the JSON log is built, now use the PV JSON lib