### PR TITLE
fix: parser artifacts memleaks

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -502,6 +502,10 @@ static int parse_storage(struct pv_state *s, struct pv_platform *p, char *buf)
 			free(value);
 			value = 0;
 		}
+		if (disk) {
+			free(disk);
+			disk = NULL;
+		}
 		k++;
 	}
 	jsmnutil_tokv_free(keys);
@@ -1712,6 +1716,7 @@ static struct pv_state *system1_parse_objects(struct pv_state *this,
 		    !strncmp("bsp/drivers.json", buf + (*k)->start, n) ||
 		    !strncmp("disks.json", buf + (*k)->start, n) ||
 		    !strncmp("groups.json", buf + (*k)->start, n) ||
+		    !strncmp("device.json", buf + (*k)->start, n) ||
 		    !strncmp("#spec", buf + (*k)->start, n)) {
 			k++;
 			continue;

--- a/signature.c
+++ b/signature.c
@@ -301,6 +301,8 @@ err:
 	}
 
 out:
+	if (pvs)
+		free(pvs);
 	if (json)
 		free(json);
 	if (typ)

--- a/storage.c
+++ b/storage.c
@@ -500,14 +500,15 @@ bool pv_storage_validate_trails_json_value(const char *rev, const char *name,
 
 	pv_paths_storage_trail_file(path, PATH_MAX, rev, name);
 	buf = pv_fs_file_load(path, 0);
-
 	if (!buf) {
 		pv_log(ERROR, "could not load %s, %s", path, strerror(errno));
 		return false;
 	}
 
 	pv_log(DEBUG, "validating value for json %s", path);
-	return pv_str_matches(val, strlen(val), buf, strlen(buf));
+	bool ret = pv_str_matches(val, strlen(val), buf, strlen(buf));
+	free(buf);
+	return ret;
 }
 
 void pv_storage_set_active(struct pantavisor *pv)
@@ -972,15 +973,12 @@ err:
 
 char *pv_storage_get_state_json(const char *rev)
 {
-	char *res;
 	char path[PATH_MAX];
 
 	pv_paths_storage_trail_pvr_file(path, PATH_MAX, rev, JSON_FNAME);
 	pv_log(DEBUG, "reading state from: '%s'", path);
 
-	res = pv_fs_file_load(path, 0);
-
-	return res;
+	return pv_fs_file_load(path, 0);
 }
 
 bool pv_storage_verify_state_json(const char *rev, char *msg,


### PR DESCRIPTION
Fixing various memleaks related to unfreed artifacts from state JSON parser:
* storage disk name not being freed after volume-disk linking
* json list values not being freed after validation
* signature pvs not being freed after signature parsing
* device.json duplication during parsing