### PR TITLE
fix: PH client not properly updating status error after rollback

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -721,8 +721,13 @@ void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev)
 		       strerror(errno));
 }
 
+#define MAX_PROGRES_SIZE 4096
+
 void pv_storage_set_rev_progress(const char *rev, const char *progress)
 {
+	if (!rev)
+		return;
+
 	char path[PATH_MAX];
 
 	pv_paths_storage_trail_pv_file(path, PATH_MAX, rev, PROGRESS_FNAME);
@@ -732,6 +737,18 @@ void pv_storage_set_rev_progress(const char *rev, const char *progress)
 	if (pv_fs_file_save(path, progress, 0644) < 0)
 		pv_log(WARN, "could not save file %s: %s", path,
 		       strerror(errno));
+}
+
+char *pv_storage_get_rev_progress(const char *rev)
+{
+	if (!rev)
+		return NULL;
+
+	char path[PATH_MAX];
+	pv_paths_storage_trail_pv_file(path, PATH_MAX, rev, PROGRESS_FNAME);
+
+	pv_log(DEBUG, "loading progress file for rev %s from %s", rev, path);
+	return pv_fs_file_load(path, MAX_PROGRES_SIZE);
 }
 
 #define PVR_CONFIGF "{\"ObjectsDir\": \"%s/objects\"}"

--- a/storage.h
+++ b/storage.h
@@ -41,6 +41,7 @@ bool pv_storage_verify_state_json(const char *rev, char *msg,
 
 void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev);
 void pv_storage_set_rev_progress(const char *rev, const char *progress);
+char *pv_storage_get_rev_progress(const char *rev);
 void pv_storage_init_trail_pvr(void);
 void pv_storage_rm_rev(const char *rev);
 void pv_storage_set_active(struct pantavisor *pv);

--- a/updater.h
+++ b/updater.h
@@ -103,6 +103,7 @@ struct pv_update {
 	char *endpoint;
 	int progress_size;
 	struct timer retry_timer;
+	char *rev;
 	struct pv_state *pending;
 	char *progress_objects;
 	int retries;


### PR DESCRIPTION
This problem was brought  to surface by  the [ERROR status message improvements](https://github.com/pantavisor/pantavisor/pull/348) and only affect remote mode.

All the ERROR status-msg before that PR were "Error during update". As now that has changed, it turned out that all the errors that were set before stablishing contact with PH were being overwritten by "PH Client: Stale revision".

With this PR, we load the status that was last set during the INPROGRESS and TESTING before a rollback and send it to PH so the status-msg corresponds with the actual cause of error.

It also attaches the revision of an update to the update struct itself instead of using the status one, which would cause Pantavisor to not update the progress JSON of an update until the signature validation and state parsing was completed, which at the same time would make Pantavisor to miss updates on progress.