### PR TITLE
Fixes detection of ubifs volumes

### DIFF
--- a/utils/fs.c
+++ b/utils/fs.c
@@ -365,6 +365,18 @@ ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size)
 	return total_read;
 }
 
+ssize_t pv_fs_file_read_to_buf(const char *path, char *buf, ssize_t size)
+{
+	int fd = pv_fs_file_check_and_open(path, O_RDONLY, 0);
+	if (fd < 0)
+		return -1;
+
+	ssize_t read = pv_fs_file_read_nointr(fd, buf, size);
+	close(fd);
+
+	return read;
+}
+
 int pv_fs_file_lock(int fd)
 {
 	struct flock flock;

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -47,6 +47,10 @@ ssize_t pv_fs_file_copy_fd(int src, int dst, bool close_src);
 // This function doesn't perform sync
 ssize_t pv_fs_file_write_nointr(int fd, const char *buf, ssize_t size);
 ssize_t pv_fs_file_read_nointr(int fd, char *buf, ssize_t size);
+
+// check path, open, read nointr and close
+ssize_t pv_fs_file_read_to_buf(const char *path, char *buf, ssize_t size);
+
 int pv_fs_file_lock(int fd);
 int pv_fs_file_unlock(int fd);
 int pv_fs_file_gzip(const char *fname, const char *target_name);


### PR DESCRIPTION
Adds to blkid lib the ubifs detection using /sys filesystem:

1. Checks the fs with pv_config_get_storage_fstype()
2. Gets the device and volume names from pv_config_get_storage_path(), normally in the format device:volume (e.g. ubi0:pvroot)
3. Checks the device in /sys/devices/virtual/ubi
4. Checks all volumes names, if the volume it's found, then the path in format /dev/<device> will be written in the blkid_info struct