### PR TITLE
fix: logserver exiting before relevant pantavisor.config entries have been sent

### DIFF
--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -48,8 +48,13 @@ struct logserver_data {
 	int len;
 };
 
+typedef enum {
+	LOG_PROTOCOL_LEGACY = 0,
+	LOG_PROTOCOL_CMD = 256
+} log_protocol_code_t;
+
 struct logserver_log {
-	int ver;
+	log_protocol_code_t code;
 	int lvl;
 	uint64_t tsec;
 	uint32_t tnano;

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -131,7 +131,7 @@ int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
 char *logserver_utils_jsonify_log(const struct logserver_log *log)
 {
 	struct logserver_log js = {
-		.ver = log->ver,
+		.code = log->code,
 		.lvl = log->lvl,
 		.tsec = log->tsec,
 		.plat = pv_json_format(log->plat, strlen(log->plat)),


### PR DESCRIPTION
Previously, logserver was being closed by sending a SIGTERM from the main thread. Then, we waited for 5 seconds max before sending a SIGKILL. The SIGTERM would then be handled from the logserver thread, which would stop accepting pending log entries right away. This would make the logserver to stop printing before the relevant cause of a reboot/rollback was saved in the logs, in some cases, making debugging hard.

This PR proposes a new type of message that can be sent to the logserver socket that would substitute the SIGTERM from the main thread. That way, we know the logserver thread has processed all entries before the command is received. Then, we still wait the 5 seconds max before sending SIGKILL, just in case.

The logserver commands use the version field of the log messages format, which will be used as a more generic code number, and prepares the terrain to be also used by the updater logsink, which is part of the [update error reporting improvements](https://hackmd.io/33RAIpSSS6SOGj2lDTyAfQ) effort.
