### PR TITLE
rpiab booloader support for Raspbery Pi Firmware A/B tryboot

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -16,7 +16,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_LIBRARIES := libthttp mbedtls picohttpparser
+LOCAL_LIBRARIES := libthttp mbedtls picohttpparser zlib
 LOCAL_CONDITIONAL_LIBRARIES := OPTIONAL:e2fsprogs
 
 LOCAL_DESTDIR := ./
@@ -90,12 +90,14 @@ LOCAL_SRC_FILES := debug.c \
 			utils/fs.c \
 			utils/socket.c \
 			utils/pvsignals.c \
+			utils/pvzlib.c \
 			jsons.c \
 			pantahub.c \
 			updater.c \
 			bootloader.c \
 			trestclient.c \
 			uboot.c \
+			rpiab.c \
 			grub.c \
 			storage.c \
 			metadata.c \
@@ -128,6 +130,24 @@ LOCAL_COPY_FILES := $(foreach a,$(shell cd $(LOCAL_PATH)/skel; find . -type f), 
 	pvs/trust/ca-certificates.crt:etc/pantavisor/pvs/trust/ca-certificates.crt \
 	pvs/trust/cacerts.default.pem:etc/pantavisor/pvs/trust/cacerts.default.pem \
 	defaults/groups.json:etc/pantavisor/defaults/groups.json
+
+include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_DESTDIR := ./
+LOCAL_MODULE := rpiab_test
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/utils/
+
+LOCAL_LDFLAGS := -static
+
+LOCAL_SRC_FILES := rpiab.test.c \
+			utils/timer.c \
+			utils/pvsignals.c \
+			utils/tsh.c \
+			$(NULL)
+
 
 include $(BUILD_EXECUTABLE)
 

--- a/bootloader.c
+++ b/bootloader.c
@@ -49,6 +49,7 @@ static struct pv_bootloader pv_bootloader;
 
 extern const struct bl_ops uboot_ops;
 extern const struct bl_ops grub_ops;
+extern const struct bl_ops rpiab_ops;
 
 const struct bl_ops *ops = 0;
 
@@ -166,6 +167,30 @@ void pv_bootloader_remove()
 		free(pv_bootloader.pv_done);
 }
 
+int pv_bootloader_install_update(struct pv_update *update)
+{
+	if (ops->install_update)
+		return ops->install_update(update);
+
+	return -2;
+}
+
+int pv_bootloader_commit_update()
+{
+	if (ops->commit_update)
+		return ops->commit_update();
+
+	return -2;
+}
+
+int pv_bootloader_fail_update(struct pv_update *update)
+{
+	if (ops->fail_update)
+		return ops->fail_update(update);
+
+	return -2;
+}
+
 static int pv_bl_init()
 {
 	int ret;
@@ -174,6 +199,9 @@ static int pv_bl_init()
 	case BL_UBOOT_PLAIN:
 	case BL_UBOOT_PVK:
 		ops = &uboot_ops;
+		break;
+	case BL_RPIAB:
+		ops = &rpiab_ops;
 		break;
 	case BL_GRUB:
 		ops = &grub_ops;

--- a/config.c
+++ b/config.c
@@ -148,6 +148,8 @@ static int config_get_value_bl_type(struct dl_list *config_list, char *key,
 
 	if (!strcmp(item, "uboot"))
 		value = BL_UBOOT_PLAIN;
+	else if (!strcmp(item, "rpiab"))
+		value = BL_RPIAB;
 	else if (!strcmp(item, "uboot-pvk"))
 		value = BL_UBOOT_PVK;
 	else if (!strcmp(item, "grub"))

--- a/config.h
+++ b/config.h
@@ -112,7 +112,7 @@ struct pantavisor_updater {
 	int commit_delay;
 };
 
-enum { BL_UBOOT_PLAIN = 0, BL_UBOOT_PVK, BL_GRUB };
+enum { BL_UBOOT_PLAIN = 0, BL_UBOOT_PVK, BL_GRUB, BL_RPIAB };
 
 struct pantavisor_bootloader {
 	int type;

--- a/grub.c
+++ b/grub.c
@@ -256,4 +256,7 @@ const struct bl_ops grub_ops = {
 	.unset_env_key = grub_unset_env_key,
 	.get_env_key = grub_get_env_key,
 	.flush_env = grub_flush_env,
+	.install_update = NULL,
+	.commit_update = NULL,
+	.fail_update = NULL,
 };

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -383,11 +383,17 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 
 	s->bsp.img.ut.fit = pv_json_get_value(buf, "fit", tokv, tokc);
 	if (!s->bsp.img.ut.fit) {
-		s->bsp.img.std.kernel =
-			pv_json_get_value(buf, "linux", tokv, tokc);
-		s->bsp.img.std.fdt = pv_json_get_value(buf, "fdt", tokv, tokc);
-		s->bsp.img.std.initrd =
-			pv_json_get_value(buf, "initrd", tokv, tokc);
+		s->bsp.img.rpiab.bootimg =
+			pv_json_get_value(buf, "rpiab", tokv, tokc);
+
+		if (!s->bsp.img.rpiab.bootimg) {
+			s->bsp.img.std.kernel =
+				pv_json_get_value(buf, "linux", tokv, tokc);
+			s->bsp.img.std.fdt =
+				pv_json_get_value(buf, "fdt", tokv, tokc);
+			s->bsp.img.std.initrd =
+				pv_json_get_value(buf, "initrd", tokv, tokc);
+		}
 	}
 	s->bsp.firmware = pv_json_get_value(buf, "firmware", tokv, tokc);
 	s->bsp.modules = pv_json_get_value(buf, "modules", tokv, tokc);
@@ -405,7 +411,7 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 	}
 
 	if ((!s->bsp.img.std.kernel || !s->bsp.img.std.initrd) &&
-	    !s->bsp.img.ut.fit) {
+	    !s->bsp.img.ut.fit && !s->bsp.img.rpiab.bootimg) {
 		pv_log(ERROR,
 		       "kernel or initrd not configured in bsp/run.json. Cannot continue.",
 		       strlen(buf), buf);

--- a/paths.h
+++ b/paths.h
@@ -98,6 +98,7 @@ void pv_paths_storage_config_file(char *buf, size_t size, const char *name);
 
 #define GRUBENV_FNAME "grubenv"
 #define UBOOTTXT_FNAME "uboot.txt"
+#define RPIABTXT_FNAME "rpiab.txt"
 
 void pv_paths_storage_boot_file(char *buf, size_t size, const char *name);
 

--- a/rpiab.c
+++ b/rpiab.c
@@ -1,0 +1,1070 @@
+/*
+ * Copyright (c) 2023-2024 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/sysinfo.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <mtd/mtd-user.h>
+#include <linux/limits.h>
+
+#include <byteswap.h>
+
+#include "bootloader.h"
+#include "paths.h"
+#include "state.h"
+#include "utils/fs.h"
+#include "utils/pvsignals.h"
+#include "utils/pvzlib.h"
+#include "utils/str.h"
+#include "utils/tsh.h"
+
+#define MODULE_NAME "rpiab"
+#ifndef PVTEST
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#else
+#define pv_log(level, msg, ...)                                                \
+	printf("%s[%d]: ", MODULE_NAME, level);                                \
+	printf(msg "\n", ##__VA_ARGS__)
+#endif
+#include "log.h"
+
+enum {
+	RPI_FIRMWARE_SET_REBOOT_FLAGS = 0x00038064,
+};
+
+struct rpiab_paths {
+	int init;
+	char *bootimg[3];
+	char *dtb_partition;
+	char *dtb_tryboot;
+	char *boot_mode;
+	char *autoboot_tmp;
+	char *cmdline_tmp;
+	char *rpiab_txt;
+};
+
+static int autoboot_boot_partition = 0;
+static int autoboot_try_partition = 0;
+static uint32_t is_tryboot = 0;
+static uint32_t boot_mode = 0;
+static uint32_t partition = 0;
+#define UBOOT_ENV_SIZE 512
+
+static int mbox_property(int file_desc, void *buf);
+static int mbox_open(void);
+static void mbox_close(int file_desc);
+
+static struct rpiab_paths paths = {
+	.init = 0,
+	.bootimg = { "/dev/mmcblk0p1", "/dev/mmcblk0p2", "/dev/mmcblk0p3" },
+	.dtb_partition = "/proc/device-tree/chosen/bootloader/partition",
+	.dtb_tryboot = "/proc/device-tree/chosen/bootloader/tryboot",
+	.boot_mode = "/proc/device-tree/chosen/bootloader/boot-mode",
+	.autoboot_tmp = "/tmp/autoboot.txt",
+	.cmdline_tmp = "/tmp/cmdline.txt",
+};
+
+static int rpiab_init_fw(struct rpiab_paths *paths)
+{
+	int wstatus;
+	size_t s, s1, r;
+	sigset_t oldset;
+	char autoboot_txt[513];
+	char *cmdbuf = NULL;
+	FILE *f;
+	char *peek;
+	char *end;
+	char b;
+
+	// read bootloader chosen info from /proc/device-tree
+	// note: numbers are big endian so you see bswap_32(...)
+	f = fopen(paths->dtb_tryboot, "r");
+	if (!f) {
+		pv_log(ERROR, "Cannot open tryboot state on RPI: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	r = fread(&is_tryboot, 1, sizeof(is_tryboot), f);
+	if (r < sizeof(is_tryboot)) {
+		pv_log(ERROR, "Cannot read tryboot state on RPI from %s: %s",
+		       paths->dtb_tryboot, strerror(errno));
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	is_tryboot = bswap_32(is_tryboot);
+	pv_log(DEBUG, "RPI Tryboot state: %d", is_tryboot);
+
+	f = fopen(paths->boot_mode, "r");
+	if (!f) {
+		pv_log(ERROR, "Cannot open boot-mode state on RPI: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	r = fread(&boot_mode, 1, sizeof(boot_mode), f);
+	if (r < sizeof(boot_mode)) {
+		pv_log(ERROR, "Cannot read boot_mode state on RPI from %s: %s",
+		       paths->boot_mode, strerror(errno));
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	boot_mode = bswap_32(boot_mode);
+	pv_log(DEBUG, "RPI Boot Mode: %d", boot_mode);
+
+	// for now we only support boot mode sd card (1) and usb disk (4)
+	if (boot_mode & 4) {
+		paths->bootimg[0] = strdup("/dev/sda1");
+		paths->bootimg[1] = strdup("/dev/sda2");
+		paths->bootimg[2] = strdup("/dev/sda3");
+	} else if (!(boot_mode & 1)) {
+		pv_log(ERROR, "Boot mode not supported: %d", boot_mode);
+		return -1;
+	}
+
+	f = fopen(paths->dtb_partition, "r");
+	if (!f) {
+		pv_log(ERROR, "Cannot open tryboot state on RPI: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	r = fread(&partition, 1, sizeof(partition), f);
+	if (r < sizeof(partition)) {
+		pv_log(ERROR, "Cannot read tryboot state on RPI: %s",
+		       strerror(errno));
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	partition = bswap_32(partition);
+	pv_log(DEBUG, "RPI Partition booted: %d", partition);
+
+	// now we extract autoboot.txt from partition 0 with mcopy
+	s = snprintf(cmdbuf, 0, "mcopy -n -i %s ::autoboot.txt %s",
+		     paths->bootimg[0], paths->autoboot_tmp);
+
+	cmdbuf = realloc(cmdbuf, (s + 1) * sizeof(char));
+
+	if (!cmdbuf) {
+		pv_log(ERROR, "Out of Memory (OOM) trying to allocate cmdbuf");
+		return -1;
+	}
+
+	s1 = snprintf(cmdbuf, (s + 1), "mcopy -n -i %s ::autoboot.txt %s",
+		      paths->bootimg[0], paths->autoboot_tmp);
+
+	if (pvsignals_block_chld(&oldset)) {
+		pv_log(ERROR, "Cannot block sigchld: %s", strerror(errno));
+		free(cmdbuf);
+		return -2;
+	}
+
+	if (s1 != s) {
+		pv_log(ERROR,
+		       "Error producing cmdbuf. size does not match expected size( %d != %d)",
+		       s, s1);
+		free(cmdbuf);
+		return -2;
+	}
+
+	pid_t p = tsh_run(cmdbuf, 0, NULL);
+
+	free(cmdbuf);
+
+	for (int i = 0; i < 10; i++) {
+		pid_t wp = waitpid(p, &wstatus, WNOHANG);
+		if (wp < 0) {
+			pv_log(ERROR,
+			       "error running mcopy for autoboot.txt: %s",
+			       strerror(errno));
+			pvsignals_setmask(&oldset);
+			return -1;
+		}
+		if (wp > 0) {
+			if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus)) {
+				pv_log(DEBUG,
+				       "autoboot.txt extraxt from img failed with status %d",
+				       WEXITSTATUS(wstatus));
+				return -1;
+			}
+			break;
+		}
+		sleep(1);
+	}
+	pvsignals_setmask(&oldset);
+
+	f = fopen(paths->autoboot_tmp, "r");
+	if (!f) {
+		pv_log(INFO, "Cannot open tryboot state on RPI: %s",
+		       strerror(errno));
+		fclose(f);
+		return -1;
+	}
+
+	r = fread(&autoboot_txt, 1, 512, f);
+
+	if (r <= 0) {
+		pv_log(ERROR, "Cannot read %s: %s; falling back to uboot",
+		       paths->autoboot_tmp, strerror(errno));
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+
+	// set end marker if file does not have trailing 0
+	autoboot_txt[r] = 0;
+
+	// parse autoboot.txt
+	peek = strstr(autoboot_txt, "[all]");
+	if (!peek) {
+		pv_log(WARN,
+		       "fail to find [all] in autoboot.txt; continue best guess");
+		goto bestguess;
+	}
+
+	peek = strstr(peek, "boot_partition=");
+	if (!peek) {
+		pv_log(WARN,
+		       "fail to find 'boot_partition=' for [all] in autoboot.txt; continue best guess");
+		goto bestguess;
+	}
+
+	peek = peek + strlen("boot_partition=");
+	if (peek > autoboot_txt + r) {
+		pv_log(WARN,
+		       "file too short to parse 'boot_partition='; continue best guess");
+		goto bestguess;
+	}
+	end = peek;
+	if (*end < '0' || *end > '9') {
+		pv_log(WARN,
+		       "boot_partition= for [all] has no number following it; continue best guess");
+		goto bestguess;
+	}
+	while (*end >= '0' && *end <= '9') {
+		end++;
+	}
+
+	b = *end;
+	*end = 0;
+	autoboot_boot_partition = atoi(peek);
+	*end = b;
+
+	pv_log(DEBUG, "Autoboot.txt: boot partition %d",
+	       autoboot_boot_partition);
+
+	// if parsing fails we do a best guess to
+	// boot something... rather than fail.
+	peek = strstr(autoboot_txt, "[tryboot]");
+	if (peek) {
+		peek = strstr(peek, "boot_partition=");
+		if (!peek)
+			goto bestguess;
+
+		peek = peek + strlen("boot_partition=");
+		if (peek > autoboot_txt + r) {
+			pv_log(WARN,
+			       "file too short to parse 'boot_partition=' for [tryboot]; continue best guess");
+			goto bestguess;
+		}
+		end = peek;
+		if (*end < '0' || *end > '9') {
+			pv_log(WARN,
+			       "boot_partition= for [all] has no number following it; continue best guess");
+			goto bestguess;
+		}
+		while (*end >= '0' && *end <= '9') {
+			end++;
+		}
+		b = *end;
+		*end = 0;
+		autoboot_try_partition = atoi(peek);
+		*end = b;
+		pv_log(DEBUG, "Autoboot.txt: try partition %d",
+		       autoboot_try_partition);
+		return 0;
+	}
+bestguess:
+	if (!autoboot_boot_partition) {
+		autoboot_boot_partition = 2;
+		pv_log(WARN,
+		       "error parsing autoboot.txt; setting boot partition to %d",
+		       autoboot_boot_partition);
+	}
+	// if we have no try_partition; guess one ...
+	if (autoboot_boot_partition == 3)
+		autoboot_try_partition = 2;
+	else
+		autoboot_try_partition = 3;
+
+	return 0;
+}
+
+static int rpiab_init()
+{
+	char *b;
+	const char *hay;
+
+	// already init'd?
+	if (paths.init)
+		return 0;
+
+	b = malloc(PATH_MAX);
+
+	if (getenv("PVTEST_PATH_BOOTIMG")) {
+		paths.bootimg[0] = strdup(getenv("PVTEST_PATH_BOOTIMG"));
+	}
+
+	paths.bootimg[1] = strdup(paths.bootimg[0]);
+	paths.bootimg[1][strlen(paths.bootimg[0]) - 1] = '2';
+	paths.bootimg[2] = strdup(paths.bootimg[0]);
+	paths.bootimg[2][strlen(paths.bootimg[0]) - 1] = '3';
+
+	hay = getenv("PVTEST_PATH_TMP");
+	if (hay) {
+		size_t s = snprintf(b, 1, "%s/autoboot.txt", hay) + 1;
+		b = realloc(b, s);
+		snprintf(b, s, "%s/autoboot.txt", hay);
+		paths.autoboot_tmp = strdup(b);
+		s = snprintf(b, 1, "%s/cmdline.txt", hay) + 1;
+		b = realloc(b, s);
+		snprintf(b, s, "%s/cmdline.txt", hay);
+		paths.cmdline_tmp = strdup(b);
+	} else {
+		paths.autoboot_tmp = strdup(paths.autoboot_tmp);
+	}
+
+	hay = getenv("PVTEST_PATH_DEVICE_TREE_BOOTLOADER");
+	if (hay) {
+		size_t s = snprintf(b, 1, "%s/partition", hay) + 1;
+		b = realloc(b, s);
+		snprintf(b, s, "%s/partition", hay);
+		paths.dtb_partition = strdup(b);
+		s = snprintf(b, 1, "%s/tryboot", hay) + 1;
+		b = realloc(b, s);
+		snprintf(b, s, "%s/tryboot", hay);
+		paths.dtb_tryboot = strdup(b);
+	} else {
+		paths.dtb_partition = strdup(paths.dtb_partition);
+		paths.dtb_tryboot = strdup(paths.dtb_tryboot);
+	}
+
+	hay = getenv("PVTEST_PATH_STORAGE_BOOT");
+	if (hay) {
+		size_t s = snprintf(b, 1, "%s/rpiab.txt", hay) + 1;
+		b = realloc(b, s);
+		snprintf(b, s, "%s/rpiab.txt", hay);
+		paths.rpiab_txt = strdup(b);
+	} else {
+		// setup rpiab.txt location
+#ifndef PVTEST
+		pv_paths_storage_boot_file(b, PATH_MAX, RPIABTXT_FNAME);
+		paths.rpiab_txt = strdup(b);
+#else
+		printf("ERROR: must specify PVTEST_PATH_STORAGE_BOOT env in test\n");
+		exit(1);
+#endif
+	}
+	free(b);
+
+	pv_log(DEBUG, "bootimg@%s", paths.bootimg[0]);
+	pv_log(DEBUG, "bootimg2@%s", paths.bootimg[1]);
+	pv_log(DEBUG, "bootimg3@%s", paths.bootimg[2]);
+	pv_log(DEBUG, "rpiab.txt@%s", paths.rpiab_txt);
+	pv_log(DEBUG, "autoboot.txt@%s", paths.autoboot_tmp);
+	pv_log(DEBUG, "dtb-partition@%s", paths.dtb_partition);
+	pv_log(DEBUG, "dtb-tryboot@%s", paths.dtb_tryboot);
+	pv_log(DEBUG, "dtb-bootmode@%s", paths.boot_mode);
+
+	if (rpiab_init_fw(&paths)) {
+		pv_log(ERROR, "rpiab_init_fw() failed");
+		return -1;
+	}
+
+	paths.init = 1;
+
+	return 0;
+}
+
+static char *rpiab_get_env_key(char *key)
+{
+	int fd, n, len, ret;
+	char *buf, *path, *value = NULL;
+
+	path = paths.rpiab_txt;
+	len = UBOOT_ENV_SIZE;
+
+	fd = open(path, O_RDONLY);
+	if (!fd)
+		return value;
+
+	lseek(fd, 0, SEEK_SET);
+	buf = calloc(len, sizeof(char));
+	ret = read(fd, buf, len);
+	close(fd);
+
+	n = strlen(key);
+
+	int k = 0;
+	for (int i = 0; i < ret; i++) {
+		if (buf[i] != '\0')
+			continue;
+
+		if (!strncmp(buf + k, key, n)) {
+			value = strdup(buf + k + n + 1);
+			break;
+		}
+		k = i + 1;
+	}
+	free(buf);
+
+	return value;
+}
+
+// this always happens in rpiab.txt
+static int rpiab_set_env_key(char *key, char *value)
+{
+	int fd, ret = -1, res, len;
+	char *s, *d, *path;
+	char v[128] = { 0 };
+	char old[UBOOT_ENV_SIZE] = { 0 };
+	char new[UBOOT_ENV_SIZE] = { 0 };
+
+	pv_log(DEBUG, "setting boot env key %s with value %s", key, value);
+
+	path = paths.rpiab_txt;
+	len = UBOOT_ENV_SIZE;
+
+	fd = open(path, O_RDWR | O_CREAT | O_SYNC, 0600);
+	if (fd < 0) {
+		pv_log(FATAL, "open bootloader file failed for %s: %s", path,
+		       strerror(errno));
+		goto out;
+	}
+
+	lseek(fd, 0, SEEK_SET);
+	res = read(fd, old, len);
+
+	d = (char *)new;
+	for (uint16_t i = 0; i < res; i++) {
+		if ((old[i] == '\xFF' && old[i + 1] == '\xFF') ||
+		    (old[i] == '\0' && old[i + 1] == '\0'))
+			break;
+
+		if (old[i] == '\0')
+			continue;
+
+		// skip garbage before (start with alpha)
+		if (old[i] < 'A' || old[i] > 'z')
+			continue;
+
+		s = (char *)old + i;
+		len = strlen(s);
+		// remove garbage from end
+		for (int j = 0; j < len; j++) {
+			// anything below ! and above ~ is invalid and we cut it
+			if (old[j] <= '!' || old[j] >= '~')
+				old[j] = 0;
+		}
+		// get new len
+		len = strlen(s);
+		if (memcmp(s, key, strlen(key))) {
+			memcpy(d, s, len + 1);
+			d += len + 1;
+		}
+		i += len;
+	}
+
+	SNPRINTF_WTRUNC(v, sizeof(v) - 1, "%s=%s", key, value);
+
+	memcpy(d, v, strlen(v) + 1);
+
+	lseek(fd, 0, SEEK_SET);
+	write(fd, new, sizeof(new));
+	fsync(fd);
+	close(fd);
+	pv_fs_path_sync(path);
+
+	ret = 0;
+out:
+	return ret;
+}
+
+// this always happens in rpiab.txt
+static int rpiab_unset_env_key(char *key)
+{
+	return rpiab_set_env_key(key, "\0");
+}
+
+static int rpiab_flush_env(void)
+{
+	return 0;
+}
+
+static int _rpiab_mark_tryboot()
+{
+	int rv = 0;
+	unsigned args[256] = {};
+
+	// here we mark tryboot through raspberry pi mailbox api
+	// see vcmailbox(7)
+	// 0 - size of request in bytes = 7 * sizeof(u32)
+	// 1 - 0 for request code (here response success will be placed
+	// 2 - tag: tag ID
+	// 3 - tag: size of payload (1 word = 4 bytes)
+	// 4 - tag: request ID (0 for bit 31 must be 0)
+	// 5 - tag: the payload -> u32 0x1 (mark tryboot)
+	// 6 - tag: end tag
+	args[0] = 7 * sizeof(args[0]);
+	args[1] = 0;
+	args[2] = RPI_FIRMWARE_SET_REBOOT_FLAGS;
+	args[3] = 4;
+	args[4] = 0;
+	args[5] = (uint32_t)0x1;
+	args[6] = 0;
+
+	int mbox = mbox_open();
+	if (mbox < 0) {
+		pv_log(ERROR, "Failed to open mbox for rpiab %s",
+		       strerror(errno));
+		return -5;
+	}
+
+	rv = mbox_property(mbox, args);
+	if (rv < 0) {
+		pv_log(ERROR, "Failed to write mbox property: %s",
+		       strerror(errno));
+		return -5;
+	}
+	mbox_close(mbox);
+
+	return 0;
+}
+
+static int _rpiab_install_trybootimg(struct pv_state *pending)
+{
+	char imgpath[PATH_MAX];
+	char trypath[PATH_MAX];
+	struct stat st;
+	int rv;
+	off_t si;
+
+	// if no bootimg, we can't install things.
+	if (!pending->bsp.img.rpiab.bootimg) {
+		return -1;
+	}
+
+#ifndef PVTEST
+	pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, pending->rev,
+				       "rpiboot.img");
+	if (stat(imgpath, &st)) {
+		pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, pending->rev,
+					       "rpiboot.img.gz");
+	}
+
+#else
+	char *mock_bootimg = getenv("PVTEST_PATH_RPIBOOT");
+	if (!mock_bootimg) {
+		pv_log(ERROR,
+		       "no PVTEST_PATH_RPIBOOT env set; point it to the boot.img to install");
+		return -1;
+	}
+	memcpy(imgpath, mock_bootimg, strlen(mock_bootimg));
+#endif
+
+	rv = stat(imgpath, &st);
+	if (rv) {
+		pv_log(ERROR, "rpiboot.img io error %s: %s", imgpath,
+		       strerror(errno));
+		return -3;
+	}
+
+	sprintf(trypath, "%s", paths.bootimg[autoboot_try_partition - 1]);
+	pv_log(INFO, "Installing rpiab boot.img on try path partition %d: %s",
+	       autoboot_try_partition, trypath);
+
+	FILE *tryf = fopen(imgpath, "r");
+	if (!tryf) {
+		pv_log(ERROR, "Unable to open rpiab image souce path: %s - %s",
+		       imgpath, strerror(errno));
+		return -5;
+	}
+	FILE *tryp = fopen(trypath, "w");
+	if (!tryp) {
+		pv_log(ERROR,
+		       "Unable to open rpiab image try part path: %s - %s",
+		       trypath, strerror(errno));
+		fclose(tryf);
+		return -5;
+	}
+
+	// gzip install
+	if (!strcmp(imgpath + strlen(imgpath) - 3, ".gz")) {
+		pv_log(DEBUG, "Installing bootimg %s with .gz compression %s",
+		       imgpath, trypath);
+		rv = pv_zlib_uncompress(tryf, tryp);
+		if (rv) {
+			pv_zlib_report_error(rv, tryf, tryp);
+			pv_log(ERROR, "Unable install gzipped bootimg %s",
+			       trypath);
+			fclose(tryf);
+			fclose(tryp);
+			return -1;
+		}
+	} else {
+		pv_log(DEBUG, "Installing bootimg with no compression %s -> %s",
+		       imgpath, trypath);
+
+		char *b = malloc(1024 * 1024);
+
+		for (si = 0; si < st.st_size; si = si + (1024 * 1024)) {
+			int rc, wc;
+			rc = fread(b, 1, (1024 * 1024), tryf);
+			if (rc < 0) {
+				pv_log(ERROR,
+				       "unable to finish write; too large boot.img for partition");
+				goto close_err;
+			}
+			if (!rc)
+				break;
+			wc = fwrite(b, 1, rc, tryp);
+			if (wc != rc) {
+				pv_log(ERROR,
+				       "unable to finish write; too large boot.img for partition");
+				goto close_err;
+			}
+			continue;
+		close_err:
+			fclose(tryf);
+			fclose(tryp);
+			return -4;
+		}
+		free(b);
+		b = NULL;
+	}
+	fflush(tryp);
+	fsync(fileno(tryp));
+	fclose(tryf);
+	fclose(tryp);
+	pv_log(INFO, "Installing rpiab boot.img finished. %s", trypath);
+
+	return 0;
+}
+
+static char *trim_space(char *str)
+{
+	char *end;
+	/* skip leading whitespace */
+	while (isspace(*str)) {
+		str = str + 1;
+	}
+	/* remove trailing whitespace */
+	end = str + strlen(str) - 1;
+	while (end > str && isspace(*end)) {
+		end = end - 1;
+	}
+	/* write null character */
+	*(end + 1) = '\0';
+	return str;
+}
+
+static int _rpiab_setrev_trybootimg(struct pv_state *pending)
+{
+	int wstatus;
+	size_t s;
+	sigset_t oldset;
+	char cmdline_buf[32257] = { 0 };
+	char *cmdline_ptr;
+	char *cmdbuf = NULL, *cmdbuf2 = NULL;
+	;
+
+	pv_log(INFO, "setrev on trybootimg");
+
+	s = snprintf(cmdbuf, 0, "mcopy -n -i %s ::cmdline.txt %s",
+		     paths.bootimg[autoboot_try_partition - 1],
+		     paths.cmdline_tmp) +
+	    1;
+
+	cmdbuf2 = realloc(cmdbuf, s * sizeof(char));
+	if (!cmdbuf2) {
+		if (cmdbuf)
+			free(cmdbuf);
+		pv_log(ERROR, "Cannot allocate memory for cmdbuf");
+		return -1;
+	}
+	cmdbuf = cmdbuf2;
+	cmdbuf2 = NULL;
+
+	snprintf(cmdbuf, s, "mcopy -n -i %s ::cmdline.txt %s",
+		 paths.bootimg[autoboot_try_partition - 1], paths.cmdline_tmp);
+
+	if (pvsignals_block_chld(&oldset)) {
+		pv_log(ERROR, "Cannot block sigchld: %s", strerror(errno));
+		free(cmdbuf);
+		return -2;
+	}
+
+	pv_log(DEBUG, "extracting cmdline.txt from boot.img");
+
+	pid_t p = tsh_run(cmdbuf, 0, NULL);
+	if (p < 0) {
+		pv_log(ERROR, "tsh_run '%s' failed with error: %s\n", cmdbuf,
+		       strerror(errno));
+		return -1;
+	}
+
+	free(cmdbuf);
+	for (int i = 0; i < 10; i++) {
+		pid_t wp = waitpid(p, &wstatus, WNOHANG);
+		if (wp < 0) {
+			pv_log(INFO,
+			       "error running mcopy for autoboot.txt extract: %s",
+			       strerror(errno));
+			pvsignals_setmask(&oldset);
+			return -1;
+		}
+		if (wp > 0) {
+			if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus)) {
+				pv_log(DEBUG,
+				       "cmdline.txt extract from image failed with status %d",
+				       WEXITSTATUS(wstatus));
+				return -1;
+			}
+			break;
+		}
+		sleep(1);
+	}
+
+	cmdbuf = NULL;
+	pvsignals_setmask(&oldset);
+
+	pv_log(DEBUG, "reading cmdline.txt");
+	FILE *f = fopen(paths.cmdline_tmp, "r");
+
+	if (!f) {
+		pv_log(ERROR, "Cannot open cmdline.txt %s: %s",
+		       paths.cmdline_tmp, strerror(errno));
+		return -12;
+	}
+
+	s = fread(cmdline_buf, 1, sizeof(cmdline_buf), f);
+	fclose(f);
+
+	if (!s) {
+		pv_log(ERROR, "Cannot proceed with empty cmdline.txt");
+		return -1;
+	}
+
+	cmdline_buf[sizeof(cmdline_buf) - 1] = 0;
+
+	// support 128 chars long pv_rev=... string
+	if (s > sizeof(cmdline_buf) - 129) {
+		pv_log(ERROR,
+		       "cmdline.txt too large. we only support up to %llu bytes",
+		       sizeof(cmdline_buf) - 129);
+		return -1;
+	}
+	cmdline_buf[s + 1] = 0;
+
+	cmdline_ptr = trim_space(cmdline_buf);
+	char *peek = strstr(cmdline_ptr, "pv_rev=");
+
+	// cut off any traling pv_rev= stanza
+	if (peek)
+		*peek = 0;
+
+	// append pv_rev=REVISION to finish the patch...
+	s = snprintf(cmdline_ptr + strlen(cmdline_ptr), 0, " pv_rev=%s",
+		     pending->rev);
+
+	snprintf(cmdline_ptr + strlen(cmdline_ptr), s + 1, " pv_rev=%s",
+		 pending->rev);
+
+	f = fopen(paths.cmdline_tmp, "w");
+	fwrite(cmdline_ptr, 1, strlen(cmdline_ptr), f);
+	fclose(f);
+
+	pv_log(DEBUG, "synching cmdline.txt: %s", cmdline_ptr);
+
+	//
+	// now we copy the file to try_boot partition
+	//
+	s = snprintf(cmdbuf, 0, "mcopy -o -i %s %s ::cmdline.txt",
+		     paths.bootimg[autoboot_try_partition - 1],
+		     paths.cmdline_tmp) +
+	    1;
+	cmdbuf2 = realloc(cmdbuf, s * sizeof(char));
+	if (!cmdbuf2) {
+		if (cmdbuf)
+			free(cmdbuf);
+		pv_log(ERROR, "Cannot allocate memory for cmdbuf");
+		return -1;
+	}
+	cmdbuf = cmdbuf2;
+	cmdbuf2 = NULL;
+
+	snprintf(cmdbuf, s, "mcopy -o -i %s %s ::cmdline.txt",
+		 paths.bootimg[autoboot_try_partition - 1], paths.cmdline_tmp);
+
+	if (pvsignals_block_chld(&oldset)) {
+		pv_log(ERROR, "Cannot block sigchld: %s", strerror(errno));
+		free(cmdbuf);
+		return -2;
+	}
+
+	pv_log(DEBUG, "copying patched cmdline.txt to bootimg: %s", cmdbuf);
+	p = tsh_run(cmdbuf, 0, NULL);
+
+	free(cmdbuf);
+	for (int i = 0; i < 10; i++) {
+		pid_t wp = waitpid(p, &wstatus, WNOHANG);
+		if (wp < 0) {
+			pv_log(INFO, "error running mcopy for autoboot.txt: %s",
+			       strerror(errno));
+			pvsignals_setmask(&oldset);
+			return -1;
+		}
+		if (wp > 0) {
+			if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus)) {
+				pv_log(DEBUG,
+				       "cmdline.txt copy to image failed with status %d",
+				       WEXITSTATUS(wstatus));
+				return -1;
+			}
+			break;
+		}
+		sleep(1);
+	}
+
+	pvsignals_setmask(&oldset);
+
+	pv_log(INFO, "setrev on trybootimg done.");
+	return 0;
+}
+
+static int rpiab_install_update(struct pv_update *update)
+{
+	struct pv_state *pending = update->pending;
+
+	if (_rpiab_install_trybootimg(pending)) {
+		pv_log(ERROR, "Error installing tryboot image.");
+		return -1;
+	}
+
+	if (_rpiab_setrev_trybootimg(pending)) {
+		pv_log(ERROR, "Error setting pv_rev in tryboot");
+		return -1;
+	}
+
+	if (_rpiab_mark_tryboot()) {
+		pv_log(ERROR, "Error marking tryboot");
+		return -1;
+	}
+
+	pv_log(INFO, "Install update finished.");
+	return 0;
+}
+
+static int rpiab_commit_update()
+{
+	size_t s;
+	char *cmdbuf = NULL, *cmdbuf2 = NULL;
+	sigset_t oldset;
+	pid_t p;
+	int wstatus;
+
+	// here we flip try and normal boot
+	char autoconf_buf[512] = { 0 };
+	s = snprintf(autoconf_buf, 512,
+		     "[all]\n"
+		     "tryboot_a_b=1\n"
+		     "boot_partition=%d\n"
+		     "[tryboot]\n"
+		     "boot_partition=%d\n",
+		     autoboot_try_partition, autoboot_boot_partition);
+
+	pv_log(DEBUG, "Creating autoboot.txt: %s", autoconf_buf);
+
+	FILE *f = fopen(paths.autoboot_tmp, "w");
+	if (!f) {
+		pv_log(ERROR, "Cannot open autoboot.txt tmp for write %s: %s",
+		       paths.autoboot_tmp, strerror(errno));
+		return -1;
+	}
+	if (!fwrite(autoconf_buf, 1, s + 1, f)) {
+		pv_log(ERROR, "Cannot write to autoboot.txt %s: %s",
+		       paths.autoboot_tmp, strerror(errno));
+		return -1;
+	}
+	fclose(f);
+
+	//
+	// now we copy the file to autoboot partition
+	//
+	s = snprintf(cmdbuf, 0, "mcopy -o -i %s %s ::autoboot.txt",
+		     paths.bootimg[0], paths.autoboot_tmp) +
+	    1;
+	cmdbuf2 = realloc(cmdbuf, s * sizeof(char));
+	if (!cmdbuf2) {
+		if (cmdbuf)
+			free(cmdbuf);
+		pv_log(ERROR, "Cannot allocate memory for cmdbuf");
+		return -1;
+	}
+	cmdbuf = cmdbuf2;
+	cmdbuf2 = NULL;
+
+	snprintf(cmdbuf, s, "mcopy -o -i %s %s ::autoboot.txt",
+		 paths.bootimg[0], paths.autoboot_tmp);
+
+	if (pvsignals_block_chld(&oldset)) {
+		pv_log(ERROR, "Cannot block sigchld: %s", strerror(errno));
+		free(cmdbuf);
+		return -2;
+	}
+
+	pv_log(DEBUG, "copying patched autoboot.txt to bootimg: %s", cmdbuf);
+	p = tsh_run(cmdbuf, 0, NULL);
+
+	free(cmdbuf);
+	for (int i = 0; i < 10; i++) {
+		pid_t wp = waitpid(p, &wstatus, WNOHANG);
+		if (wp < 0) {
+			pv_log(INFO, "error running mcopy for autoboot.txt: %s",
+			       strerror(errno));
+			pvsignals_setmask(&oldset);
+			return -1;
+		}
+		if (wp > 0) {
+			if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus)) {
+				pv_log(DEBUG,
+				       "autoboot copy failed with status %d",
+				       WEXITSTATUS(wstatus));
+				return -1;
+			}
+
+			break;
+		}
+		sleep(1);
+	}
+
+	pvsignals_setmask(&oldset);
+
+	return -1;
+}
+
+static int rpiab_fail_update(struct pv_update *update)
+{
+	return -1;
+}
+
+const struct bl_ops rpiab_ops = {
+	.init = rpiab_init,
+	.set_env_key = rpiab_set_env_key,
+	.unset_env_key = rpiab_unset_env_key,
+	.get_env_key = rpiab_get_env_key,
+	.flush_env = rpiab_flush_env,
+	.install_update = rpiab_install_update,
+	.commit_update = rpiab_commit_update,
+	.fail_update = rpiab_fail_update,
+};
+
+/*
+Copyright (c) 2015 Raspberry Pi (Trading) Ltd.
+All rights reserved.
+Copyright (c) 2024 Pantacor Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define DEVICE_FILE_NAME "/dev/vcio"
+#define MAJOR_NUM 100
+#define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)
+
+/*
+ * use ioctl to send mbox property message
+ */
+
+static int mbox_property(int file_desc, void *buf)
+{
+	int ret_val = ioctl(file_desc, IOCTL_MBOX_PROPERTY, buf);
+
+	if (ret_val < 0) {
+		pv_log(ERROR, "ioctl_set_msg IOCTL_MBOX_PROPERTY failed:%d\n",
+		       ret_val);
+	}
+	return ret_val;
+}
+
+static int mbox_open()
+{
+	int file_desc;
+
+	// open a char device file used for communicating with kernel mbox driver
+	file_desc = open(DEVICE_FILE_NAME, 0);
+	if (file_desc < 0) {
+		printf("Can't open device file: %s\n", DEVICE_FILE_NAME);
+		printf("Try creating a device file with: sudo mknod %s c %d 0\n",
+		       DEVICE_FILE_NAME, MAJOR_NUM);
+		return -1;
+	}
+	return file_desc;
+}
+
+static void mbox_close(int file_desc)
+{
+	close(file_desc);
+}

--- a/rpiab.test.c
+++ b/rpiab.test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2023-2024 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,44 +19,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef PV_BOOTLOADER_H
-#define PV_BOOTLOADER_H
 
-#include <stdbool.h>
+#ifndef PVTEST
+#define PVTEST
+#endif
+
+#include "rpiab.c"
+#include "state.h"
 #include "updater.h"
 
-struct bl_ops {
-	int (*init)(void);
+int main()
+{
+	rpiab_init();
 
-	/* old primitive semantic */
-	int (*set_env_key)(char *key, char *value);
-	int (*unset_env_key)(char *key);
-	char *(*get_env_key)(char *key);
-	int (*flush_env)(void);
+	struct pv_state state_mock = { .rev = "1",
+				       .bsp = { .img.rpiab = {
+							.bootimg = "/test",
+						} } };
 
-	/* new semantic */
-	int (*install_update)(struct pv_update *update);
-	int (*commit_update)();
-	int (*fail_update)(struct pv_update *update);
-};
+	struct pv_update update_mock = { .pending = &state_mock };
 
-void pv_bootloader_print(void);
+	printf("=== _rpiab_install_trybootimg ===\n");
 
-const char *pv_bootloader_get_rev(void);
-const char *pv_bootloader_get_try(void);
-const char *pv_bootloader_get_done(void);
+	if (_rpiab_install_trybootimg(&state_mock)) {
+		pv_log(ERROR, "Error installing tryboot image.");
+		return -1;
+	}
 
-bool pv_bootloader_update_in_progress(void);
-bool pv_bootloader_trying_update(void);
-
-int pv_bootloader_set_installed(char *rev);
-int pv_bootloader_set_commited(char *rev);
-int pv_bootloader_set_failed(void);
-
-int pv_bootloader_install_update(struct pv_update *update);
-int pv_bootloader_commit_update(void);
-int pv_bootloader_fail_update(struct pv_update *update);
-
-void pv_bootloader_remove(void);
-
-#endif
+	printf("=== _rpiab_setrev_trybootimg ===\n");
+	if (_rpiab_setrev_trybootimg(&state_mock)) {
+		pv_log(ERROR, "Error setting pv_rev in tryboot");
+		return -1;
+	}
+	return 0;
+}

--- a/state.h
+++ b/state.h
@@ -38,6 +38,10 @@ struct pv_bsp {
 		struct {
 			char *fit;
 		} ut;
+		struct {
+			void *padding;
+			char *bootimg;
+		} rpiab;
 	} img;
 	char *firmware;
 	char *modules;

--- a/uboot.c
+++ b/uboot.c
@@ -178,7 +178,7 @@ static int uboot_set_env_key(char *key, char *value)
 	unsigned char old[MTD_ENV_SIZE] = { 0 };
 	unsigned char new[MTD_ENV_SIZE] = { 0 };
 	char *s, *d, *path;
-	char v[128];
+	char v[128] = { 0 };
 
 	pv_log(DEBUG, "setting boot env key %s with value %s", key, value);
 
@@ -321,4 +321,7 @@ const struct bl_ops uboot_ops = {
 	.unset_env_key = uboot_unset_env_key,
 	.get_env_key = uboot_get_env_key,
 	.flush_env = uboot_flush_env,
+	.install_update = NULL,
+	.commit_update = NULL,
+	.fail_update = NULL,
 };

--- a/updater.c
+++ b/updater.c
@@ -1428,6 +1428,7 @@ int pv_update_finish(struct pantavisor *pv)
 		}
 		pv_update_set_status(u, UPDATE_DONE);
 		pv_storage_set_rev_done(pv->state->rev);
+		pv_bootloader_commit_update();
 		pv->state->done = true;
 		break;
 	// UPDATED TRANSITIONS
@@ -2021,6 +2022,12 @@ int pv_update_install(struct pantavisor *pv)
 	if (!pv_storage_meta_expand_jsons(pv, pending)) {
 		pv_log(ERROR,
 		       "unable to install platform and pantavisor jsons");
+		ret = -1;
+		goto out;
+	}
+
+	if (pv_bootloader_install_update(update)) {
+		pv_log(ERROR, "unable to install bootloader");
 		ret = -1;
 		goto out;
 	}

--- a/utils/pvzlib.c
+++ b/utils/pvzlib.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2024 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* This original file was downloaded from https://www.zlib.net/zpipe.c on
+   Jan 22, 2024 and came with following public domain licesnse header:
+
+   zpipe.c: example of proper use of zlib's inflate() and deflate()
+   Not copyrighted -- provided to the public domain
+   Version 1.4  11 December 2005  Mark Adler */
+
+/* Version history:
+   1.0  30 Oct 2004  First version
+   1.1   8 Nov 2004  Add void casting for unused return values
+                     Use switch statement for inflate() return values
+   1.2   9 Nov 2004  Add assertions to document zlib guarantees
+   1.3   6 Apr 2005  Remove incorrect assertion in inf()
+   1.4  11 Dec 2005  Add hack to avoid MSDOS end-of-line conversions
+                     Avoid some compiler warnings for input and output buffers
+   XX      Jan 2024  Pantavisor integration mangling....
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "zlib.h"
+
+#if defined(MSDOS) || defined(OS2) || defined(WIN32) || defined(__CYGWIN__)
+#include <fcntl.h>
+#include <io.h>
+#define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
+#else
+#define SET_BINARY_MODE(file)
+#endif
+
+#define CHUNK 16384
+
+// Pantavisor integration for logs
+#include "utils/pvzlib.h"
+
+#define MODULE_NAME "pvzlib"
+#ifndef PVTEST
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#else
+#define pv_log(level, msg, ...)                                                \
+	printf("%s[%d]: ", MODULE_NAME, level);                                \
+	printf(msg "\n", ##__VA_ARGS__)
+#endif
+#include "log.h"
+
+/* Compress from file source to file dest until EOF on source.
+   def() returns Z_OK on success, Z_MEM_ERROR if memory could not be
+   allocated for processing, Z_STREAM_ERROR if an invalid compression
+   level is supplied, Z_VERSION_ERROR if the version of zlib.h and the
+   version of the library linked do not match, or Z_ERRNO if there is
+   an error reading or writing the files. */
+int pv_zlib_compress(FILE *source, FILE *dest, int level)
+{
+	int ret, flush;
+	unsigned have;
+	z_stream strm;
+	unsigned char in[CHUNK];
+	unsigned char out[CHUNK];
+
+	/* allocate deflate state */
+	strm.zalloc = Z_NULL;
+	strm.zfree = Z_NULL;
+	strm.opaque = Z_NULL;
+	ret = deflateInit(&strm, level);
+	if (ret != Z_OK)
+		return ret;
+
+	/* compress until end of file */
+	do {
+		strm.avail_in = fread(in, 1, CHUNK, source);
+		if (ferror(source)) {
+			(void)deflateEnd(&strm);
+			return Z_ERRNO;
+		}
+		flush = feof(source) ? Z_FINISH : Z_NO_FLUSH;
+		strm.next_in = in;
+
+		/* run deflate() on input until output buffer not full, finish
+           compression if all of source has been read in */
+		do {
+			strm.avail_out = CHUNK;
+			strm.next_out = out;
+			ret = deflate(&strm, flush); /* no bad return value */
+			assert(ret != Z_STREAM_ERROR); /* state not clobbered */
+			have = CHUNK - strm.avail_out;
+			if (fwrite(out, 1, have, dest) != have ||
+			    ferror(dest)) {
+				(void)deflateEnd(&strm);
+				return Z_ERRNO;
+			}
+		} while (strm.avail_out == 0);
+		assert(strm.avail_in == 0); /* all input will be used */
+
+		/* done when last data in file processed */
+	} while (flush != Z_FINISH);
+	assert(ret == Z_STREAM_END); /* stream will be complete */
+
+	/* clean up and return */
+	(void)deflateEnd(&strm);
+	return Z_OK;
+}
+
+/* Decompress from file source to file dest until stream ends or EOF.
+   inf() returns Z_OK on success, Z_MEM_ERROR if memory could not be
+   allocated for processing, Z_DATA_ERROR if the deflate data is
+   invalid or incomplete, Z_VERSION_ERROR if the version of zlib.h and
+   the version of the library linked do not match, or Z_ERRNO if there
+   is an error reading or writing the files. */
+int pv_zlib_uncompress(FILE *source, FILE *dest)
+{
+	int ret;
+	unsigned have;
+	z_stream strm;
+	unsigned char in[CHUNK];
+	unsigned char out[CHUNK];
+
+	/* allocate inflate state */
+	strm.zalloc = Z_NULL;
+	strm.zfree = Z_NULL;
+	strm.opaque = Z_NULL;
+	strm.avail_in = 0;
+	strm.next_in = Z_NULL;
+	ret = inflateInit2(&strm, 16 + MAX_WBITS);
+	if (ret != Z_OK)
+		return ret;
+
+	/* decompress until deflate stream ends or end of file */
+	do {
+		strm.avail_in = fread(in, 1, CHUNK, source);
+		if (ferror(source)) {
+			(void)inflateEnd(&strm);
+			return Z_ERRNO;
+		}
+		if (strm.avail_in == 0)
+			break;
+		strm.next_in = in;
+
+		/* run inflate() on input until output buffer not full */
+		do {
+			strm.avail_out = CHUNK;
+			strm.next_out = out;
+			ret = inflate(&strm, Z_NO_FLUSH);
+			assert(ret != Z_STREAM_ERROR); /* state not clobbered */
+			switch (ret) {
+			case Z_NEED_DICT:
+				ret = Z_DATA_ERROR; /* and fall through */
+				// fall through
+			case Z_DATA_ERROR:
+				// fall through
+			case Z_MEM_ERROR:
+				(void)inflateEnd(&strm);
+				return ret;
+			}
+
+			have = CHUNK - strm.avail_out;
+			if (fwrite(out, 1, have, dest) != have ||
+			    ferror(dest)) {
+				(void)inflateEnd(&strm);
+				return Z_ERRNO;
+			}
+		} while (strm.avail_out == 0);
+
+		/* done when inflate() says it's done */
+	} while (ret != Z_STREAM_END);
+
+	/* clean up and return */
+	(void)inflateEnd(&strm);
+	return ret == Z_STREAM_END ? Z_OK : Z_DATA_ERROR;
+}
+
+/* report a zlib or i/o error */
+void pv_zlib_report_error(int ret, FILE *src, FILE *dst)
+{
+	switch (ret) {
+	case Z_ERRNO:
+		if (ferror(src))
+			pv_log(WARN, "error reading source\n");
+		if (ferror(dst))
+			pv_log(WARN, "error writing to dst\n");
+		break;
+	case Z_STREAM_ERROR:
+		pv_log(WARN, "invalid compression level\n");
+		break;
+	case Z_DATA_ERROR:
+		pv_log(WARN, "invalid or incomplete deflate data\n");
+		break;
+	case Z_MEM_ERROR:
+		pv_log(WARN, "out of memory\n");
+		break;
+	case Z_VERSION_ERROR:
+		pv_log(WARN, "zlib version mismatch!\n");
+	}
+}

--- a/utils/pvzlib.h
+++ b/utils/pvzlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2024 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -19,44 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef PV_BOOTLOADER_H
-#define PV_BOOTLOADER_H
+#ifndef PVZLIB_H
+#define PVZLIB_H
+#include <stdio.h>
 
-#include <stdbool.h>
-#include "updater.h"
-
-struct bl_ops {
-	int (*init)(void);
-
-	/* old primitive semantic */
-	int (*set_env_key)(char *key, char *value);
-	int (*unset_env_key)(char *key);
-	char *(*get_env_key)(char *key);
-	int (*flush_env)(void);
-
-	/* new semantic */
-	int (*install_update)(struct pv_update *update);
-	int (*commit_update)();
-	int (*fail_update)(struct pv_update *update);
-};
-
-void pv_bootloader_print(void);
-
-const char *pv_bootloader_get_rev(void);
-const char *pv_bootloader_get_try(void);
-const char *pv_bootloader_get_done(void);
-
-bool pv_bootloader_update_in_progress(void);
-bool pv_bootloader_trying_update(void);
-
-int pv_bootloader_set_installed(char *rev);
-int pv_bootloader_set_commited(char *rev);
-int pv_bootloader_set_failed(void);
-
-int pv_bootloader_install_update(struct pv_update *update);
-int pv_bootloader_commit_update(void);
-int pv_bootloader_fail_update(struct pv_update *update);
-
-void pv_bootloader_remove(void);
+int pv_zlib_compress(FILE *source, FILE *dest, int level);
+int pv_zlib_uncompress(FILE *source, FILE *dest);
+void pv_zlib_report_error(int ret, FILE *src, FILE *dst);
 
 #endif


### PR DESCRIPTION

    rpiab booloader support for Raspbery Pi Firmware A/B tryboot
    
     * ship pantavisor and kernel as part of full raspberry pi boot partition
     * install dtbs to boot partition from kernel
     * use mcopy to copy autoboot.txt to and from partition 1
     * patch cmdline.txt in boot-a/b partition to have pv_rev
     * add pvzlib.c/h helper to support shipping gzipped boot partitions
     * add support for shipping 'rpiab' partition in run.json
     * parse /proc-device-tree and autoconf.txt in early boot to find tryboot
       info and partition and boot disk (through boot-mode)
     * set tryboot flag through IOCTL_MBOX_PROPERTY ioctl (mbox_property)
    
    Example run.json:
    {
        "addons": [],
        "firmware": "firmware.squashfs",
        "initrd_config": "trail.config",
        "modules": "modules.squashfs",
        "rpiab": "pantavisor-rpi.img.gz"
    }
    
    See: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#fail-safe-os-updates-tryboot
    See: https://www.raspberrypi.com/documentation/computers/config_txt.html#autoboot-txt
    See: https://github.com/raspberrypi/userland/tree/master/host_applications/linux/apps/vcmailbox