### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+root = true
+
+[*.{c, h, mk, atom, sh}]
+indent_style = tab
+indent_size = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.{yml, json}]
+indent_style = space
+indent_size = 2
+
+[*.conf]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Adds .editorconfig file to autoconfigure supported editors 
Please check https://editorconfig.org/

This is not meant to autoformat code, isn't a clang-format replacement, this file allows configuring the editor to use the right settings (tab/spaces length of tab, end of line type, etc.) to edit the Pantavisor files.