### PR TITLE
Rework init reaping code so it reaps only direct childs.

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -21,6 +21,7 @@
  */
 
 #include <fcntl.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
@@ -142,6 +143,12 @@ bool pv_debug_is_ssh_pid(pid_t pid)
 {
 	return (pid != -1) && (pid == db_pid);
 }
+
+pid_t pv_debug_get_ssh_pid()
+{
+	return db_pid;
+}
+
 #else
 void pv_debug_start_shell()
 {

--- a/debug.h
+++ b/debug.h
@@ -32,5 +32,6 @@ void pv_debug_start_ssh(void);
 void pv_debug_stop_ssh(void);
 void pv_debug_check_ssh_running(void);
 bool pv_debug_is_ssh_pid(pid_t pid);
+pid_t pv_debug_get_ssh_pid(void);
 
 #endif // PV_DEBUG_H

--- a/init.c
+++ b/init.c
@@ -144,17 +144,6 @@ static int other_mounts()
 	return 0;
 }
 
-static pid_t waitpids(int *wstatus)
-{
-	pid_t pid;
-
-	if ((pid = waitpid(-1, wstatus, WNOHANG)) > 0) {
-		return pid;
-	}
-
-	return 0;
-}
-
 static void signal_handler(int signal)
 {
 	pid_t pid = 0;
@@ -163,8 +152,7 @@ static void signal_handler(int signal)
 	if (signal != SIGCHLD)
 		return;
 
-	while ((pid = waitpids(&wstatus)) > 0) {
-		// ignore signals of 0 and db_pid
+	while ((pid = waitpid(-1, &wstatus, WNOHANG)) > 0) {
 		if (pv_init_is_daemon(pid)) {
 			pv_log(WARN, "Daemon exited.");
 			pv_init_daemon_exited(pid);
@@ -175,10 +163,15 @@ static void signal_handler(int signal)
 			       "Respawn of critical service failed %d: %s", pid,
 			       strerror(errno));
 		}
-		if (getpid() == 1 || pv_debug_is_ssh_pid(pid) || tsh_bgid_pop(pid))
+		// ignore signals if not in init pid
+		// ignore signals from ssh and tsh childs
+		if (getpid() == 1 || pv_debug_is_ssh_pid(pid) ||
+		    tsh_bgid_pop(pid))
 			continue;
 
-		pv_log(ERROR, "we dont know about reaped PID and will stop pantavisor ... %d", pid);
+		pv_log(ERROR,
+		       "we dont know about reaped PID and will stop pantavisor ... %d",
+		       pid);
 		pv_stop();
 
 		if (WIFSIGNALED(wstatus) || WIFEXITED(wstatus)) {

--- a/init.c
+++ b/init.c
@@ -147,26 +147,11 @@ static int other_mounts()
 static pid_t waitpids(int *wstatus)
 {
 	pid_t pid;
-	int i = 0;
-	struct pv_init_daemon *daemons = NULL;
 
-	if ((pid = waitpid(0, wstatus, WNOHANG)) > 0) {
+	if ((pid = waitpid(-1, wstatus, WNOHANG)) > 0) {
 		return pid;
 	}
 
-	daemons = pv_init_get_daemons();
-	if (!daemons)
-		return 0;
-
-	while (daemons[i].name) {
-		pid = 0;
-		if (daemons[i].pid > 0 &&
-		    (pid = waitpid(daemons[i].pid, wstatus, WNOHANG)) > 0)
-			return daemons[i].pid;
-		if (pid < 0)
-			return pid;
-		i++;
-	}
 	return 0;
 }
 
@@ -190,8 +175,10 @@ static void signal_handler(int signal)
 			       "Respawn of critical service failed %d: %s", pid,
 			       strerror(errno));
 		}
-		if (pv_pid == 0 || (pv_debug_is_ssh_pid(pid)))
+		if (getpid() == 1 || pv_debug_is_ssh_pid(pid) || tsh_bgid_pop(pid))
 			continue;
+
+		pv_log(ERROR, "we dont know about reaped PID and will stop pantavisor ... %d", pid);
 		pv_stop();
 
 		if (WIFSIGNALED(wstatus) || WIFEXITED(wstatus)) {

--- a/platforms.c
+++ b/platforms.c
@@ -512,6 +512,7 @@ static int __start_pvlogger_for_platform(struct pv_platform *platform,
 								  platform->name));
 		_exit(0);
 	}
+	tsh_bgid_push(pid);
 	log_info->logger_pid = pid;
 	return pid;
 }

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Pantacor Ltd.
+ * Copyright (c) 2017-2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@
 #include "state.h"
 #include "platforms.h"
 #include "paths.h"
+#include "utils/tsh.h"
 
 #define MODULE_NAME "pv_lxc"
 #define pv_log(level, msg, ...) __vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
@@ -509,6 +510,7 @@ void *pv_start_container(struct pv_platform *p, const char *rev,
 	}
 
 	else if (child_pid) { /*Parent*/
+		tsh_bgid_push(child_pid);
 		pid_t container_pid = -1;
 		/*Parent would read*/
 		close(pipefd[1]);

--- a/utils/tsh.c
+++ b/utils/tsh.c
@@ -65,7 +65,9 @@ static char **_tsh_split_cmd(char *cmd)
 	return ts;
 }
 
-pid_t bgpids[128];
+#define TSH_BGPIDS_SIZE 128
+
+pid_t bgpids[TSH_BGPIDS_SIZE];
 int bgid_init = 0;
 
 int tsh_bgid_push(pid_t pid)
@@ -78,7 +80,7 @@ int tsh_bgid_push(pid_t pid)
 	while (bgpids[i]) {
 		i++;
 	}
-	if (i > 127)
+	if (i >= TSH_BGPIDS_SIZE)
 		return -1;
 	bgpids[i] = pid;
 	return 0;
@@ -90,7 +92,7 @@ int tsh_bgid_pop(pid_t pid)
 		memset(bgpids, '\0', sizeof(bgpids));
 		bgid_init = 1;
 	}
-	for (int i = 0; i < 128; i++) {
+	for (int i = 0; i < TSH_BGPIDS_SIZE; i++) {
 		if (bgpids[i] == pid) {
 			bgpids[i] = 0;
 			return 1;

--- a/utils/tsh.h
+++ b/utils/tsh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pantacor Ltd.
+ * Copyright (c) 2017-2023 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,5 +29,8 @@ pid_t tsh_run_io(char *cmd, int wait, int *status, int stdin_p[],
 		 int stdout_p[], int stderr_p[]);
 int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 		   char *err_buf, int err_size);
+
+int tsh_bgid_pop(pid_t pid);
+int tsh_bgid_push(pid_t pid);
 
 #endif


### PR DESCRIPTION
 * introduce a background pid pool so we can reap them without stopping pantavisor
 * introduce tsh facilities to push and pop tracked pids
 * remember forked lxc processes that exit after daemonizing as background ids
 * remember tsh_run pids started in background in pid pool
 * also fix potential issues in run processes by resetting sigmask in child