### PR TITLE
new stdout_direct logserver sink

### DIFF
--- a/config.c
+++ b/config.c
@@ -171,6 +171,9 @@ static int config_parse_log_server_outputs(const char *value)
 			server_outputs |= LOG_SERVER_OUTPUT_FILE_TREE;
 		else if (!strncmp(token, "nullsink", strlen("nullsink")))
 			server_outputs |= LOG_SERVER_OUTPUT_NULL_SINK;
+		else if (!strncmp(token, "stdout_direct",
+				  strlen("stdout_direct")))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_DIRECT;
 		else if (!strncmp(token, "stdout.containers",
 				  strlen("stdout.containers")))
 			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_CONTAINERS;

--- a/config.h
+++ b/config.h
@@ -147,7 +147,8 @@ typedef enum {
 	LOG_SERVER_OUTPUT_STDOUT = 1 << 3,
 	LOG_SERVER_OUTPUT_STDOUT_CONTAINERS = 1 << 4,
 	LOG_SERVER_OUTPUT_STDOUT_PANTAVISOR = 1 << 5,
-	LOG_SERVER_OUTPUT_UPDATE = 1 << 6,
+	LOG_SERVER_OUTPUT_STDOUT_DIRECT = 1 << 6,
+	LOG_SERVER_OUTPUT_UPDATE = 1 << 7,
 } log_server_output_mask_t;
 
 struct pantavisor_log_server {

--- a/init.c
+++ b/init.c
@@ -54,6 +54,7 @@
 #include "wdt.h"
 #include "drivers.h"
 #include "apparmor.h"
+#include "buffer.h"
 
 #include "utils/tsh.h"
 #include "utils/math.h"
@@ -374,6 +375,10 @@ int main(int argc, char *argv[])
 {
 	char *config_path = NULL, *cmdline = NULL;
 
+	pv_init();
+	// init buffer with 128Kb to allow logging. Will later be resized according to config
+	pv_buffer_init(10, 128);
+
 	pv_pid = 0;
 
 	setenv("LIBPVPATH", "/lib/pv", 0);
@@ -386,9 +391,6 @@ int main(int argc, char *argv[])
 
 	// get command argument options
 	parse_options(argc, argv, &config_path, &cmdline);
-
-	// init pv struct
-	pv_init();
 
 	// read /proc/cmdline if not injected from args
 	if (read_cmdline(cmdline))

--- a/log.c
+++ b/log.c
@@ -128,7 +128,7 @@ void __log(char *module, int level, const char *fmt, ...)
 {
 	va_list args;
 
-	if (level > pv_config_get_log_loglevel())
+	if ((level != FATAL) && (level > pv_config_get_log_loglevel()))
 		return;
 
 	va_start(args, fmt);


### PR DESCRIPTION
A new sink meant for early init and crash debugging. It works in a similar way as stdout with two differences:
* when enabled, stdout_direct messages are directly printed from the calling thread. This means, it will not pass through logserver.
* If stdout is enabled and logserver is off (before its initialization and after its shutdown), it behaves the same way as stdout_direct.
* All FATAL level logs will be printed using this method no matter the sink is enabled.

To enable it in cmdline:
`pv_log.server.outputs=stdout_direct`

In config:
`log.server.outputs=stdout_direct`