### PR TITLE
refactor: update status report

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -263,10 +263,7 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 		goto out;
 	}
 
-	// set factory revision progress
-	if (!strncmp(pv->state->rev, "0", sizeof("0")))
-		pv_storage_set_rev_progress(
-			"0", DEVICE_STEP_FACTORY_PROGRESS_UNREGISTERED);
+	pv_update_set_factory_status();
 
 	// reload remote bool after non reboot updates, when we don't load config again
 	pv->remote_mode = pv_config_get_control_remote();
@@ -365,15 +362,11 @@ static pv_state_t pv_wait_unclaimed(struct pantavisor *pv)
 	if (!pv_ph_device_is_owned(pv, &c)) {
 		pv_metadata_add_devmeta(DEVMETA_KEY_PH_STATE,
 					ph_state_string(PH_STATE_CLAIM));
-		pv_storage_set_rev_progress(
-			"0", DEVICE_STEP_FACTORY_PROGRESS_UNCLAIMED);
 		pv_log(INFO, "device challenge: '%s'", c);
 		pv_ph_update_hint_file(pv, c);
 	} else {
 		pv_metadata_add_devmeta(DEVMETA_KEY_PH_STATE,
 					ph_state_string(PH_STATE_SYNC));
-		pv_storage_set_rev_progress(
-			"0", DEVICE_STEP_FACTORY_PROGRESS_SYNCING);
 		pv_log(INFO, "device has been claimed, proceeding normally");
 		pv->unclaimed = false;
 		pv_config_save_creds();
@@ -525,13 +518,9 @@ static pv_state_t pv_wait_network(struct pantavisor *pv)
 			    pv_config_get_updater_interval(), 0, RELATIV_TIMER);
 	}
 
-	if (pv->synced) {
+	if (pv->synced)
 		pv_metadata_add_devmeta(DEVMETA_KEY_PH_STATE,
 					ph_state_string(PH_STATE_IDLE));
-		if (!strncmp(pv->state->rev, "0", sizeof("0")))
-			pv_storage_set_rev_progress(
-				"0", DEVICE_STEP_FACTORY_PROGRESS_DONE);
-	}
 
 out:
 	// process ongoing updates, if any

--- a/storage.c
+++ b/storage.c
@@ -721,8 +721,6 @@ void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev)
 		       strerror(errno));
 }
 
-#define MAX_PROGRES_SIZE 4096
-
 void pv_storage_set_rev_progress(const char *rev, const char *progress)
 {
 	if (!rev)
@@ -748,7 +746,7 @@ char *pv_storage_get_rev_progress(const char *rev)
 	pv_paths_storage_trail_pv_file(path, PATH_MAX, rev, PROGRESS_FNAME);
 
 	pv_log(DEBUG, "loading progress file for rev %s from %s", rev, path);
-	return pv_fs_file_load(path, MAX_PROGRES_SIZE);
+	return pv_fs_file_load(path, UPDATE_PROGRESS_JSON_SIZE);
 }
 
 #define PVR_CONFIGF "{\"ObjectsDir\": \"%s/objects\"}"

--- a/updater.h
+++ b/updater.h
@@ -28,25 +28,8 @@
 
 #define DEVICE_TRAIL_ENDPOINT_FMT "/trails/%s/steps"
 #define DEVICE_STEP_ENDPOINT_FMT "/trails/%s/steps/%s/progress"
-#define DEVICE_STEP_STATUS_FMT                                                 \
-	"{ \"status\" : \"%s\", \"status-msg\" : \"%s\", \"progress\" : %d }"
-#define DEVICE_STEP_STATUS_WONTGO_FMT                                          \
-	"{ \"status\" : \"WONTGO\", \"status-msg\" : \"%s: %s\", \"progress\" : 0 }"
-#define DEVICE_STEP_STATUS_ERROR_FMT                                           \
-	"{ \"status\" : \"ERROR\", \"status-msg\" : \"%s: %s\", \"progress\" : 0 }"
-#define DEVICE_STEP_STATUS_FMT_WITH_DATA                                       \
-	"{ \"status\" : \"%s\", \"status-msg\" : \"%s\", \"progress\" : %d ,\"data\":\"%d\"}"
-#define DEVICE_STEP_STATUS_FMT_PROGRESS_DATA                                   \
-	"{ \"status\" : \"%s\", \"status-msg\" : \"%s\", \"progress\" : %d ,\"data\":\"%d\",\
-	\"downloads\": {\"total\":%s, \"objects\":[%s]}}"
-#define DEVICE_STEP_FACTORY_PROGRESS_UNREGISTERED                              \
-	"{ \"status\" : \"UNREGISTERED\", \"status-msg\" : \"Registering\", \"progress\" : 0 }"
-#define DEVICE_STEP_FACTORY_PROGRESS_UNCLAIMED                                 \
-	"{ \"status\" : \"UNCLAIMED\", \"status-msg\" : \"Waiting for claim\", \"progress\" : 0 }"
-#define DEVICE_STEP_FACTORY_PROGRESS_SYNCING                                   \
-	"{ \"status\" : \"SYNCING\", \"status-msg\" : \"Uploading initial data\", \"progress\" : 20 }"
-#define DEVICE_STEP_FACTORY_PROGRESS_DONE                                      \
-	"{ \"status\" : \"DONE\", \"status-msg\" : \"Factory revision\", \"progress\" : 100 }"
+
+#define UPDATE_PROGRESS_JSON_SIZE 4096
 
 #define TRAIL_OBJECT_DL_FMT "/objects/%s"
 #define DEVICE_TRAIL_ENDPOINT_QUEUED "?progress.status=QUEUED"
@@ -60,6 +43,7 @@
 
 enum update_status {
 	UPDATE_INIT,
+	UPDATE_FACTORY,
 	UPDATE_ABORTED,
 	UPDATE_QUEUED,
 	UPDATE_DOWNLOADED,
@@ -89,9 +73,7 @@ enum update_status {
 	UPDATE_DOWNLOAD_PROGRESS
 };
 
-struct object_update {
-	char *object_name;
-	char *object_id;
+struct download_info {
 	uint64_t total_size;
 	uint64_t start_time;
 	uint64_t current_time;
@@ -105,9 +87,8 @@ struct pv_update {
 	struct timer retry_timer;
 	char *rev;
 	struct pv_state *pending;
-	char *progress_objects;
 	int retries;
-	struct object_update *total_update;
+	struct download_info total;
 	bool local;
 };
 
@@ -141,5 +122,6 @@ bool pv_update_is_testing(struct pv_update *u);
 void pv_update_set_status_msg(struct pv_update *update,
 			      enum update_status status, const char *msg);
 void pv_update_set_status(struct pv_update *update, enum update_status status);
+void pv_update_set_factory_status(void);
 
 #endif

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -213,6 +213,11 @@ out:
 
 int pv_fs_file_save(const char *fname, const char *data, mode_t mode)
 {
+	if (!data) {
+		errno = ENODATA;
+		return -1;
+	}
+
 	char tmp[PATH_MAX] = { 0 };
 	if (pv_fs_file_tmp(tmp, fname) != 0)
 		return -1;


### PR DESCRIPTION
This PR completely refactors the update status progress reporting code with these goals in mind:
* serialize the progress JSON in one place instead of using multiple different defines
* make it easier to add a configurable limit of size of the JSON
* make it easier to add new fields to the JSON, such as the logs
* use the JSON serialization utils functions