### PR TITLE
Fixes logserver timestamp format in filetree output

### DIFF
--- a/logserver/logserver_filetree.c
+++ b/logserver/logserver_filetree.c
@@ -85,7 +85,7 @@ static int add_log(struct logserver_out *out, const struct logserver_log *log)
 	if (is_pv)
 		len = logserver_utils_print_pvfmt(fd, log, "pantavisor", true);
 	else
-		len = dprintf(fd, "%.*s", log->data.len, log->data.buf);
+		len = logserver_utils_print_raw(fd, log);
 
 	close(fd);
 	free(path);

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -138,6 +138,19 @@ static int print_pvfmt_log(int fd, const struct logserver_log *log,
 	return len;
 }
 
+int logserver_utils_print_raw(int fd, const struct logserver_log *log)
+{
+	char *ts_fmt = pv_config_get_log_filetree_timestamp_format();
+	if (!ts_fmt)
+		return dprintf(fd, "%.*s", log->data.len, log->data.buf);
+
+	char ts[256] = { 0 };
+	if (logserver_timestamp_get_formated(ts, 256, &log->time, ts_fmt) != 0)
+		strncpy(ts, "--", 3);
+
+	return dprintf(fd, "[%s] %.*s", ts, log->data.len, log->data.buf);
+}
+
 int logserver_utils_stdout(const struct logserver_log *log)
 {
 	return print_pvfmt_log(STDOUT_FILENO, log, "unknown",

--- a/logserver/logserver_utils.h
+++ b/logserver/logserver_utils.h
@@ -30,6 +30,7 @@
 int logserver_utils_open_logfile(const char *path);
 int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
 				const char *src, bool lf);
+int logserver_utils_print_raw(int fd, const struct logserver_log *log);
 char *logserver_utils_jsonify_log(const struct logserver_log *log);
 char *logserver_utils_output_to_str(int out_type);
 int logserver_utils_stdout(const struct logserver_log *log);


### PR DESCRIPTION
Adds timestamp format to the container's log output, this is:
```
<container>/lxc/lxc.log
<container>/lxc/console.log
<container>/var/log/messages
<container>/var/log/syslog
```
To avoid break any log format, the timestamp was added at the begging of the lines logs.

**Note:** some logs arrive in lines batches, those logs only have a timestamp at the begging of the first line
