### PR TITLE
fix: JSON state being duplicated 3 times per update

### DIFF
--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -326,9 +326,6 @@ struct pv_state *multi1_parse(struct pv_state *this, const char *buf)
 	}
 	jsmnutil_tokv_free(keys);
 
-	// copy buffer
-	this->json = strdup(buf);
-
 	pv_state_print(this);
 
 	// remove platforms that have no loaded data

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -1786,9 +1786,6 @@ out:
 static struct pv_state *system1_parse_validate(struct pv_state *this,
 					       const char *buf)
 {
-	// copy buffer
-	this->json = strdup(buf);
-
 	system1_link_object_json_platforms(this);
 
 	if (pv_state_validate(this))

--- a/state.c
+++ b/state.c
@@ -129,9 +129,6 @@ void pv_state_free(struct pv_state *s)
 	pv_jsons_empty(s);
 	pv_state_empty_groups(s);
 
-	if (s->json)
-		free(s->json);
-
 	free(s);
 }
 

--- a/state.h
+++ b/state.h
@@ -57,7 +57,6 @@ struct pv_state {
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
 	bool using_runlevels;
-	char *json;
 	int tryonce;
 	bool local;
 };


### PR DESCRIPTION
JSON state memory was being allocated 3 times per update:
* first one, to get the contents from the storage on disk into memory for signature validation and parsing.
* during parsing, we were storing the json in the state struct for later use, which can be avoided.
* during revision installation, we were duplicating once again to parse the JSON and search for other JSONs to be installed in /storage/trails. This is also not necessary as we already store a list of all JSONs in the state struct.

 While this was not a memory leak, it was a great waste of resources and was messing the heap when Pantavisor was trying to allocate such big buffers. As a refrence, a regular state JSON with 3 containers can take 22KB aprox.

On this PR, we avoid storing the state JSON in the state struct, which allows us to avoid the second and third allocations.