### PR TITLE
Fixes problems from original disk PR

### DIFF
--- a/disk/disk.h
+++ b/disk/disk.h
@@ -68,11 +68,12 @@ struct pv_disk {
 	struct dl_list list;
 };
 
-struct pv_disk *pv_disk_add(struct pv_state *s);
-int pv_disk_mount_swap(struct pv_state *s);
-int pv_disk_umount_all(struct pv_state *s);
-void pv_disk_empty(struct pv_state *s);
-int pv_disk_mount_handler(struct pv_disk *disk, const char *action);
+struct pv_disk *pv_disk_add(struct dl_list *disks);
+int pv_disk_mount_swap(struct dl_list *disks);
+int pv_disk_umount_all(struct dl_list *disks);
+void pv_disk_empty(struct dl_list *disks);
+int pv_disk_mount(struct pv_disk *disk);
+int pv_disk_umount(struct pv_disk *disk);
 
 inline const char *pv_disk_format_to_str(pv_disk_format_t type)
 {

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -879,7 +879,7 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 	pv_init_umount();
 
 	// unmount disks
-	pv_disk_umount_all(pv->state);
+	pv_disk_umount_all(&pv->state->disks);
 
 	pv_storage_umount();
 

--- a/state.c
+++ b/state.c
@@ -123,7 +123,7 @@ void pv_state_free(struct pv_state *s)
 	pv_drivers_empty(s);
 	pv_platforms_empty(s);
 	pv_volumes_empty(s);
-	pv_disk_empty(s);
+	pv_disk_empty(&s->disks);
 	pv_addons_empty(s);
 	pv_objects_empty(s);
 	pv_jsons_empty(s);
@@ -444,7 +444,8 @@ int pv_state_validate(struct pv_state *s)
 
 static int pv_state_mount_bsp_volumes(struct pv_state *s)
 {
-	pv_disk_mount_swap(s);
+	if (pv_disk_mount_swap(&s->disks) != 0)
+		return -1;
 
 	struct pv_volume *v, *tmp;
 

--- a/volumes.c
+++ b/volumes.c
@@ -161,7 +161,7 @@ int pv_volume_mount(struct pv_volume *v)
 	}
 
 	if (v->disk && !v->disk->def && !v->disk->mounted) {
-		ret = pv_disk_mount_handler(v->disk, "mount");
+		ret = pv_disk_mount(v->disk);
 		if (ret != 0) {
 			pv_log(ERROR, "disk %s mount failed", disk_name);
 			return ret;


### PR DESCRIPTION
This PR address several problems/improvements mentioned in the original disk PR:

* Replace API to use disk (struct dl_list *disks) instead of pv_state *s
* Remove some confusing logs.
* Remove unused #define
* Change API to mount/umount disk
* Rename disk parse functions
* Adds checks to detect unknown formats in the parser