### PR TITLE
feature: ctrl command go remote

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -770,6 +770,19 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 		goto error;
 	}
 
+	if (!pv_config_get_control_remote() && ((*cmd)->op == CMD_GO_REMOTE)) {
+		pv_ctrl_write_error_response(
+			req_fd, HTTP_STATUS_CONFLICT,
+			"Cannot do this operation when remote mode is disabled by config");
+		goto error;
+	}
+
+	if (pv->remote_mode && ((*cmd)->op == CMD_GO_REMOTE)) {
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_CONFLICT,
+					     "Already in remote mode");
+		goto error;
+	}
+
 	return 0;
 
 error:

--- a/ctrl.h
+++ b/ctrl.h
@@ -36,6 +36,7 @@ typedef enum {
 	CMD_MAKE_FACTORY = 7,
 	CMD_RUN_GC = 8,
 	CMD_ENABLE_SSH = 9,
+	CMD_GO_REMOTE = 10,
 	MAX_CMD_OP
 } pv_cmd_operation_t;
 
@@ -61,7 +62,8 @@ pv_ctrl_string_cmd_operation(const pv_cmd_operation_t op)
 					 "LOCAL_APPLY",
 					 "MAKE_FACTORY",
 					 "RUN_GC",
-					 "ENABLE_SSH" };
+					 "ENABLE_SSH",
+					 "GO_REMOTE" };
 	return strings[op];
 }
 

--- a/log.h
+++ b/log.h
@@ -30,6 +30,19 @@
 #include "pantavisor.h"
 #include <stdarg.h>
 
+#ifdef DEBUG
+#define WARN_ONCE(msg, args...)                                                \
+	do {                                                                   \
+		static bool __warned = false;                                  \
+		if (!__warned) {                                               \
+			pv_log(WARN, msg, ##args);                             \
+			__warned = true;                                       \
+		}                                                              \
+	} while (0)
+#else
+#define WARN_ONCE(msg, args...)
+#endif
+
 void exit_error(int err, char *msg) __attribute__((__noreturn__));
 
 enum log_level {

--- a/state.c
+++ b/state.c
@@ -73,6 +73,7 @@ struct pv_state *pv_state_new(const char *rev, state_spec_t spec)
 		dl_list_init(&s->bsp.drivers);
 		s->using_runlevels = false;
 		s->local = false;
+		s->done = false;
 	}
 
 	return s;
@@ -305,6 +306,7 @@ void pv_state_print(struct pv_state *s)
 		if (j->plat)
 			pv_log(DEBUG, "  platform: '%s'", j->plat->name);
 	}
+	pv_log(DEBUG, "done=%d", s->done);
 }
 
 static int pv_state_set_default_groups(struct pv_state *s)

--- a/state.h
+++ b/state.h
@@ -59,6 +59,7 @@ struct pv_state {
 	bool using_runlevels;
 	int tryonce;
 	bool local;
+	bool done;
 };
 
 struct pv_state *pv_state_new(const char *rev, state_spec_t spec);

--- a/storage.c
+++ b/storage.c
@@ -713,7 +713,7 @@ out:
 	return json;
 }
 
-void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev)
+void pv_storage_set_rev_done(const char *rev)
 {
 	char path[PATH_MAX];
 
@@ -723,6 +723,15 @@ void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev)
 	if (pv_fs_file_save(path, "", 0644) < 0)
 		pv_log(WARN, "could not save file %s: %s", path,
 		       strerror(errno));
+}
+
+bool pv_storage_is_rev_done(const char *rev)
+{
+	char path[PATH_MAX];
+
+	pv_paths_storage_trail_pv_file(path, PATH_MAX, rev, DONE_FNAME);
+
+	return pv_fs_path_exist(path);
 }
 
 void pv_storage_set_rev_progress(const char *rev, const char *progress)

--- a/storage.h
+++ b/storage.h
@@ -39,7 +39,8 @@ char *pv_storage_get_state_json(const char *rev);
 bool pv_storage_verify_state_json(const char *rev, char *msg,
 				  unsigned int msg_len);
 
-void pv_storage_set_rev_done(struct pantavisor *pv, const char *rev);
+void pv_storage_set_rev_done(const char *rev);
+bool pv_storage_is_rev_done(const char *rev);
 void pv_storage_set_rev_progress(const char *rev, const char *progress);
 char *pv_storage_get_rev_progress(const char *rev);
 void pv_storage_init_trail_pvr(void);

--- a/updater.c
+++ b/updater.c
@@ -706,6 +706,8 @@ void pv_update_set_factory_status()
 
 	if (json)
 		free(json);
+
+	pv_storage_set_rev_done("0");
 }
 
 static int pv_update_load_progress(struct pv_update *update)
@@ -1421,7 +1423,8 @@ int pv_update_finish(struct pantavisor *pv)
 			goto out;
 		}
 		pv_update_set_status(u, UPDATE_DONE);
-		pv_storage_set_rev_done(pv, pv->state->rev);
+		pv_storage_set_rev_done(pv->state->rev);
+		pv->state->done = true;
 		break;
 	// UPDATED TRANSITIONS
 	case UPDATE_TESTING_NONREBOOT:


### PR DESCRIPTION
Adds a new ctrl command to force remote in a locals/ revision. This can be used to claim a device in any locals/ revision or claim it, go local and then allow to get back to remote without having to rollback.

To use the command with curl:
```
curl -X POST --header 'Content-Type: application/json' --data '{"op":"GO_REMOTE","payload":""}' --unix-socket /var/run/pv-ctrl.pantavisor http://localhost/commands
```

A pvcontrol command will be added too.

 The command will only work if:
* device is not in remote mode already
* control.remote is enabled by config

Additionally, we now store if a revision update was DONE in memory (we were already doing it on disk). This is later used to disable claiming revisions that are not DONE.