### PR TITLE
fix overlayfs lower layers order so it starts with highest layer and …

### DIFF
--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -193,7 +193,7 @@ static void pv_setup_lxc_container_cgroup(struct lxc_container *c)
 	c->set_config_item(c, "lxc.cgroup2.devices.allow", "a");
 }
 
-static char *insrchr(char *path, int n, char chr, char *seed)
+static char *inschr(char *path, int n, char chr, char *seed)
 {
 	int sl = strlen(seed);
 	int pl = strlen(path);
@@ -201,7 +201,7 @@ static char *insrchr(char *path, int n, char chr, char *seed)
 	if (pl + sl + 2 >= n)
 		return NULL;
 
-	char *i = strrchr(path, chr);
+	char *i = strchr(path, chr);
 	if (!i)
 		return NULL;
 	char *tn = strdup(i);
@@ -251,7 +251,7 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 	c->get_config_item(c, "lxc.rootfs.path", path + strlen(path), PATH_MAX - strlen(path) - 1);
 
 	ret = stat(seed, &st);
-	if (!ret && !insrchr(path, PATH_MAX, ':', seed)) {
+	if (!ret && !inschr(path, PATH_MAX, ':', seed)) {
 		pv_log(WARN,
 		       "failed to setup configoverlay in lxc.rootfs.path %s + %s",
 		       path, seed);


### PR DESCRIPTION
…ends with lowest

Below the upstream kernel doc related to the order:

Multiple lower layers
---------------------

Multiple lower layers can now be given using the the colon (":") as a separator character between the directory names.  For example:

  mount -t overlay overlay -olowerdir=/lower1:/lower2:/lower3 /merged

As the example shows, "upperdir=" and "workdir=" may be omitted.  In that case the overlay will be read-only.

The specified lower directories will be stacked beginning from the rightmost one and going left.  In the above example lower1 will be the top, lower2 the middle and lower3 the bottom layer.