### PR TITLE
feature: logserver update sink

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -52,6 +52,7 @@ LOCAL_SRC_FILES := debug.c \
 			logserver/logserver_timestamp.c \
 			logserver/logserver_utils.c \
 			logserver/logserver_out.c \
+			logserver/logserver_update.c \
 			logserver/logserver_singlefile.c \
 			logserver/logserver_filetree.c \
 			logserver/logserver_null.c \
@@ -80,6 +81,7 @@ LOCAL_SRC_FILES := debug.c \
 			utils/math.c \
 			utils/timer.c \
 			utils/fs.c \
+			utils/socket.c \
 			jsons.c \
 			pantahub.c \
 			updater.c \

--- a/config.c
+++ b/config.c
@@ -173,6 +173,8 @@ static int config_parse_log_server_outputs(char *value)
 			server_outputs |= LOG_SERVER_OUTPUT_STDOUT;
 	}
 
+	server_outputs |= LOG_SERVER_OUTPUT_UPDATE;
+
 	return server_outputs;
 }
 

--- a/config.h
+++ b/config.h
@@ -144,7 +144,8 @@ typedef enum {
 	LOG_SERVER_OUTPUT_NULL_SINK = 1 << 0,
 	LOG_SERVER_OUTPUT_SINGLE_FILE = 1 << 1,
 	LOG_SERVER_OUTPUT_FILE_TREE = 1 << 2,
-	LOG_SERVER_OUTPUT_STDOUT = 1 << 3
+	LOG_SERVER_OUTPUT_STDOUT = 1 << 3,
+	LOG_SERVER_OUTPUT_UPDATE = 1 << 4,
 } log_server_output_mask_t;
 
 struct pantavisor_log_server {

--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -62,7 +62,8 @@ struct logserver_log {
 	time_t time;
 	char *plat;
 	char *src;
-	char *rev;
+	char *running_rev;
+	char *updated_rev;
 	struct logserver_data data;
 };
 

--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -34,7 +34,7 @@
 
 static char *create_dir(const struct logserver_log *log)
 {
-	if (!log->rev) {
+	if (!log->running_rev) {
 		WARN_ONCE(
 			"Log with no revision (null) arrives to singlefile output: %s",
 			log->data.buf);
@@ -42,12 +42,12 @@ static char *create_dir(const struct logserver_log *log)
 	}
 
 	char path[PATH_MAX];
-	pv_paths_pv_log(path, sizeof(path), log->rev);
+	pv_paths_pv_log(path, sizeof(path), log->running_rev);
 
 	if (pv_fs_mkdir_p(path, 0755))
 		return NULL;
 
-	pv_paths_pv_log_plat(path, sizeof(path), log->rev, "pv.log");
+	pv_paths_pv_log_plat(path, sizeof(path), log->running_rev, "pv.log");
 
 	return strdup(path);
 }

--- a/logserver/logserver_update.h
+++ b/logserver/logserver_update.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Pantacor Ltd.
+ * Copyright (c) 2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,33 +20,11 @@
  * SOFTWARE.
  */
 
-#ifndef LOGSERVER_H
-#define LOGSERVER_H
+#ifndef LOGSERVER_UPDATE_H
+#define LOGSERVER_UPDATE_H
 
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdarg.h>
-#include "pantavisor.h"
+#include "logserver_out.h"
 
-#define PV_PLATFORM_STR "pantavisor"
+struct logserver_out *logserver_update_new(void);
 
-void pv_logserver_toggle(struct pantavisor *pv, const char *rev);
-
-int pv_logserver_init(void);
-
-int pv_logserver_send_log(bool is_platform, char *platform, char *src,
-			  int level, const char *msg, ...);
-int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
-			   int level, const char *msg, va_list args);
-
-void pv_logserver_reload(void);
-void pv_logserver_stop(void);
-
-void pv_logserver_start_update(const char *rev);
-void pv_logserver_stop_update(const char *rev);
-
-int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src,
-			      int loglevel);
-int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
-
-#endif /* LOGSERVER_H */
+#endif

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -207,6 +207,8 @@ char *logserver_utils_output_to_str(int out_type)
 		return "filetree";
 	case LOG_SERVER_OUTPUT_SINGLE_FILE:
 		return "singlefile";
+	case LOG_SERVER_OUTPUT_UPDATE:
+		return "update";
 	}
 
 	return "unknown";

--- a/paths.h
+++ b/paths.h
@@ -76,6 +76,8 @@ void pv_paths_storage_object(char *buf, size_t size, const char *sha);
 #define COMMITMSG_FNAME "commitmsg"
 #define JSON_FNAME "json"
 #define CONFIG_FNAME "config"
+#define LOGS_FNAME "logs"
+#define LOGS_TMP_FNAME "logs.tmp"
 
 void pv_paths_storage_trail(char *buf, size_t size, const char *rev);
 void pv_paths_storage_trail_file(char *buf, size_t size, const char *rev,

--- a/updater.h
+++ b/updater.h
@@ -29,6 +29,10 @@
 #define DEVICE_TRAIL_ENDPOINT_FMT "/trails/%s/steps"
 #define DEVICE_STEP_ENDPOINT_FMT "/trails/%s/steps/%s/progress"
 
+#define UPDATE_PROGRESS_STATUS_SIZE 16
+#define UPDATE_PROGRESS_STATUS_MSG_SIZE 256
+#define UPDATE_PROGRESS_DATA_SIZE 16
+#define UPDATE_PROGRESS_LOGS_SIZE 4092
 #define UPDATE_PROGRESS_JSON_SIZE 4096
 
 #define TRAIL_OBJECT_DL_FMT "/objects/%s"
@@ -82,6 +86,7 @@ struct download_info {
 
 struct pv_update {
 	enum update_status status;
+	char msg[UPDATE_PROGRESS_STATUS_MSG_SIZE];
 	char *endpoint;
 	int progress_size;
 	struct timer retry_timer;
@@ -107,7 +112,7 @@ int pv_updater_check_for_updates(struct pantavisor *pv);
 bool pv_trail_is_auth(struct pantavisor *pv);
 void pv_trail_remote_remove(struct pantavisor *pv);
 
-struct pv_update *pv_update_get_step_local(char *rev);
+struct pv_update *pv_update_get_step_local(const char *rev);
 
 int pv_update_download(struct pantavisor *pv);
 int pv_update_install(struct pantavisor *pv);

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -27,6 +27,17 @@ bool pv_fs_path_exist(const char *path)
 	return access(path, F_OK) == 0;
 }
 
+bool pv_fs_path_exist_timeout(const char *path, unsigned int timeout)
+{
+	unsigned int i;
+	for (i = 0; i < timeout; i++) {
+		if (pv_fs_path_exist(path))
+			return true;
+		sleep(1);
+	}
+	return false;
+}
+
 bool pv_fs_path_is_directory(const char *path)
 {
 	DIR *tmp = opendir(path);

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 
 bool pv_fs_path_exist(const char *path);
+bool pv_fs_path_exist_timeout(const char *path, unsigned int timeout);
 bool pv_fs_path_is_directory(const char *path);
 void pv_fs_path_sync(const char *path);
 void pv_fs_path_concat(char *buf, int size, ...);

--- a/utils/json.c
+++ b/utils/json.c
@@ -142,17 +142,15 @@ int pv_json_get_value_int(const char *buf, const char *key, jsmntok_t *tok,
 	for (i = 0; i < tokc; i++) {
 		int n = tok[i].end - tok[i].start;
 		int m = strlen(key);
-		if (tok[i].type == JSMN_PRIMITIVE && n == m &&
+		if ((n == m) && (tok[i].type == JSMN_STRING) &&
 		    !strncmp(buf + tok[i].start, key, n)) {
 			t = 1;
-		} else if (t == 1) {
+		} else if ((t == 1) && (tok[i].type == JSMN_PRIMITIVE)) {
 			char *idval = malloc(n + 1);
 			idval[n] = 0;
 			strncpy(idval, buf + tok[i].start, n);
 			val = atoi(idval);
 			free(idval);
-			return val;
-		} else if (t == 1) {
 			return val;
 		}
 	}

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Pantacor Ltd.
+ * Copyright (c) 2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,33 +20,12 @@
  * SOFTWARE.
  */
 
-#ifndef LOGSERVER_H
-#define LOGSERVER_H
+#ifndef UTILS_SOCKET_H
+#define UTILS_SOCKET_H
 
-#include <sys/types.h>
 #include <unistd.h>
-#include <stdarg.h>
-#include "pantavisor.h"
+#include <sys/types.h>
 
-#define PV_PLATFORM_STR "pantavisor"
+pid_t pv_socket_get_sender_pid(int fd);
 
-void pv_logserver_toggle(struct pantavisor *pv, const char *rev);
-
-int pv_logserver_init(void);
-
-int pv_logserver_send_log(bool is_platform, char *platform, char *src,
-			  int level, const char *msg, ...);
-int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
-			   int level, const char *msg, va_list args);
-
-void pv_logserver_reload(void);
-void pv_logserver_stop(void);
-
-void pv_logserver_start_update(const char *rev);
-void pv_logserver_stop_update(const char *rev);
-
-int pv_logserver_subscribe_fd(int fd, const char *platform, const char *src,
-			      int loglevel);
-int pv_logserver_unsubscribe_fd(const char *platform, const char *src);
-
-#endif /* LOGSERVER_H */
+#endif


### PR DESCRIPTION
This PR introduces a new logserver sink to store update related logs. Unlike other sinks, this one can compile in a single file logs that come from two different revisions (the updated and the updater) and is enabled by default during updates.

The ultimate objective is to show these logs stored by the update sink in the update progress JSON, which is currently used both for remote and local experience update feedback. These logs provide additional information in case of WONTGO or ERROR. For example:

```
{
  "status":"ERROR",
  "status-msg":"A container could not be started",
  "progress":100,
  "logs":"{\"tsec\":10214,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"platforms\",\"msg\":\"error starting platform: 'pvr-sdk'\"}\n{\"tsec\":10214,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"state\",\"msg\":\"platform pvr-sdk could not be started\"}\n{\"tsec\":10214,\"tnano\":0,\"platform\":\"pantavisor\",\"lvl\":\"ERROR\",\"src\":\"controller\",\"msg\":\"a platform did not work as expected. Tearing down...\"}\n"
}
```

List of changes:
* **logserver:** the new update sink stores all pantavisor logs with ERROR level since a start command is received from the main thread.
* **logserver:** the new sink stores logs in /storage/trails/\<rev\>/.pv/logs.tmp temporarily until a stop command is received from the main thread.
* **logserver:** update sink to permanently store update logs in /storage/trails/\<rev\>/.pv/logs after the stop command.
* **logserver:** the update sink stores the logs in the same format as the singlefile sink (a string of JSONs separated by \n).
* **logserver:** the update sink is always enabled and cannot be removed for now.
* **logserver:** new logserver commands to start and stop recording update logs. This is necessary as the logs we are interested in can start during the updater revision and stop in the updated one, so they are not attached to the running revision as with the other sinks.
* **logserver:** logserver will now only accept commands coming from the main thread.
* **updater:** added a new logs field to progress JSON, which can be get with `pvcontrol steps show-progress` and is sent to the hub in remote mode.
* **updater:** the main thread will wait for 5 seconds max for  /storage/trails/\<rev\>/.pv/logs to appear. This is done to avoid missing logs due to main thread being faster than the logserver processing logs, and should only significantly affect the update time in case of logserver flood plus update failure.
* **updater:** the progress field value will be 100 when the update is finished, no matter whether the update succeeded or not. This is done to notify pvr or UI that the update has finished and there will be no further info in progress JSON.
* **updater:** refactored pv_update_finish to avoid code duplication.
* **updater:** start and stop the logserver update sink using the new commands.

Future work:
* **logserver:** the update sink will be able to also get logs from platforms.
* **config:** the operator will be able to set a max size for logs in each revision, so we don't take too much space in /storage. This amount should now be not very significant right now as we are only saving ERROR messages from pantavisor logs.