### PR TITLE
fix: dmverity and crypt disks not being preemptively closed

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -160,6 +160,24 @@ do_dm_sanity()
 	which mkfs.ext4 &> /dev/null || exit 111
 }
 
+clean_disk()
+{
+	local type="$1"
+	local name="$2"
+
+	if [ "$type" = "caam" ]; then
+		if dmsetup info -c "$name" >/dev/null 2>&1; then
+			echo "WARN: dm $name still exists"
+			dmsetup remove "$name" > /dev/null 2>&1 || true
+		fi
+	elif [ "$type" = "dcp" ] || [ "$type" = "versatile" ]; then
+		if cryptsetup status "$name" > /dev/null 2>&1; then
+			echo "WARN: cryptdisk $1 still exists"
+			cryptsetup close "$name" > /dev/null 2>&1 || true
+		fi
+	fi
+}
+
 do_mount_disk()
 {
 	do_dm_sanity
@@ -194,6 +212,7 @@ do_mount_disk()
 	fi
 
 	device_name=`echo $img_file | awk '{split($0,a,"."); print a[1]}'`
+	clean_disk "$dm_type" "$device_name"
 	if [ $dm_type == "caam" ]; then
 		dmsetup create $device_name --table "0 $(blockdev --getsz $CAAM_LOOP) crypt capi:tk(cbc(aes))-plain :36:logon:logkey: 0 $CAAM_LOOP 0 1 sector_size:512"
 	elif [ $dm_type == "dcp" ]; then

--- a/scripts/volmount/verity/dm
+++ b/scripts/volmount/verity/dm
@@ -27,6 +27,14 @@ volumesrc=$2
 container=$3
 volume=$4
 
+clean_dm() {
+	local name="$1"
+	if dmsetup info -c "$name" >/dev/null 2>&1; then
+		echo "WARN: dm $name still exists"
+		dmsetup remove "$name" > /dev/null 2>&1 || true
+	fi
+}
+
 do_mount_squash() {
 	traildir=`dirname $1`
 	squashname=`basename $1`
@@ -44,6 +52,7 @@ do_mount_squash() {
 	hdev=`cat $dmmanifest | JSON.sh -l |  grep hash_device | awk '{ print $2 }' | sed -e 's/^"//;s/"$//'`
 	rhash=`cat $dmmanifest | JSON.sh -l | grep root_hash | awk '{ print $2 }' | sed -e 's/^"//;s/"$//'`
 
+	clean_dm "$dmname"
 	if ! veritysetup create $dmname $traildir/$ddev $traildir/$hdev $rhash; then
 		echo "ERROR: could not setup dm volume with veritysetup"
 		return 2


### PR DESCRIPTION
It has been observed in App Engine that, if Pantavisor cannot properly shutdown, it would leave remnants for the next execution. This would make Pantavisor fail unless the host machine were rebooted.

With this PR, we want to preemptively close those crypt and dmverity vols before trying to initialize them.