### PR TITLE
fix: rpiab bootloader support breaking other bootloaders

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -130,30 +130,42 @@ bool pv_bootloader_trying_update()
 			 strlen(pv_bootloader_get_rev()) + 1));
 }
 
-int pv_bootloader_set_installed(char *rev)
+int pv_bootloader_install_update(char *rev)
 {
 	pv_log(INFO,
 	       "setting installed revision %s to be started after next reboot",
 	       rev);
+
+	if (ops->install_update)
+		return ops->install_update(rev);
+
 	return pv_bootloader_set_try(rev);
 }
 
-int pv_bootloader_set_commited(char *rev)
+int pv_bootloader_commit_update(char *rev)
 {
 	if (!ops)
 		return -1;
 
 	pv_log(INFO, "setting done revision %s to be started after next reboot",
 	       rev);
+
+	if (ops->commit_update)
+		return ops->commit_update();
+
 	return (pv_bootloader_set_rev(rev) || pv_bootloader_unset_try() ||
 		ops->flush_env());
 }
 
-int pv_bootloader_set_failed()
+int pv_bootloader_fail_update()
 {
 	pv_log(INFO,
 	       "setting failed revision %s not to be started after next reboot",
 	       pv_bootloader_get_try() ? pv_bootloader_get_try() : "<NA>");
+
+	if (ops->fail_update)
+		return ops->fail_update();
+
 	return pv_bootloader_unset_try();
 }
 
@@ -165,30 +177,6 @@ void pv_bootloader_remove()
 		free(pv_bootloader.pv_try);
 	if (pv_bootloader.pv_done)
 		free(pv_bootloader.pv_done);
-}
-
-int pv_bootloader_install_update(struct pv_update *update)
-{
-	if (ops->install_update)
-		return ops->install_update(update);
-
-	return -2;
-}
-
-int pv_bootloader_commit_update()
-{
-	if (ops->commit_update)
-		return ops->commit_update();
-
-	return -2;
-}
-
-int pv_bootloader_fail_update(struct pv_update *update)
-{
-	if (ops->fail_update)
-		return ops->fail_update(update);
-
-	return -2;
 }
 
 static int pv_bl_init()

--- a/bootloader.h
+++ b/bootloader.h
@@ -23,7 +23,6 @@
 #define PV_BOOTLOADER_H
 
 #include <stdbool.h>
-#include "updater.h"
 
 struct bl_ops {
 	int (*init)(void);
@@ -35,9 +34,9 @@ struct bl_ops {
 	int (*flush_env)(void);
 
 	/* new semantic */
-	int (*install_update)(struct pv_update *update);
+	int (*install_update)(char *rev);
 	int (*commit_update)();
-	int (*fail_update)(struct pv_update *update);
+	int (*fail_update)();
 };
 
 void pv_bootloader_print(void);
@@ -49,13 +48,9 @@ const char *pv_bootloader_get_done(void);
 bool pv_bootloader_update_in_progress(void);
 bool pv_bootloader_trying_update(void);
 
-int pv_bootloader_set_installed(char *rev);
-int pv_bootloader_set_commited(char *rev);
-int pv_bootloader_set_failed(void);
-
-int pv_bootloader_install_update(struct pv_update *update);
-int pv_bootloader_commit_update(void);
-int pv_bootloader_fail_update(struct pv_update *update);
+int pv_bootloader_install_update(char *rev);
+int pv_bootloader_commit_update(char *rev);
+int pv_bootloader_fail_update(void);
 
 void pv_bootloader_remove(void);
 

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -413,8 +413,14 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 	if ((!s->bsp.img.std.kernel || !s->bsp.img.std.initrd) &&
 	    !s->bsp.img.ut.fit && !s->bsp.img.rpiab.bootimg) {
 		pv_log(ERROR,
-		       "kernel or initrd not configured in bsp/run.json. Cannot continue.",
-		       strlen(buf), buf);
+		       "kernel or initrd not configured in bsp/run.json");
+		ret = 0;
+		goto out;
+	}
+
+	if ((pv_config_get_bl_type() == BL_RPIAB) &&
+	    !s->bsp.img.rpiab.bootimg) {
+		pv_log(ERROR, "bootimg not configured but required by config");
 		ret = 0;
 		goto out;
 	}

--- a/rpiab.c
+++ b/rpiab.c
@@ -573,7 +573,7 @@ static int _rpiab_mark_tryboot()
 	return 0;
 }
 
-static int _rpiab_install_trybootimg(struct pv_state *pending)
+static int _rpiab_install_trybootimg(char *rev)
 {
 	char imgpath[PATH_MAX];
 	char trypath[PATH_MAX];
@@ -581,16 +581,10 @@ static int _rpiab_install_trybootimg(struct pv_state *pending)
 	int rv;
 	off_t si;
 
-	// if no bootimg, we can't install things.
-	if (!pending->bsp.img.rpiab.bootimg) {
-		return -1;
-	}
-
 #ifndef PVTEST
-	pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, pending->rev,
-				       "rpiboot.img");
+	pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, rev, "rpiboot.img");
 	if (stat(imgpath, &st)) {
-		pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, pending->rev,
+		pv_paths_storage_trail_pv_file(imgpath, PATH_MAX, rev,
 					       "rpiboot.img.gz");
 	}
 
@@ -700,7 +694,7 @@ static char *trim_space(char *str)
 	return str;
 }
 
-static int _rpiab_setrev_trybootimg(struct pv_state *pending)
+static int _rpiab_setrev_trybootimg(char *rev)
 {
 	int wstatus;
 	size_t s;
@@ -806,11 +800,9 @@ static int _rpiab_setrev_trybootimg(struct pv_state *pending)
 		*peek = 0;
 
 	// append pv_rev=REVISION to finish the patch...
-	s = snprintf(cmdline_ptr + strlen(cmdline_ptr), 0, " pv_rev=%s",
-		     pending->rev);
+	s = snprintf(cmdline_ptr + strlen(cmdline_ptr), 0, " pv_rev=%s", rev);
 
-	snprintf(cmdline_ptr + strlen(cmdline_ptr), s + 1, " pv_rev=%s",
-		 pending->rev);
+	snprintf(cmdline_ptr + strlen(cmdline_ptr), s + 1, " pv_rev=%s", rev);
 
 	f = fopen(paths.cmdline_tmp, "w");
 	fwrite(cmdline_ptr, 1, strlen(cmdline_ptr), f);
@@ -874,16 +866,14 @@ static int _rpiab_setrev_trybootimg(struct pv_state *pending)
 	return 0;
 }
 
-static int rpiab_install_update(struct pv_update *update)
+static int rpiab_install_update(char *rev)
 {
-	struct pv_state *pending = update->pending;
-
-	if (_rpiab_install_trybootimg(pending)) {
+	if (_rpiab_install_trybootimg(rev)) {
 		pv_log(ERROR, "Error installing tryboot image.");
 		return -1;
 	}
 
-	if (_rpiab_setrev_trybootimg(pending)) {
+	if (_rpiab_setrev_trybootimg(rev)) {
 		pv_log(ERROR, "Error setting pv_rev in tryboot");
 		return -1;
 	}
@@ -985,7 +975,7 @@ static int rpiab_commit_update()
 	return -1;
 }
 
-static int rpiab_fail_update(struct pv_update *update)
+static int rpiab_fail_update()
 {
 	return -1;
 }

--- a/state.c
+++ b/state.c
@@ -105,9 +105,10 @@ void pv_state_free(struct pv_state *s)
 
 	if (s->rev)
 		free(s->rev);
-	if (!s->bsp.img.std.initrd) {
-		if (s->bsp.img.ut.fit)
-			free(s->bsp.img.ut.fit);
+	if (s->bsp.img.ut.fit) {
+		free(s->bsp.img.ut.fit);
+	} else if (s->bsp.img.rpiab.bootimg) {
+		free(s->bsp.img.rpiab.bootimg);
 	} else {
 		if (s->bsp.img.std.kernel)
 			free(s->bsp.img.std.kernel);

--- a/storage.c
+++ b/storage.c
@@ -930,7 +930,7 @@ int pv_storage_meta_link_boot(struct pantavisor *pv, struct pv_state *s)
 		pv_log(ERROR,
 		       "bsp type not supported. no std,fit or rpiab boot assets found for rev=%s",
 		       s->rev);
-		return -2;
+		return -1;
 	}
 
 	pv_log(DEBUG, "linked boot assets for rev=%s", s->rev);


### PR DESCRIPTION
This PR contains the corrections for https://github.com/pantavisor/pantavisor/pull/402:

* bootloader: use a single set of install, commit and fail functions in bootloader.h
* bootloader: fix install failing in case the new bootloader semantic is not being used
* parser: make parsing fail in case bootimg is not specified and we are expecting it by config
* rpiab: remove pv_update and pv_state from interfaces. Only used to check bootimg not set, which was moved to parser (see previous bullet). Changed in favor of char *rev to make it more similar to the rest of the bootloader types
* state: free bootimg in pv_state_free
* updater: call bootloader installed and commit functions only once. In the case of pv_bootloader_commit_update, it has been changed to the old place. IMO it makes no sense to report DONE to cloud and save done in /storage if the bootloader failed to commit and thus the whole update will fail for Pantavisor