### PR TITLE
Initial CMake support for yocto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,257 @@
+# Set the minimum required version of CMake
+cmake_minimum_required(VERSION 3.0)
+
+# Set the project name and version
+project(pantavisor VERSION 019)
+
+# subdirectories
+add_subdirectory(plugins)
+
+# include cmake packages
+include(FindPackageHandleStandardArgs)
+
+# feature flags
+set(PANTAVISOR_DM_VERITY OFF CACHE BOOL "Enable support for dm verity mounted squash volumes")
+set(PANTAVISOR_DM_CRYPT OFF CACHE BOOL "Enable support for dm crypt mounted disks")
+set(PANTAVISOR_PVZRAM_TEST OFF CACHE BOOL "Build pvzram-test binary")
+set(PANTAVISOR_DEBUG OFF CACHE BOOL "Enable debug features for Pantavisor")
+set(PANTAVISOR_APPENGINE OFF CACHE BOOL "Build Pantavisor as appengine")
+
+# set cmake defintions
+set(CODE_INSTALL_BASE "\$ENV{DESTDIR}")
+
+# Find the shared library
+find_library(THTTP thttp)
+find_library(PICOHTTPPARSER picohttpparser)
+find_library(LXC lxc)
+find_library(ZLIB z)
+find_path(MBEDTLS_INCLUDE_DIRS mbedtls/ssl.h)
+find_library(MBEDTLS_LIBRARY mbedtls)
+find_library(MBEDX509_LIBRARY mbedx509)
+find_library(MBEDCRYPTO_LIBRARY mbedcrypto)
+set(MBEDTLS_LIBRARIES "${MBEDTLS_LIBRARY}" "${MBEDX509_LIBRARY}" "${MBEDCRYPTO_LIBRARY}")
+find_package_handle_standard_args(MBEDTLS DEFAULT_MSG
+    MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
+mark_as_advanced(MBEDTLS_INCLUDE_DIRS MBEDTLS_LIBRARY MBEDX509_LIBRARY MBEDCRYPTO_LIBRARY)
+
+# Generate version.c
+add_custom_command(
+    OUTPUT  version.c
+    COMMAND sh
+	-c
+	\"cd ${CMAKE_CURRENT_SOURCE_DIR}\; ./gen_version.sh CMAKE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SYSTEM_PROCESSOR}\"
+)
+
+# Build and Install Pantavisor
+add_executable(pantavisor
+			addons.c
+			addons.h
+			apparmor.c
+			apparmor.h
+			blkid.c
+			blkid.h
+			bootloader.c
+			bootloader.h
+			buffer.c
+			buffer.h
+			cgroup.c
+			cgroup.h
+			condition.c
+			condition.h
+			config.c
+			config.h
+			config_parser.c
+			config_parser.h
+			ctrl.c
+			ctrl.h
+			daemons.c
+			daemons.h
+			debug.c
+			debug.h
+			disk/disk.c
+			disk/disk.h
+			disk/disk_crypt.c
+			disk/disk_impl.h
+			disk/disk_swap.c
+			disk/disk_utils.c
+			disk/disk_utils.h
+			disk/disk_volume.c
+			disk/disk_volume.h
+			disk/disk_zram.c
+			disk/disk_zram_utils.c
+			disk/disk_zram_utils.h
+			drivers.c
+			drivers.h
+			group.c
+			group.h
+			grub.c
+			init.c
+			init.h
+			jsons.c
+			jsons.h
+			log.c
+			log.h
+			logger.c
+			logger.h
+			logserver/logserver.c
+			logserver/logserver.h
+			logserver/logserver_filetree.c
+			logserver/logserver_filetree.h
+			logserver/logserver_null.c
+			logserver/logserver_null.h
+			logserver/logserver_out.c
+			logserver/logserver_out.h
+			logserver/logserver_singlefile.c
+			logserver/logserver_singlefile.h
+			logserver/logserver_stdout.c
+			logserver/logserver_stdout.h
+			logserver/logserver_timestamp.c
+			logserver/logserver_timestamp.h
+			logserver/logserver_update.c
+			logserver/logserver_update.h
+			logserver/logserver_utils.c
+			logserver/logserver_utils.h
+			loop.c
+			loop.h
+			metadata.c
+			metadata.h
+			mount.c
+			mount.h
+			network.c
+			network.h
+			objects.c
+			objects.h
+			pantahub.c
+			pantahub.h
+			pantavisor.c
+			pantavisor.h
+			parser/parser.c
+			parser/parser.h
+			parser/parser_bundle.h
+			parser/parser_multi1.c
+			parser/parser_multi1.h
+			parser/parser_system1.c
+			parser/parser_system1.h
+			paths.c
+			paths.h
+			ph_logger.c
+			ph_logger.h
+			platforms.c
+			platforms.h
+			pvctl_utils.c
+			pvctl_utils.h
+			pvlogger.c
+			pvlogger.h
+			rpiab.c
+			signature.c
+			signature.h
+			state.c
+			state.h
+			storage.c
+			storage.h
+			trestclient.c
+			trestclient.h
+			uboot.c
+			updater.c
+			updater.h
+			utils/base64.c
+			utils/fs.c
+			utils/json.c
+			utils/math.c
+			utils/pvsignals.c
+			utils/pvsignals.h
+			utils/pvzlib.c
+			utils/pvzlib.h
+			utils/socket.c
+			utils/socket.h
+			utils/str.c
+			utils/strrep.c
+			utils/system.c
+			utils/timer.c
+			utils/tsh.c
+			version.c version.h
+			version.h
+			volumes.c
+			volumes.h
+			wdt.c
+			wdt.h
+)
+target_include_directories(pantavisor PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/utils ${MBEDTLS_INCLUDE_DIR})
+target_link_libraries(pantavisor ${THTTP} ${PICOHTTPPARSER} ${MBEDTLS_LIBRARIES} ${LXC} ${ZLIB})
+install(TARGETS pantavisor DESTINATION bin)
+IF(PANTAVISOR_DEBUG)
+target_compile_definitions(pantavisor PRIVATE PANTAVISOR_DEBUG)
+ENDIF()
+
+## install basic filesystem skeleton
+install(DIRECTORY skel/ DESTINATION /)
+
+### ... insert defaults/
+install(DIRECTORY defaults DESTINATION /etc/pantavisor)
+
+### install PVS secureboot files
+IF(DEFINED PANTAVISOR_PVS_DIR)
+install(DIRECTORY ${PANTAVISOR_PVS_DIR}/ DESTINATION /etc/pantavisor/pvs/trust FILES_MATCHING PATTERN "*.crt")
+ELSE()
+install(DIRECTORY pvs/ DESTINATION /etc/pantavisor/pvs)
+ENDIF()
+
+### install /init link if not appengine build
+if(NOT PANTAVISOR_APPENGINE)
+install(CODE "file(CREATE_LINK usr/bin/pantavisor ${CODE_INSTALL_BASE}/init SYMBOLIC)")
+ENDIF()
+
+### install scripts
+install(FILES scripts/JSON.sh scripts/pv_e2fsgrow scripts/pvcrash
+	PERMISSIONS WORLD_READ WORLD_EXECUTE GROUP_READ GROUP_EXECUTE OWNER_READ OWNER_WRITE OWNER_EXECUTE
+	DESTINATION /lib/pv/)
+install(DIRECTORY scripts/hooks_lxc-mount.d
+	FILE_PERMISSIONS WORLD_READ WORLD_EXECUTE GROUP_READ GROUP_EXECUTE OWNER_READ OWNER_WRITE OWNER_EXECUTE
+	DESTINATION /lib/pv)
+install(PROGRAMS tools/pventer
+			tools/fallbear-cmd
+	DESTINATION /usr/bin)
+
+### install dm crypt feature
+IF(PANTAVISOR_DM_CRYPT)
+install(DIRECTORY scripts/volmount/crypt
+	FILE_PERMISSIONS WORLD_READ WORLD_EXECUTE GROUP_READ GROUP_EXECUTE OWNER_READ OWNER_WRITE OWNER_EXECUTE
+	DESTINATION /lib/pv/volmount)
+ENDIF()
+
+### install dm verity feature
+IF(PANTAVISOR_DM_VERITY)
+install(DIRECTORY scripts/volmount/verity
+	FILE_PERMISSIONS WORLD_READ WORLD_EXECUTE GROUP_READ GROUP_EXECUTE OWNER_READ OWNER_WRITE OWNER_EXECUTE
+	DESTINATION /lib/pv/volmount)
+ENDIF()
+
+
+# Build and install tests feature
+IF(PANTAVISOR_TESTS)
+add_executable(test-pv-zram
+			disk/disk_zram_utils.c
+			disk/disk_zram_utils.h
+			utils/pv_zram.c
+)
+target_link_libraries(test-pv-zram -largp)
+install(TARGETS test-pv-zram DESTINATION bin)
+
+add_executable(test-pv-json
+			utils/json.test.c
+			utils/json.c
+			utils/tsh.c utils/tsh.h
+			utils/pvsignals.h utils/pvsignals.c
+)
+target_link_libraries(test-pv-json  ${THTTP})
+install(TARGETS test-pv-json DESTINATION bin)
+
+add_executable(test-pv-tsh
+			utils/tsh.test.c
+			utils/tsh.c utils/tsh.h
+			utils/pvsignals.c utils/pvsignals.h
+)
+target_link_libraries(test-pv-tsh)
+install(TARGETS test-pv-tsh DESTINATION bin)
+ENDIF()
+

--- a/atom.mk
+++ b/atom.mk
@@ -2,136 +2,32 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_LIBRARIES := lxc libthttp
-LOCAL_CONDITIONAL_LIBRARIES := OPTIONAL:libseccomp OPTIONAL:libcap OPTIONAL:apparmor
-LOCAL_DESTDIR := ./lib/
+## backward compatility modules (null op) to keep old global.config's happy
 LOCAL_MODULE := pv_lxc
 
-LOCAL_CFLAGS := -g -Wno-format-nonliteral -Wno-format-contains-nul -fPIC
-LOCAL_LDFLAGS := -Wl,--no-as-needed -lutil -Wl,--as-needed
-
-LOCAL_SRC_FILES := plugins/pv_lxc.c utils/fs.c utils/tsh.c utils/pvsignals.c
-
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_CUSTOM)
 
 include $(CLEAR_VARS)
 
-LOCAL_LIBRARIES := libthttp mbedtls picohttpparser zlib
-LOCAL_CONDITIONAL_LIBRARIES := OPTIONAL:e2fsprogs
-
-LOCAL_DESTDIR := ./
 LOCAL_MODULE := init
-
-LOCAL_CFLAGS := -g -Wno-format-nonliteral -Wno-format-contains-nul -D_FILE_OFFSET_BITS=64 -Werror
-LOCAL_LDFLAGS := -Wl,--no-as-needed -ldl -Wl,--as-needed
-
-PV_BUILD_DIR := $(call local-get-build-dir)
-PV_VERSION_C := $(PV_BUILD_DIR)/version.c
-
-$(PV_VERSION_C): .FORCE
-	$(Q) $(PRIVATE_PATH)/gen_version.sh PVALCHEMY $(PV_BUILD_DIR) $(TARGET)
-
-LOCAL_PREREQUISITES += \
-	$(PV_VERSION_H)
-
-ifeq ($(PANTAVISOR_DEBUG), yes)
-LOCAL_CFLAGS += -DPANTAVISOR_DEBUG
-LOCAL_DEPENDS_MODULES += dropbear-pv
-endif
-
+LOCAL_DESCRIPTION := Pantavisor
+LOCAL_LIBRARIES := libthttp mbedtls picohttpparser zlib lxc
+LOCAL_CONDITIONAL_LIBRARIES := OPTIONAL:e2fsprogs OPTIONAL:dropbear-pv OPTIONAL:cryptsetup
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_DM_VERITY=$(CONFIG_ALCHEMY_BUILD_INIT_DM)"
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_DM_CRYPT=$(CONFIG_ALCHEMY_BUILD_INIT_CRYPT)"
 LOCAL_CODECHECK_C := clang
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/utils/
+ifeq ($(CONFIG_ALCHEMY_BUILD_PVZRAM), y)
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_PVZRAM_TEST=ON"
+endif
 
-LOCAL_SRC_FILES := debug.c \
-			daemons.c \
-			init.c \
-			loop.c \
-			logger.c \
-			log.c \
-			logserver/logserver_timestamp.c \
-			logserver/logserver_utils.c \
-			logserver/logserver_out.c \
-			logserver/logserver_update.c \
-			logserver/logserver_singlefile.c \
-			logserver/logserver_filetree.c \
-			logserver/logserver_null.c \
-			logserver/logserver_stdout.c \
-			logserver/logserver.c \
-			config_parser.c \
-			config.c \
-			pantavisor.c \
-			state.c \
-			group.c \
-			condition.c \
-			platforms.c \
-			addons.c \
-			volumes.c \
-			disk/disk.c \
-			disk/disk_crypt.c \
-			disk/disk_swap.c \
-			disk/disk_volume.c \
-			disk/disk_zram.c \
-			disk/disk_utils.c \
-			disk/disk_zram_utils.c \
-			signature.c \
-			parser/parser.c \
-			parser/parser_multi1.c \
-			parser/parser_system1.c \
-			objects.c \
-			utils/tsh.c \
-			utils/system.c \
-			utils/str.c \
-			utils/strrep.c \
-			utils/json.c \
-			utils/base64.c \
-			utils/math.c \
-			utils/timer.c \
-			utils/fs.c \
-			utils/socket.c \
-			utils/pvsignals.c \
-			utils/pvzlib.c \
-			jsons.c \
-			pantahub.c \
-			updater.c \
-			bootloader.c \
-			trestclient.c \
-			uboot.c \
-			rpiab.c \
-			grub.c \
-			storage.c \
-			metadata.c \
-			ctrl.c \
-			wdt.c \
-			network.c \
-			pvlogger.c \
-			pvctl_utils.c \
-			mount.c \
-			ph_logger.c \
-			buffer.c \
-			blkid.c \
-			paths.c \
-			drivers.c \
-			cgroup.c \
-			apparmor.c
+ifeq ($(PANTAVISOR_DEBUG), yes)
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_DEBUG=ON"
+else
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_DEBUG=OFF"
+endif
 
-LOCAL_INSTALL_HEADERS := log.h
-LOCAL_GENERATED_SRC_FILES := version.c
-
-LOCAL_COPY_FILES := $(foreach a,$(shell cd $(LOCAL_PATH)/skel; find . -type f), skel/$(a):$(a)) \
-	scripts/pv_e2fsgrow:lib/pv/pv_e2fsgrow \
-	scripts/hooks_lxc-mount.d/export.sh:lib/pv/hooks_lxc-mount.d/export.sh \
-	scripts/hooks_lxc-mount.d/mdev.sh:lib/pv/hooks_lxc-mount.d/mdev.sh \
-	scripts/hooks_lxc-mount.d/remount.sh:lib/pv/hooks_lxc-mount.d/remount.sh \
-	scripts/JSON.sh:lib/pv/JSON.sh \
-	scripts/pvcrash:lib/pv/pvcrash \
-	tools/pventer:usr/bin/pventer \
-	tools/fallbear-cmd:usr/bin/fallbear-cmd \
-	pvs/trust/ca-certificates.crt:etc/pantavisor/pvs/trust/ca-certificates.crt \
-	pvs/trust/cacerts.default.pem:etc/pantavisor/pvs/trust/cacerts.default.pem \
-	defaults/groups.json:etc/pantavisor/defaults/groups.json
-
-include $(BUILD_EXECUTABLE)
+include $(BUILD_CMAKE)
 
 include $(CLEAR_VARS)
 
@@ -180,30 +76,24 @@ include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
-LOCAL_DESTDIR := ./
+# keep this as null-op target for backward compatibilityyy
 LOCAL_MODULE := init-dm
-LOCAL_LIBRARIES := cryptsetup
-
-LOCAL_COPY_FILES := scripts/volmount/verity/dm:lib/pv/volmount/verity/dm
 
 include $(BUILD_CUSTOM)
 
 include $(CLEAR_VARS)
 
+# keep this as null-op target for backward compatibilityyy
 LOCAL_MODULE := init-crypt
-LOCAL_LIBRARIES := cryptsetup
-LOCAL_COPY_FILES := scripts/volmount/crypt/crypt:lib/pv/volmount/crypt/crypt
 
 include $(BUILD_CUSTOM)
 
 include $(CLEAR_VARS)
 
 LOCAL_DESTDIR := ./
-LOCAL_MODULE := pvzram
+LOCAL_MODULE := pvtests
+LOCAL_LIBRARIES += argp-standalone
+LOCAL_CMAKE_CONFIGURE_ARGS += "-DPANTAVISOR_TESTS=ON"
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
+include $(BUILD_CMAKE)
 
-LOCAL_SRC_FILES := disk/disk_zram_utils.c \
-		   utils/pv_zram.c
-
-include $(BUILD_EXECUTABLE)

--- a/init.c
+++ b/init.c
@@ -78,15 +78,20 @@ static int early_mounts()
 	int ret = 0;
 	errno = 0;
 
+	mkdir("/tmp", 0755);
+
+	mkdir("/proc", 0755);
 	ret = mount("none", "/proc", "proc", MS_NODEV | MS_NOSUID | MS_NOEXEC,
 		    NULL);
 	if (ret < 0)
 		exit_error(errno, "Could not mount /proc");
 
+	mkdir("/dev", 0755);
 	ret = mount("none", "/dev", "devtmpfs", 0, "size=10240k,mode=0755");
 	if (ret < 0)
 		exit_error(errno, "Could not mount /dev");
 
+	mkdir("/sys", 0755);
 	ret = mount("none", "/sys", "sysfs", 0, NULL);
 	if (ret < 0)
 		exit_error(errno, "Could not mount /sys");

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Set the minimum required version of CMake
+cmake_minimum_required(VERSION 3.0)
+
+# Set the project name and version
+project(pv_lxc VERSION 019)
+
+# Find the shared library
+find_library(LXC_LIB lxc)
+
+# Set the source files for the binary
+add_library(pv_lxc MODULE
+    pv_lxc.c
+    pv_lxc.h
+)
+
+get_filename_component(PARENT_DIR ../ ABSOLUTE)
+target_include_directories(pv_lxc PRIVATE ${PARENT_DIR})
+SET_TARGET_PROPERTIES(pv_lxc PROPERTIES PREFIX "")
+target_link_libraries(pv_lxc ${LXC_LIB})
+
+install(TARGETS pv_lxc
+	DESTINATION /lib/
+)
+


### PR DESCRIPTION
[Switch build system to CMake for alchemy and yocto](https://github.com/pantavisor/pantavisor/pull/409/commits/15f59528378b5eeddfdbb290290655f30cdcf224) 

install trust certs from PANTAVISOR_PVS_DIR

CMake Flags:
  PANTAVISOR_DEBUG=ON - passes -DPANTAVISOR_DEBUG to build
  PANTAVISOR_DM_VERITY=ON - enable dm verity feature
  PANTAVISOR_DM_CRYPT=ON - enable dm crypt disk feature
  PANTAVISOR_TESTS=ON - build tests

atom.mk:
  - move all build targets to BUILD_CMAKE or BUILD_CUSTOM (for dummy support)
  - use CONFIG_ALCHEMY_BUILD_INIT_DM to enable PANTAVISOR_DM_VERITY feature flag
  - use CONFIG_ALCHEMY_BUILD_INIT_CRYPT to enable PANTAVISOR_DM_CRYPT feature flag
  - introduce pvtests module to build pantavisor including tests

Create skeleton dirs at runtime
  - mkdir /tmp and early mount dirs
  - install scripts with 0755 permissions