### PR TITLE
refactor config with lookup table

### DIFF
--- a/apparmor.c
+++ b/apparmor.c
@@ -107,7 +107,7 @@ static void load_from_list(const char *prof)
 
 void pv_apparmor_load_profiles()
 {
-	char *profiles = pv_config_get_system_apparmor_profiles();
+	char *profiles = pv_config_get_str(CI_SYSTEM_APPARMOR_PROFILES);
 	if (!profiles)
 		return;
 

--- a/blkid.c
+++ b/blkid.c
@@ -341,7 +341,8 @@ static int get_blkid_ubifs(struct blkid_info *info, const char *key)
  * */
 int get_blkid(struct blkid_info *info, const char *key)
 {
-	if (!strncmp(pv_config_get_storage_fstype(), "ubifs", strlen("ubifs")))
+	if (!strncmp(pv_config_get_str(CI_STORAGE_FSTYPE), "ubifs",
+		     strlen("ubifs")))
 		return get_blkid_ubifs(info, key);
 
 	unsigned int ma, mi, sz;

--- a/bootloader.c
+++ b/bootloader.c
@@ -207,7 +207,7 @@ static int pv_bl_init()
 {
 	int ret;
 
-	switch (pv_config_get_bl_type()) {
+	switch (pv_config_get_bootloader_type()) {
 	case BL_UBOOT_PLAIN:
 	case BL_UBOOT_PVK:
 		ops = &uboot_ops;

--- a/config.c
+++ b/config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Pantacor Ltd.
+ * Copyright (c) 2017-2024 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,56 +48,541 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #include "log.h"
 
-static bool config_has_value(struct dl_list *config_list, char *key)
+typedef enum {
+	BOOL,
+	BOOTLOADER,
+	INIT_MODE,
+	INT,
+	LOG_SERVER_OUTPUT_UPDATE_MASK,
+	SB_MODE,
+	STR,
+	WDT_MODE
+} type_t;
+
+typedef enum {
+	DEFAULT = 0,
+	ARGS = 1 << 0,
+	PV_CONF = 1 << 1,
+	PH_CONF = 1 << 2,
+	PH_CLIENT = 1 << 3,
+	POLICY = 1 << 4,
+	PV_CMDLINE = 1 << 5,
+	PH_CMDLINE = 1 << 6,
+	TRAIL = 1 << 7,
+	META = 1 << 8,
+	CMD = 1 << 9
+} level_t;
+
+#define PV_ENTRY PV_CONF | PV_CMDLINE
+#define PH_ENTRY PH_CONF | PH_CMDLINE
+#define UPDATE_TIME POLICY | TRAIL
+#define RUN_TIME UPDATE_TIME | META | CMD
+
+// default list
+#define CACHE_DEVMETADIR_DEF "/storage/cache/devmeta"
+#define CACHE_USRMETADIR_DEF "/storage/cache/meta"
+#define CREDS_HOST_DEF "192.168.53.1"
+#define CREDS_TYPE_DEF "builtin"
+#define DISK_EXPORTSDIR_DEF "/exports"
+#define DISK_VOLDIR_DEF "/volumes"
+#define DISK_WRITABLEDIR_DEF "/writable"
+#define DROPBEAR_CACHE_DIR_DEF "/storage/cache/dropbear"
+#define LIBTHTTP_CERTSDIR_DEF "/certs"
+#define LOG_DIR_DEF "/storage/logs/"
+#define LOG_MAXSIZE_DEF (1 << 21) // 2MiB
+#define LOG_SERVER_OUTPUTS_DEF "filetree"
+#define NET_BRADDRESS4_DEF "10.0.3.1"
+#define NET_BRDEV_DEF "lxcbr0"
+#define NET_BRMASK4_DEF "255.255.255.0"
+#define SECUREBOOT_TRUSTSTORE_DEF PVS_CERT_DEFAULT_STORE
+#define SYSTEM_CONFDIR_DEF "/configs"
+#define SYSTEM_ETCDIR_DEF "/etc"
+#define SYSTEM_LIBDIR_DEF "/lib"
+#define SYSTEM_MEDIADIR_DEF "/media"
+#define SYSTEM_RUNDIR_DEF "/pv"
+#define SYSTEM_USRDIR_DEF "/usr"
+
+struct pv_config_entry {
+	type_t type;
+	const char *key;
+	level_t allowed;
+	level_t modified;
+	struct {
+		bool b;
+		int i;
+		char *s;
+	} value;
+};
+
+// configuration lookup table
+static struct pv_config_entry entries[] = {
+	{ STR, "bootloader.fitconfig", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ STR, "bootloader.mtd_env", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ BOOL, "bootloader.mtd_only", PV_ENTRY | POLICY, 0, .value.b = false },
+	{ BOOTLOADER, "bootloader.type", PV_ENTRY | POLICY, 0,
+	  .value.i = BL_UBOOT_PLAIN },
+	{ STR, "cache.devmetadir", PV_ENTRY | POLICY, 0,
+	  .value.s = CACHE_DEVMETADIR_DEF },
+	{ STR, "cache.usrmetadir", PV_ENTRY | POLICY, 0,
+	  .value.s = CACHE_USRMETADIR_DEF },
+	{ BOOL, "control.remote", PV_ENTRY | POLICY, 0, .value.b = true },
+	{ BOOL, "control.remote.always", PV_ENTRY | POLICY, 0,
+	  .value.b = false },
+	{ STR, "creds.host", PH_ENTRY, 0, .value.s = CREDS_HOST_DEF },
+	{ STR, "creds.id", PH_ENTRY, 0, .value.s = NULL },
+	{ INT, "creds.port", PH_ENTRY, 0, .value.i = 12365 },
+	{ STR, "creds.proxy.host", PH_ENTRY | UPDATE_TIME, 0, .value.s = NULL },
+	{ INT, "creds.proxy.noproxyconnect", PH_ENTRY | UPDATE_TIME, 0,
+	  .value.i = 0 },
+	{ INT, "creds.proxy.port", PH_ENTRY | UPDATE_TIME, 0, .value.i = 3218 },
+	{ STR, "creds.prn", PH_ENTRY, 0, .value.s = NULL },
+	{ STR, "creds.secret", PH_ENTRY, 0, .value.s = NULL },
+	{ STR, "creds.tpm.cert", PH_ENTRY, 0, .value.s = NULL },
+	{ STR, "creds.tpm.key", PH_ENTRY, 0, .value.s = NULL },
+	{ STR, "creds.type", PH_ENTRY, 0, .value.s = CREDS_TYPE_DEF },
+	{ BOOL, "debug.shell", PV_ENTRY | POLICY, 0, .value.b = true },
+	{ BOOL, "debug.shell.autologin", PV_ENTRY | POLICY, 0,
+	  .value.b = false },
+	{ BOOL, "debug.ssh", PV_ENTRY | RUN_TIME, 0, .value.b = true },
+	{ STR, "debug.ssh_authorized_keys", PV_ENTRY | RUN_TIME, 0,
+	  .value.s = NULL },
+	{ STR, "disk.exportsdir", PV_ENTRY | POLICY, 0,
+	  .value.s = DISK_EXPORTSDIR_DEF },
+	{ STR, "disk.voldir", PV_ENTRY | POLICY, 0,
+	  .value.s = DISK_VOLDIR_DEF },
+	{ STR, "disk.writabledir", PV_ENTRY | POLICY, 0,
+	  .value.s = DISK_WRITABLEDIR_DEF },
+	{ STR, "dropbear.cache.dir", PV_ENTRY | POLICY, 0,
+	  .value.s = DROPBEAR_CACHE_DIR_DEF },
+	{ STR, "factory.autotok", PH_ENTRY, 0, .value.s = NULL },
+	{ STR, "libthttp.certsdir", PV_ENTRY | POLICY, 0,
+	  .value.s = LIBTHTTP_CERTSDIR_DEF },
+	{ INT, "libthttp.log.level", PV_ENTRY | RUN_TIME, 0, .value.i = 3 },
+	{ BOOL, "log.capture", PV_ENTRY | UPDATE_TIME, 0, .value.b = true },
+	{ BOOL, "log.capture.dmesg", PV_ENTRY | UPDATE_TIME, 0,
+	  .value.b = false },
+	{ INT, "log.buf_nitems", PV_ENTRY | UPDATE_TIME, 0, .value.i = 128 },
+	{ STR, "log.dir", PV_ENTRY | POLICY, 0, .value.s = LOG_DIR_DEF },
+	{ STR, "log.filetree.timestamp.format", PV_ENTRY | RUN_TIME, 0,
+	  .value.s = NULL },
+	{ INT, "log.level", PV_ENTRY | RUN_TIME, 0, .value.i = 0 },
+	{ BOOL, "log.loggers", PV_ENTRY | UPDATE_TIME, 0, .value.b = true },
+	{ INT, "log.maxsize", PV_ENTRY | RUN_TIME, 0,
+	  .value.i = LOG_MAXSIZE_DEF },
+	{ BOOL, "log.push", PV_ENTRY | RUN_TIME, 0, .value.b = true },
+	{ LOG_SERVER_OUTPUT_UPDATE_MASK, "log.server.outputs",
+	  PV_ENTRY | RUN_TIME, 0,
+	  .value.i = LOG_SERVER_OUTPUT_FILE_TREE | LOG_SERVER_OUTPUT_UPDATE },
+	{ STR, "log.singlefile.timestamp.format", PV_ENTRY | RUN_TIME, 0,
+	  .value.s = NULL },
+	{ BOOL, "log.stdout", PV_ENTRY | RUN_TIME, 0, .value.b = false },
+	{ STR, "log.stdout.timestamp.format", PV_ENTRY | RUN_TIME, 0,
+	  .value.s = NULL },
+	{ INT, "lxc.log.level", PV_ENTRY | UPDATE_TIME, 0, .value.i = 2 },
+	{ INT, "metadata.devmeta.interval", PH_ENTRY | RUN_TIME, 0,
+	  .value.i = 10 },
+	{ INT, "metadata.usrmeta.interval", PH_ENTRY | RUN_TIME, 0,
+	  .value.i = 5 },
+	{ STR, "net.braddress4", PV_ENTRY | UPDATE_TIME, 0,
+	  .value.s = NET_BRADDRESS4_DEF },
+	{ STR, "net.brdev", PV_ENTRY | UPDATE_TIME, 0,
+	  .value.s = NET_BRDEV_DEF },
+	{ STR, "net.brmask4", PV_ENTRY | UPDATE_TIME, 0,
+	  .value.s = NET_BRMASK4_DEF },
+	{ STR, "policy", PV_ENTRY, 0, .value.s = NULL },
+	{ INT, "revision.retries", PV_ENTRY | RUN_TIME, 0, .value.i = 10 },
+	{ INT, "revision.retries.timeout", PV_ENTRY | RUN_TIME, 0,
+	  .value.i = 120 },
+	{ BOOL, "secureboot.checksum", PV_ENTRY | POLICY, 0, .value.b = true },
+	{ BOOL, "secureboot.handlers", PV_ENTRY | POLICY, 0, .value.b = true },
+	{ SB_MODE, "secureboot.mode", PV_ENTRY | POLICY, 0,
+	  .value.i = SB_LENIENT },
+	{ STR, "secureboot.truststore", PV_ENTRY | POLICY, 0,
+	  .value.s = SECUREBOOT_TRUSTSTORE_DEF },
+	{ STR, "storage.device", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ STR, "storage.fstype", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ BOOL, "storage.gc.keep_factory", PV_ENTRY | RUN_TIME, 0,
+	  .value.b = false },
+	{ INT, "storage.gc.reserved", PV_ENTRY | RUN_TIME, 0, .value.i = 5 },
+	{ INT, "storage.gc.threshold.defertime", PV_ENTRY | RUN_TIME, 0,
+	  .value.i = 600 },
+	{ INT, "storage.gc.threshold", PV_ENTRY | RUN_TIME, 0, .value.i = 0 },
+	{ STR, "storage.logtempsize", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ STR, "storage.mntpoint", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ STR, "storage.mnttype", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ STR, "storage.opts", PV_ENTRY | POLICY, 0, .value.s = NULL },
+	{ INT, "storage.wait", PV_ENTRY | POLICY, 0, .value.i = 5 },
+	{ STR, "system.apparmor.profiles", PV_ENTRY | POLICY, 0,
+	  .value.s = NULL },
+	{ STR, "system.confdir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_CONFDIR_DEF },
+	{ BOOL, "system.drivers.load_early.auto", PV_ENTRY | POLICY, 0,
+	  .value.b = false },
+	{ STR, "system.etcdir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_ETCDIR_DEF },
+	{ INIT_MODE, "system.init.mode", PV_ENTRY | POLICY, 0,
+	  .value.i = IM_EMBEDDED },
+	{ STR, "system.libdir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_LIBDIR_DEF },
+	{ STR, "system.mediadir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_MEDIADIR_DEF },
+	{ BOOL, "system.mount.securityfs", PV_ENTRY | POLICY, 0,
+	  .value.b = false },
+	{ STR, "system.rundir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_RUNDIR_DEF },
+	{ STR, "system.usrdir", PV_ENTRY | POLICY, 0,
+	  .value.s = SYSTEM_USRDIR_DEF },
+	{ INT, "updater.commit.delay", PV_ENTRY | RUN_TIME, 0, .value.i = 25 },
+	{ INT, "updater.goals.timeout", PV_ENTRY | RUN_TIME, 0,
+	  .value.i = 120 },
+	{ INT, "updater.interval", PH_ENTRY | RUN_TIME, 0, .value.i = 60 },
+	{ INT, "updater.network_timeout", PH_ENTRY | RUN_TIME, 0,
+	  .value.i = 120 },
+	{ BOOL, "updater.use_tmp_objects", PV_ENTRY | RUN_TIME, 0,
+	  .value.b = false },
+	{ BOOL, "wdt.enabled", PV_ENTRY | UPDATE_TIME, 0, .value.b = true },
+	{ WDT_MODE, "wdt.mode", PV_ENTRY | UPDATE_TIME, 0,
+	  .value.i = WDT_SHUTDOWN },
+	{ INT, "wdt.timeout", PV_ENTRY | UPDATE_TIME, 0, .value.i = 15 }
+};
+
+struct pv_config_alias {
+	char *alias;
+	char *key;
+};
+
+static struct pv_config_alias aliases[] = {
+	{ "meta.cache.dir", "cache.usrmetadir" },
+	{ "pantahub.log.push", "log.push" },
+	{ "updater.keep_factory", "storage.gc.keep_factory" }
+};
+
+bool pv_config_get_bool(config_index_t ci)
 {
-	char *item = config_get_value(config_list, key);
-
-	if (!item || !strlen(item))
-		return false;
-
-	return true;
+	return entries[ci].value.b;
 }
 
-static char *config_get_value_string(struct dl_list *config_list, char *key,
-				     char *default_value)
+static void _set_config_by_entry_bool(struct pv_config_entry *entry, bool value,
+				      level_t modified)
 {
-	char *item = config_get_value(config_list, key);
+	if (!entry)
+		return;
 
-	if (!item)
-		item = default_value;
-
-	if (!item || !strlen(item))
-		return NULL;
-
-	return strdup(item);
+	entry->value.b = value;
+	entry->modified = modified;
 }
 
-static int config_get_value_int(struct dl_list *config_list, char *key,
-				int default_value)
+static void _set_config_by_index_bool(config_index_t ci, bool value,
+				      level_t modified)
 {
-	char *item = config_get_value(config_list, key);
-	int value = default_value;
-
-	if (!item)
-		return value;
-
-	value = atoi(item);
-
-	return value;
+	_set_config_by_entry_bool(&entries[ci], value, modified);
 }
 
-static bool config_get_value_bool(struct dl_list *config_list, char *key,
-				  bool default_value)
+int pv_config_get_int(config_index_t ci)
 {
-	char *item = config_get_value(config_list, key);
-	bool value = default_value;
+	return entries[ci].value.i;
+}
 
-	if (!item)
-		return value;
+static void _set_config_by_entry_int(struct pv_config_entry *entry, int value,
+				     level_t modified)
+{
+	if (!entry)
+		return;
 
-	value = atoi(item);
+	entry->value.i = value;
+	entry->modified = modified;
+}
 
-	return value;
+char *pv_config_get_str(config_index_t ci)
+{
+	return entries[ci].value.s;
+}
+
+static void _set_config_by_entry_str(struct pv_config_entry *entry,
+				     const char *value, level_t modified)
+{
+	if (!entry)
+		return;
+
+	if (entry->value.s)
+		free(entry->value.s);
+	entry->value.s = strdup(value);
+	entry->modified = modified;
+}
+
+static void _set_config_by_index_str(config_index_t ci, const char *value,
+				     level_t modified)
+{
+	_set_config_by_entry_str(&entries[ci], value, modified);
+}
+
+bootloader_t pv_config_get_bootloader_type()
+{
+	return pv_config_get_int(CI_BOOTLOADER_TYPE);
+}
+
+static char *_get_bootloader_type_str(bootloader_t type)
+{
+	switch (type) {
+	case BL_UBOOT_PLAIN:
+		return "uboot";
+	case BL_UBOOT_PVK:
+		return "uboot-pvk";
+	case BL_GRUB:
+		return "grub";
+	case BL_RPIAB:
+		return "rpiab";
+	default:
+		return "unknown";
+	}
+}
+
+char *pv_config_get_bootloader_type_str(void)
+{
+	return _get_bootloader_type_str(pv_config_get_bootloader_type());
+}
+
+static void _set_config_by_entry_bootloader_type(struct pv_config_entry *entry,
+						 const char *value,
+						 level_t modified)
+{
+	if (!entry)
+		return;
+
+	if (pv_str_matches(value, strlen(value), "uboot", strlen("uboot")))
+		entry->value.i = BL_UBOOT_PLAIN;
+	else if (pv_str_matches(value, strlen(value), "uboot-pvk",
+				strlen("uboot-pvk")))
+		entry->value.i = BL_UBOOT_PVK;
+	else if (pv_str_matches(value, strlen(value), "grub", strlen("grub")))
+		entry->value.i = BL_GRUB;
+	else if (pv_str_matches(value, strlen(value), "rpiab", strlen("rpiab")))
+		entry->value.i = BL_RPIAB;
+	else
+		pv_log(WARN, "unknown bootloader type '%s'", value);
+}
+
+void pv_config_set_creds_id(char *id)
+{
+	_set_config_by_index_str(CI_CREDS_ID, id, PH_CLIENT);
+}
+void pv_config_set_creds_prn(char *prn)
+{
+	_set_config_by_index_str(CI_CREDS_PRN, prn, PH_CLIENT);
+}
+void pv_config_set_creds_secret(char *secret)
+{
+	_set_config_by_index_str(CI_CREDS_SECRET, secret, PH_CLIENT);
+}
+
+void pv_config_set_debug_shell(bool shell)
+{
+	_set_config_by_index_bool(CI_DEBUG_SHELL, shell, ARGS);
+}
+void pv_config_set_debug_shell_autologin(bool shell)
+{
+	_set_config_by_index_bool(CI_DEBUG_SHELL_AUTOLOGIN, shell, ARGS);
+}
+void pv_config_set_debug_ssh(bool ssh)
+{
+	_set_config_by_index_bool(CI_DEBUG_SSH, ssh, ARGS);
+}
+
+log_server_output_mask_t pv_config_get_log_server_outputs()
+{
+	return pv_config_get_int(CI_LOG_SERVER_OUTPUTS);
+}
+
+static void
+_set_config_by_entry_log_server_outputs(struct pv_config_entry *entry,
+					const char *value, level_t modified)
+{
+	if (!entry)
+		return;
+
+	char *token, *tmp;
+	int server_outputs = 0;
+
+	char *val = strdup(value);
+
+	for (token = strtok_r(val, ",", &tmp); token;
+	     token = strtok_r(NULL, ",", &tmp)) {
+		if (pv_str_matches(token, strlen(token), "singlefile",
+				   strlen("singlefile")))
+			server_outputs |= LOG_SERVER_OUTPUT_SINGLE_FILE;
+		else if (pv_str_matches(token, strlen(token), "filetree",
+					strlen("filetree")))
+			server_outputs |= LOG_SERVER_OUTPUT_FILE_TREE;
+		else if (pv_str_matches(token, strlen(token), "nullsink",
+					strlen("nullsink")))
+			server_outputs |= LOG_SERVER_OUTPUT_NULL_SINK;
+		else if (pv_str_matches(token, strlen(token), "stdout_direct",
+					strlen("stdout_direct")))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_DIRECT;
+		else if (pv_str_matches(token, strlen(token),
+					"stdout.containers",
+					strlen("stdout.containers")))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_CONTAINERS;
+		else if (pv_str_matches(token, strlen(token),
+					"stdout.pantavisor",
+					strlen("stdout.pantavisor")))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_PANTAVISOR;
+		else if (pv_str_matches(token, strlen(token), "stdout",
+					strlen("stdout")))
+			server_outputs |= LOG_SERVER_OUTPUT_STDOUT;
+		else
+			pv_log(WARN, "unknown log server output '%s'", token);
+	}
+
+	free(val);
+
+	server_outputs |= LOG_SERVER_OUTPUT_UPDATE;
+	entry->value.i = server_outputs;
+}
+
+secureboot_mode_t pv_config_get_secureboot_mode()
+{
+	return pv_config_get_int(CI_SECUREBOOT_MODE);
+}
+
+static char *_get_secureboot_mode_str(secureboot_mode_t mode)
+{
+	switch (mode) {
+	case SB_DISABLED:
+		return "disabled";
+	case SB_AUDIT:
+		return "audit";
+	case SB_LENIENT:
+		return "lenient";
+	case SB_STRICT:
+		return "strict";
+	default:
+		return "unknown";
+	}
+}
+
+char *pv_config_get_secureboot_mode_str(void)
+{
+	return _get_secureboot_mode_str(pv_config_get_secureboot_mode());
+}
+
+static void _set_config_by_entry_secureboot_mode(struct pv_config_entry *entry,
+						 const char *value,
+						 level_t modified)
+{
+	if (!entry)
+		return;
+
+	if (pv_str_matches(value, strlen(value), "disabled",
+			   strlen("disabled")))
+		entry->value.i = SB_DISABLED;
+	else if (pv_str_matches(value, strlen(value), "audit", strlen("audit")))
+		entry->value.i = SB_AUDIT;
+	else if (pv_str_matches(value, strlen(value), "lenient",
+				strlen("lenient")))
+		entry->value.i = SB_LENIENT;
+	else if (pv_str_matches(value, strlen(value), "strict",
+				strlen("strict")))
+		entry->value.i = SB_STRICT;
+	else
+		pv_log(WARN, "unknown secureboot mode '%s'", value);
+}
+
+init_mode_t pv_config_get_system_init_mode()
+{
+	return pv_config_get_int(CI_SYSTEM_INIT_MODE);
+}
+
+static char *_get_system_init_mode_str(init_mode_t mode)
+{
+	switch (mode) {
+	case IM_EMBEDDED:
+		return "embedded";
+	case IM_STANDALONE:
+		return "standalone";
+	case IM_APPENGINE:
+		return "appengine";
+	default:
+		return "unknown";
+	}
+}
+
+char *pv_config_get_system_init_mode_str(void)
+{
+	return _get_system_init_mode_str(pv_config_get_system_init_mode());
+}
+
+static void _set_config_by_entry_init_mode(struct pv_config_entry *entry,
+					   const char *value, level_t modified)
+{
+	if (!entry)
+		return;
+
+	if (pv_str_matches(value, strlen(value), "embedded",
+			   strlen("embedded")))
+		entry->value.i = IM_EMBEDDED;
+	else if (pv_str_matches(value, strlen(value), "standalone",
+				strlen("standalone")))
+		entry->value.i = IM_STANDALONE;
+	else if (pv_str_matches(value, strlen(value), "appengine",
+				strlen("appengine")))
+		entry->value.i = IM_APPENGINE;
+	else
+		pv_log(WARN, "unknown system init mode '%s'", value);
+}
+
+void pv_config_set_system_init_mode(init_mode_t mode)
+{
+	entries[CI_SYSTEM_INIT_MODE].value.i = mode;
+	entries[CI_SYSTEM_INIT_MODE].modified = ARGS;
+}
+
+wdt_mode_t pv_config_get_wdt_mode()
+{
+	return pv_config_get_int(CI_WDT_MODE);
+}
+
+static char *_get_wdt_mode_str(wdt_mode_t mode)
+{
+	switch (mode) {
+	case WDT_DISABLED:
+		return "disabled";
+	case WDT_SHUTDOWN:
+		return "shutdown";
+	case WDT_STARTUP:
+		return "startup";
+	case WDT_ALWAYS:
+		return "always";
+	default:
+		return "unknown";
+	}
+}
+
+char *pv_config_get_wdt_mode_str(void)
+{
+	return _get_wdt_mode_str(pv_config_get_wdt_mode());
+}
+
+static void _set_config_by_entry_wdt_mode(struct pv_config_entry *entry,
+					  const char *value, level_t modified)
+{
+	if (!entry)
+		return;
+
+	if (pv_str_matches(value, strlen(value), "disabled",
+			   strlen("disabled")))
+		entry->value.i = WDT_DISABLED;
+	else if (pv_str_matches(value, strlen(value), "shutdown",
+				strlen("shutdown")))
+		entry->value.i = WDT_SHUTDOWN;
+	else if (pv_str_matches(value, strlen(value), "startup",
+				strlen("startup")))
+		entry->value.i = WDT_STARTUP;
+	else if (pv_str_matches(value, strlen(value), "always",
+				strlen("always")))
+		entry->value.i = WDT_ALWAYS;
+	else
+		pv_log(WARN, "unknown wdt mode '%s'", value);
 }
 
 static char *config_get_value_policy(struct dl_list *config_list, char *key,
@@ -118,202 +603,10 @@ static char *config_get_value_policy(struct dl_list *config_list, char *key,
 	return strdup(item);
 }
 
-static int config_get_value_init_mode(struct dl_list *config_list, char *key,
-				      init_mode_t default_value)
+static int _apply_config_sysctl(const char *key, const char *value,
+				void *opaque)
 {
-	char *item = config_get_value(config_list, key);
-	init_mode_t value = default_value;
-
-	if (!item)
-		return value;
-
-	if (!strcmp(item, "embedded"))
-		value = IM_EMBEDDED;
-	else if (!strcmp(item, "standalone"))
-		value = IM_STANDALONE;
-	else if (!strcmp(item, "appengine"))
-		value = IM_APPENGINE;
-
-	return value;
-}
-
-static int config_get_value_bl_type(struct dl_list *config_list, char *key,
-				    int default_value)
-{
-	char *item = config_get_value(config_list, key);
-	int value = default_value;
-
-	if (!item)
-		return value;
-
-	if (!strcmp(item, "uboot"))
-		value = BL_UBOOT_PLAIN;
-	else if (!strcmp(item, "rpiab"))
-		value = BL_RPIAB;
-	else if (!strcmp(item, "uboot-pvk"))
-		value = BL_UBOOT_PVK;
-	else if (!strcmp(item, "grub"))
-		value = BL_GRUB;
-
-	return value;
-}
-
-static int config_parse_log_server_outputs(const char *value)
-{
-	char *token, *tmp;
-	int server_outputs = 0;
-
-	char *val = strdup(value);
-
-	for (token = strtok_r(val, ",", &tmp); token;
-	     token = strtok_r(NULL, ",", &tmp)) {
-		if (!strncmp(token, "singlefile", strlen("singlefile")))
-			server_outputs |= LOG_SERVER_OUTPUT_SINGLE_FILE;
-		else if (!strncmp(token, "filetree", strlen("filetree")))
-			server_outputs |= LOG_SERVER_OUTPUT_FILE_TREE;
-		else if (!strncmp(token, "nullsink", strlen("nullsink")))
-			server_outputs |= LOG_SERVER_OUTPUT_NULL_SINK;
-		else if (!strncmp(token, "stdout_direct",
-				  strlen("stdout_direct")))
-			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_DIRECT;
-		else if (!strncmp(token, "stdout.containers",
-				  strlen("stdout.containers")))
-			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_CONTAINERS;
-		else if (!strncmp(token, "stdout.pantavisor",
-				  strlen("stdout.pantavisor")))
-			server_outputs |= LOG_SERVER_OUTPUT_STDOUT_PANTAVISOR;
-		else if (!strncmp(token, "stdout", strlen("stdout")))
-			server_outputs |= LOG_SERVER_OUTPUT_STDOUT;
-	}
-
-	server_outputs |= LOG_SERVER_OUTPUT_UPDATE;
-
-	free(val);
-
-	return server_outputs;
-}
-
-static int config_get_value_log_server_outputs(struct dl_list *config_list,
-					       char *key, int default_value)
-{
-	char *item = config_get_value(config_list, key);
-	int server_outputs = 0;
-
-	if (!item)
-		return default_value;
-
-	server_outputs = config_parse_log_server_outputs(item);
-
-	return server_outputs;
-}
-
-static int config_get_value_sb_mode_type(struct dl_list *config_list, char *key,
-					 secureboot_mode_t default_value)
-{
-	char *item = config_get_value(config_list, key);
-	secureboot_mode_t value = default_value;
-
-	if (!item)
-		return value;
-
-	if (!strcmp(item, "disabled"))
-		value = SB_DISABLED;
-	else if (!strcmp(item, "audit"))
-		value = SB_AUDIT;
-	else if (!strcmp(item, "lenient"))
-		value = SB_LENIENT;
-	else if (!strcmp(item, "strict"))
-		value = SB_STRICT;
-
-	return value;
-}
-
-static wdt_mode_t config_parse_wdt_mode_type(const char *value)
-{
-	int type = WDT_DISABLED;
-
-	if (!strcmp(value, "disabled"))
-		type = WDT_DISABLED;
-	else if (!strcmp(value, "shutdown"))
-		type = WDT_SHUTDOWN;
-	else if (!strcmp(value, "startup"))
-		type = WDT_STARTUP;
-	else if (!strcmp(value, "always")) {
-		pv_log(WARN,
-		       "wdt always is experimental. Do not use in production");
-		type = WDT_ALWAYS;
-	} else
-		pv_log(WARN, "unknown '%s' wdt mode type. Using 'disabled'");
-
-	return type;
-}
-
-static int config_get_value_wdt_mode_type(struct dl_list *config_list,
-					  char *key, wdt_mode_t default_value)
-{
-	char *item = config_get_value(config_list, key);
-	wdt_mode_t value = default_value;
-
-	if (!item)
-		return value;
-
-	value = config_parse_wdt_mode_type(item);
-
-	return value;
-}
-
-static void config_override_value_string(struct dl_list *config_list, char *key,
-					 char **out)
-{
-	char *item = config_get_value(config_list, key);
-
-	if (item && strlen(item) > 0) {
-		if (*out)
-			free(*out);
-		*out = strdup(item);
-	}
-}
-
-static void config_override_value_int(struct dl_list *config_list, char *key,
-				      int *out)
-{
-	char *item = config_get_value(config_list, key);
-
-	if (item)
-		*out = atoi(item);
-}
-
-static void config_override_value_bool(struct dl_list *config_list, char *key,
-				       bool *out)
-{
-	char *item = config_get_value(config_list, key);
-
-	if (item)
-		*out = atoi(item);
-}
-
-static void
-config_override_value_log_server_outputs(struct dl_list *config_list, char *key,
-					 int *out)
-{
-	char *item = config_get_value(config_list, key);
-
-	if (item)
-		*out = config_parse_log_server_outputs(item);
-}
-
-static void config_override_value_wdt_mode_type(struct dl_list *config_list,
-						char *key, wdt_mode_t *out)
-{
-	char *item = config_get_value(config_list, key);
-
-	if (item)
-		*out = config_parse_wdt_mode_type(item);
-}
-
-static int config_sysctl_apply(char *key, char *value, void *opaque)
-{
-	char *start = key + strlen("sysctl");
+	const char *start = key + strlen("sysctl");
 	char *path =
 		calloc(strlen("/proc/sys") + strlen(start) + 1, sizeof(char));
 
@@ -322,7 +615,7 @@ static int config_sysctl_apply(char *key, char *value, void *opaque)
 
 	sprintf(path, "%s", "/proc/sys");
 
-	char *next = start;
+	const char *next = start;
 	char *p = path + strlen("/proc/sys");
 
 	for (int i = 0; i < (int)strlen(start); ++i)
@@ -350,349 +643,247 @@ static int pv_config_load_policy(const char *policy,
 {
 	char path[PATH_MAX];
 
-	if (!policy)
+	if (!policy) {
+		pv_log(DEBUG, "policy not set");
 		return 0;
+	}
 
 	pv_paths_etc_policy_file(path, PATH_MAX, policy);
 	if (load_key_value_file(path, config_list) < 0) {
-		pv_log(FATAL, "unable to parse %s\n", path);
+		pv_log(FATAL, "unable to parse '%s'\n", path);
 		return -1;
 	}
 
 	return 0;
 }
 
-static int pv_config_load_file(char *path, struct pantavisor_config *config)
+static struct pv_config_entry *_search_config_entry_by_key(const char *key)
 {
-	DEFINE_DL_LIST(config_list);
+	struct pv_config_entry *entry = NULL;
+	const char *k;
 
-	if (load_key_value_file(path, &config_list) < 0)
-		return -1;
-
-	// for overrides
-	config_parse_cmdline(&config_list, "pv_");
-
-	config->sys.init_mode = config_get_value_init_mode(
-		&config_list, "system.init.mode", IM_EMBEDDED);
-	config->sys.libdir =
-		config_get_value_string(&config_list, "system.libdir", "/lib");
-	config->sys.etcdir =
-		config_get_value_string(&config_list, "system.etcdir", "/etc");
-	config->sys.usrdir =
-		config_get_value_string(&config_list, "system.usrdir", "/usr");
-	config->sys.rundir =
-		config_get_value_string(&config_list, "system.rundir", "/pv");
-	config->sys.mediadir = config_get_value_string(
-		&config_list, "system.mediadir", "/media");
-	config->sys.confdir = config_get_value_string(
-		&config_list, "system.confdir", "/configs");
-	config->sys.auto_load_drivers = config_get_value_bool(
-		&config_list, "system.drivers.load_early.auto", false);
-	config->sys.mount_securityfs = config_get_value_bool(
-		&config_list, "system.mount.securityfs", false);
-
-	config->sys.apparmor_profiles = config_get_value_string(
-		&config_list, "system.apparmor.profiles", NULL);
-	config->policy = config_get_value_policy(&config_list, "policy", NULL);
-	if (pv_config_load_policy(config->policy, &config_list))
-		return -1;
-
-	config_parse_cmdline(&config_list, "pv_");
-
-	config->debug.shell =
-		config_get_value_bool(&config_list, "debug.shell", true);
-	config->debug.shell_autologin = config_get_value_bool(
-		&config_list, "debug.shell.autologin", false);
-	config->debug.ssh =
-		config_get_value_bool(&config_list, "debug.ssh", true);
-	config->debug.ssh_authorized_keys = config_get_value_string(
-		&config_list, "debug.ssh_authorized_keys", NULL);
-
-	config->cache.dropbearcachedir = config_get_value_string(
-		&config_list, "dropbear.cache.dir", "/storage/cache/dropbear");
-	config->cache.usrmetadir = config_get_value_string(
-		&config_list, "cache.usrmetadir", "/storage/cache/meta");
-	config_override_value_string(&config_list, "meta.cache.dir",
-				     &config->cache.usrmetadir);
-	config->cache.devmetadir = config_get_value_string(
-		&config_list, "cache.devmetadir", "/storage/cache/devmeta");
-
-	config->bl.type = config_get_value_bl_type(
-		&config_list, "bootloader.type", BL_UBOOT_PLAIN);
-	config->bl.mtd_only = config_get_value_bool(
-		&config_list, "bootloader.mtd_only", false);
-	config->bl.mtd_path = config_get_value_string(
-		&config_list, "bootloader.mtd_env", NULL);
-	config->bl.fitconfig = config_get_value_string(
-		&config_list, "bootloader.fitconfig", NULL);
-
-	config->storage.path =
-		config_get_value_string(&config_list, "storage.device", NULL);
-	config->storage.fstype =
-		config_get_value_string(&config_list, "storage.fstype", NULL);
-	config->storage.opts =
-		config_get_value_string(&config_list, "storage.opts", NULL);
-	config->storage.mntpoint =
-		config_get_value_string(&config_list, "storage.mntpoint", NULL);
-	config->storage.mnttype =
-		config_get_value_string(&config_list, "storage.mnttype", NULL);
-	config->storage.logtempsize = config_get_value_string(
-		&config_list, "storage.logtempsize", NULL);
-	config->storage.wait =
-		config_get_value_int(&config_list, "storage.wait", 5);
-
-	config->storage.gc.reserved =
-		config_get_value_int(&config_list, "storage.gc.reserved", 5);
-	config->storage.gc.keep_factory = config_get_value_bool(
-		&config_list, "storage.gc.keep_factory", false);
-	config->storage.gc.threshold =
-		config_get_value_int(&config_list, "storage.gc.threshold", 0);
-	config->storage.gc.threshold_defertime = config_get_value_int(
-		&config_list, "storage.gc.threshold.defertime", 600);
-
-	config->disk.voldir = config_get_value_string(
-		&config_list, "disk.voldir", "/volumes");
-	config->disk.exportsdir = config_get_value_string(
-		&config_list, "disk.exportsdir", "/exports");
-	config->disk.writabledir = config_get_value_string(
-		&config_list, "disk.writabledir", "/writable");
-
-	config->net.brdev =
-		config_get_value_string(&config_list, "net.brdev", "lxcbr0");
-	config->net.braddress4 = config_get_value_string(
-		&config_list, "net.braddress4", "10.0.3.1");
-	config->net.brmask4 = config_get_value_string(
-		&config_list, "net.brmask4", "255.255.255.0");
-
-	config->updater.commit_delay =
-		config_get_value_int(&config_list, "updater.commit.delay", 25);
-	config->updater.goals_timeout = config_get_value_int(
-		&config_list, "updater.goals.timeout", 2 * 60);
-	config->updater.use_tmp_objects = config_get_value_bool(
-		&config_list, "updater.use_tmp_objects", false);
-
-	config->updater.revision_retries =
-		config_get_value_int(&config_list, "revision.retries", 10);
-	config->updater.revision_retry_timeout = config_get_value_int(
-		&config_list, "revision.retries.timeout", 2 * 60);
-
-	config->wdt.enabled =
-		config_get_value_bool(&config_list, "wdt.enabled", true);
-	config->wdt.mode = config_get_value_wdt_mode_type(
-		&config_list, "wdt.mode", WDT_SHUTDOWN);
-	config->wdt.timeout =
-		config_get_value_int(&config_list, "wdt.timeout", 15);
-
-	config->log.logdir = config_get_value_string(&config_list, "log.dir",
-						     "/storage/logs/");
-	config->log.server.outputs = config_get_value_log_server_outputs(
-		&config_list, "log.server.outputs",
-		LOG_SERVER_OUTPUT_FILE_TREE | LOG_SERVER_OUTPUT_UPDATE);
-	config->log.logmax = config_get_value_int(&config_list, "log.maxsize",
-						  (1 << 21)); // 2 MiB
-	config->log.loglevel =
-		config_get_value_int(&config_list, "log.level", 0);
-	config->log.logsize =
-		config_get_value_int(&config_list, "log.buf_nitems", 128);
-	config->log.capture =
-		config_get_value_bool(&config_list, "log.capture", true);
-	config->log.loggers =
-		config_get_value_bool(&config_list, "log.loggers", true);
-	config->log.std_out =
-		config_get_value_bool(&config_list, "log.stdout", false);
-	config_override_value_string(&config_list, "log.dir",
-				     &config->log.logdir);
-	config->log.dmesg =
-		config_get_value_bool(&config_list, "log.capture.dmesg", false);
-	config->log.ts_filetree_fmt = config_get_value_string(
-		&config_list, "log.filetree.timestamp.format", NULL);
-	config->log.ts_singlefile_fmt = config_get_value_string(
-		&config_list, "log.singlefile.timestamp.format", NULL);
-	config->log.ts_stdout_fmt = config_get_value_string(
-		&config_list, "log.stdout.timestamp.format", NULL);
-
-	config->libthttp.loglevel =
-		config_get_value_int(&config_list, "libthttp.log.level", 3);
-
-	config->libthttp.certdir = config_get_value_string(
-		&config_list, "libthttp.certsdir", "/certs");
-
-	config->lxc.log_level =
-		config_get_value_int(&config_list, "lxc.log.level", 2);
-
-	config->control.remote =
-		config_get_value_bool(&config_list, "control.remote", true);
-	config->control.remote_always = config_get_value_bool(
-		&config_list, "control.remote.always", false);
-
-	config->secureboot.mode = config_get_value_sb_mode_type(
-		&config_list, "secureboot.mode", SB_LENIENT);
-	config->secureboot.truststore = config_get_value_string(
-		&config_list, "secureboot.truststore", PVS_CERT_DEFAULT_STORE);
-	config->secureboot.checksum = config_get_value_bool(
-		&config_list, "secureboot.checksum", true);
-	config->secureboot.handlers = config_get_value_bool(
-		&config_list, "secureboot.handlers", true);
-
-	config_iterate_items_prefix(&config_list, config_sysctl_apply,
-				    "sysctl.", NULL);
-
-	if (!config_has_value(&config_list, "sysctl.kernel.core_pattern")) {
-		config_sysctl_apply("sysctl.kernel.core_pattern",
-				    "|/lib/pv/pvcrash --skip", NULL);
+	for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+		k = entries[ci].key;
+		if (pv_str_matches(k, strlen(k), key, strlen(key))) {
+			entry = &entries[ci];
+			break;
+		}
 	}
 
-	config_clear_items(&config_list);
-
-	return 0;
+	return entry;
 }
 
-static int pv_config_load_creds_from_file(char *path,
-					  struct pantavisor_config *config)
+static char *_get_mod_level_str(level_t ml)
 {
-	DEFINE_DL_LIST(config_list);
+	switch (ml) {
+	case DEFAULT:
+		return "default";
+	case ARGS:
+		return "args";
+	case PV_CONF:
+		return "pv conf file";
+	case PH_CONF:
+		return "ph conf file";
+	case POLICY:
+		return "policy";
+	case PV_CMDLINE:
+		return "pv cmdline";
+	case PH_CMDLINE:
+		return "ph cmdline";
+	case TRAIL:
+		return "trail config";
+	case META:
+		return "metadata";
+	case CMD:
+		return "command";
+	default:
+		return "unknown";
+	}
+}
 
-	if (load_key_value_file(path, &config_list) < 0)
+static int _set_config_by_entry(struct pv_config_entry *entry,
+				const char *value, level_t modified)
+{
+	if (!entry)
 		return -1;
 
-	// for overrides
-	config_parse_cmdline(&config_list, "ph_");
+	if (!(entry->allowed & modified)) {
+		pv_log(WARN, "key '%s' not allowed in %s level", entry->key,
+		       _get_mod_level_str(modified));
+		return -1;
+	}
 
-	config->creds.type =
-		config_get_value_string(&config_list, "creds.type", "builtin");
-	config->creds.host = config_get_value_string(&config_list, "creds.host",
-						     "192.168.53.1");
-	config->creds.port =
-		config_get_value_int(&config_list, "creds.port", 12365);
-	config->creds.host_proxy =
-		config_get_value_string(&config_list, "creds.proxy.host", NULL);
-	config->creds.port_proxy =
-		config_get_value_int(&config_list, "creds.proxy.port", 3218);
-	config->creds.noproxyconnect = config_get_value_int(
-		&config_list, "creds.proxy.noproxyconnect", 0);
-	config->creds.id =
-		config_get_value_string(&config_list, "creds.id", NULL);
-	config->creds.prn =
-		config_get_value_string(&config_list, "creds.prn", NULL);
-	config->creds.secret =
-		config_get_value_string(&config_list, "creds.secret", NULL);
+	long value_int = 0;
+	if ((entry->type == BOOL) || (entry->type == INT)) {
+		char *endptr;
+		value_int = strtol(value, &endptr, 10);
 
-	config->creds.tpm.key =
-		config_get_value_string(&config_list, "creds.tpm.key", NULL);
-	config->creds.tpm.cert =
-		config_get_value_string(&config_list, "creds.tpm.cert", NULL);
+		if (*endptr != '\0') {
+			pv_log(WARN, "invalid number format '%s' for key '%s'",
+			       value, entry->key);
+			return -1;
+		}
+	}
 
-	config->factory.autotok =
-		config_get_value_string(&config_list, "factory.autotok", NULL);
-
-	config->updater.interval =
-		config_get_value_int(&config_list, "updater.interval", 60);
-	config->updater.network_timeout = config_get_value_int(
-		&config_list, "updater.network_timeout", 2 * 60);
-
-	config->log.push =
-		config_get_value_bool(&config_list, "log.push", true);
-
-	config->metadata.devmeta_interval = config_get_value_int(
-		&config_list, "metadata.devmeta.interval", 10);
-	config->metadata.usrmeta_interval = config_get_value_int(
-		&config_list, "metadata.usrmeta.interval", 5);
-
-	config_clear_items(&config_list);
+	switch (entry->type) {
+	case BOOL:
+		_set_config_by_entry_bool(entry, value_int, modified);
+		break;
+	case BOOTLOADER:
+		_set_config_by_entry_bootloader_type(entry, value, modified);
+		break;
+	case INIT_MODE:
+		_set_config_by_entry_init_mode(entry, value, modified);
+		break;
+	case INT:
+		_set_config_by_entry_int(entry, value_int, modified);
+		break;
+	case LOG_SERVER_OUTPUT_UPDATE_MASK:
+		_set_config_by_entry_log_server_outputs(entry, value, modified);
+		break;
+	case SB_MODE:
+		_set_config_by_entry_secureboot_mode(entry, value, modified);
+		break;
+	case STR:
+		_set_config_by_entry_str(entry, value, modified);
+		break;
+	case WDT_MODE:
+		_set_config_by_entry_wdt_mode(entry, value, modified);
+		break;
+	default:
+		pv_log(WARN, "unknown config type %d for key '%s'", entry->type,
+		       entry->key);
+		return -1;
+	}
 
 	return 0;
 }
 
-static int pv_config_override_config_from_file(char *path,
-					       struct pantavisor_config *config)
+static struct pv_config_entry *_search_config_entry_by_alias(const char *alias)
 {
-	DEFINE_DL_LIST(config_list);
+	size_t alias_number = sizeof(aliases) / sizeof(struct pv_config_alias);
+	char *a;
+	struct pv_config_entry *entry = NULL;
 
-	if (load_key_value_file(path, &config_list) < 0)
+	for (size_t ai = 0; ai < alias_number; ai++) {
+		a = aliases[ai].alias;
+		if (pv_str_matches(a, strlen(a), alias, strlen(alias))) {
+			entry = _search_config_entry_by_key(aliases[ai].key);
+			break;
+		}
+	}
+
+	return entry;
+}
+
+static int _set_config_by_key(const char *key, const char *value, void *opaque)
+{
+	struct pv_config_entry *entry;
+
+	entry = _search_config_entry_by_key(key);
+	if (!entry)
+		entry = _search_config_entry_by_alias(key);
+	if (!entry)
+		return 0;
+
+	level_t *level = (level_t *)opaque;
+	if (_set_config_by_entry(entry, value, *level)) {
+		pv_log(WARN, "cannot set key '%s' in config", key);
+		return 0;
+	}
+
+	return 0;
+}
+
+static void _iterate_config_items(struct dl_list *items, level_t level)
+{
+	level_t l = level;
+	config_iterate_items(items, _set_config_by_key, (void *)&l);
+	config_iterate_items_prefix(items, _apply_config_sysctl, "sysctl.",
+				    NULL);
+}
+
+static int pv_config_load_file(char *path)
+{
+	int ret = -1;
+	char *policy = NULL;
+
+	DEFINE_DL_LIST(cmdline_list);
+	DEFINE_DL_LIST(pv_conf_list);
+	DEFINE_DL_LIST(policy_list);
+
+	config_parse_cmdline(&cmdline_list, "pv_");
+
+	if (load_key_value_file(path, &pv_conf_list) < 0) {
+		pv_log(ERROR, "cannot load config from '%s'", path);
+		goto out;
+	}
+
+	policy = config_get_value_policy(&cmdline_list, "policy", NULL);
+	if (!policy)
+		policy = config_get_value_policy(&pv_conf_list, "policy", NULL);
+
+	_iterate_config_items(&pv_conf_list, PV_CONF);
+
+	// we do this here because we need the paths from pantavisor.config
+	if (pv_config_load_policy(policy, &policy_list)) {
+		pv_log(ERROR, "cannot load config from policy '%s'", policy);
+		goto out;
+	}
+
+	_iterate_config_items(&policy_list, POLICY);
+	_iterate_config_items(&cmdline_list, PV_CMDLINE);
+
+	ret = 0;
+
+out:
+	if (policy)
+		free(policy);
+
+	config_clear_items(&policy_list);
+	config_clear_items(&pv_conf_list);
+	config_clear_items(&cmdline_list);
+
+	return ret;
+}
+
+static int pv_config_load_creds_from_file(char *path)
+{
+	DEFINE_DL_LIST(ph_conf_list);
+	if (load_key_value_file(path, &ph_conf_list) < 0) {
+		pv_log(ERROR, "cannot load config from '%s'", path);
+		return -1;
+	}
+	level_t level = PH_CONF;
+	config_iterate_items(&ph_conf_list, _set_config_by_key, (void *)&level);
+	config_clear_items(&ph_conf_list);
+
+	DEFINE_DL_LIST(cmdline_list);
+	config_parse_cmdline(&cmdline_list, "ph_");
+	level = PH_CMDLINE;
+	config_iterate_items(&cmdline_list, _set_config_by_key, (void *)&level);
+	config_clear_items(&cmdline_list);
+
+	return 0;
+}
+
+static int pv_config_override_config_from_file(char *path)
+{
+	DEFINE_DL_LIST(trail_config_list);
+
+	if (load_key_value_file(path, &trail_config_list) < 0)
 		return -1;
 
-	config_override_value_string(&config_list, "creds.proxy.host",
-				     &config->creds.host_proxy);
-	config_override_value_int(&config_list, "creds.proxy.port",
-				  &config->creds.port_proxy);
-	config_override_value_int(&config_list, "creds.proxy.noproxyconnect",
-				  &config->creds.noproxyconnect);
-	config_override_value_int(&config_list, "storage.gc.reserved",
-				  &config->storage.gc.reserved);
-	config_override_value_bool(&config_list, "storage.gc.keep_factory",
-				   &config->storage.gc.keep_factory);
-	config_override_value_int(&config_list, "storage.gc.threshold",
-				  &config->storage.gc.threshold);
-	config_override_value_int(&config_list,
-				  "storage.gc.threshold.defertime",
-				  &config->storage.gc.threshold_defertime);
+	level_t level = TRAIL;
+	config_iterate_items(&trail_config_list, _set_config_by_key,
+			     (void *)&level);
 
-	config_override_value_bool(&config_list, "updater.use_tmp_objects",
-				   &config->updater.use_tmp_objects);
-	config_override_value_int(&config_list, "revision.retries",
-				  &config->updater.revision_retries);
-	config_override_value_int(&config_list, "revision.retries.timeout",
-				  &config->updater.revision_retry_timeout);
-	config_override_value_bool(&config_list, "updater.keep_factory",
-				   &config->storage.gc.keep_factory);
-	config_override_value_int(&config_list, "updater.interval",
-				  &config->updater.interval);
-	config_override_value_int(&config_list, "updater.goals.timeout",
-				  &config->updater.goals_timeout);
-	config_override_value_int(&config_list, "updater.network_timeout",
-				  &config->updater.network_timeout);
-	config_override_value_int(&config_list, "updater.commit.delay",
-				  &config->updater.commit_delay);
-
-	config_override_value_int(&config_list, "log.maxsize",
-				  &config->log.logmax);
-	config_override_value_int(&config_list, "log.level",
-				  &config->log.loglevel);
-	config_override_value_int(&config_list, "log.buf_nitems",
-				  &config->log.logsize);
-	config_override_value_bool(&config_list, "log.push", &config->log.push);
-	config_override_value_bool(&config_list, "log.capture",
-				   &config->log.capture);
-	config_override_value_bool(&config_list, "log.loggers",
-				   &config->log.loggers);
-	config_override_value_bool(&config_list, "log.stdout",
-				   &config->log.std_out);
-	config_override_value_log_server_outputs(&config_list,
-						 "log.server.outputs",
-						 &config->log.server.outputs);
-	config_override_value_bool(&config_list, "log.capture.dmesg",
-				   &config->log.dmesg);
-	config_override_value_string(&config_list,
-				     "log.filetree.timestamp.format",
-				     &config->log.ts_filetree_fmt);
-	config_override_value_string(&config_list,
-				     "log.singlefile.timestamp.format",
-				     &config->log.ts_singlefile_fmt);
-	config_override_value_string(&config_list,
-				     "log.stdout.timestamp.format",
-				     &config->log.ts_stdout_fmt);
-	config_override_value_int(&config_list, "libthttp.log.level",
-				  &config->libthttp.loglevel);
-	config_override_value_int(&config_list, "metadata.devmeta.interval",
-				  &config->metadata.devmeta_interval);
-	config_override_value_int(&config_list, "metadata.usrmeta.interval",
-				  &config->metadata.usrmeta_interval);
-	config_override_value_int(&config_list, "lxc.log.level",
-				  &config->lxc.log_level);
-
-	config_override_value_bool(&config_list, "wdt.enabled",
-				   &config->wdt.enabled);
-	config_override_value_wdt_mode_type(&config_list, "wdt.mode",
-					    &config->wdt.mode);
-	config_override_value_int(&config_list, "wdt.timeout",
-				  &config->wdt.timeout);
-
-	config_clear_items(&config_list);
+	config_clear_items(&trail_config_list);
 
 	return 0;
 }
 
-static int write_config_tuple_string(int fd, char *key, char *value)
+static int write_config_tuple_string(int fd, const char *key, const char *value)
 {
 	if (!key || !value)
 		return 0;
@@ -709,7 +900,7 @@ static int write_config_tuple_string(int fd, char *key, char *value)
 	return 1;
 }
 
-static int write_config_tuple_int(int fd, char *key, int value)
+static int write_config_tuple_int(int fd, const char *key, int value)
 {
 	char buf[MAX_DEC_STRING_SIZE_OF_TYPE(int)];
 
@@ -718,8 +909,7 @@ static int write_config_tuple_int(int fd, char *key, int value)
 	return write_config_tuple_string(fd, key, buf);
 }
 
-static int pv_config_save_creds_to_file(struct pantavisor_config *config,
-					char *path)
+static int pv_config_save_creds_to_file(char *path)
 {
 	int fd;
 	char tmp_path[PATH_MAX];
@@ -732,37 +922,27 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config,
 		return -1;
 	}
 
-	write_config_tuple_string(fd, "creds.type", config->creds.type);
-	write_config_tuple_string(fd, "creds.host", config->creds.host);
-	write_config_tuple_int(fd, "creds.port", config->creds.port);
-	if (config->creds.host_proxy) {
-		write_config_tuple_string(fd, "creds.proxy.host",
-					  config->creds.host_proxy);
-		write_config_tuple_int(fd, "creds.proxy.port",
-				       config->creds.port_proxy);
-		write_config_tuple_int(fd, "creds.proxy.noproxyconnect",
-				       config->creds.noproxyconnect);
+	for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+		struct pv_config_entry *entry = &entries[ci];
+		if (!(entry->allowed & PH_CONF))
+			continue;
+
+		switch (entry->type) {
+		case INT:
+			write_config_tuple_int(fd, entry->key, entry->value.i);
+			break;
+		case STR:
+			if (!entry->value.s)
+				continue;
+
+			write_config_tuple_string(fd, entry->key,
+						  entry->value.s);
+			break;
+		default:
+			pv_log(WARN, "unknown type for config entry %s",
+			       entry->key);
+		}
 	}
-	write_config_tuple_string(fd, "creds.id", config->creds.id);
-	write_config_tuple_string(fd, "creds.prn", config->creds.prn);
-	write_config_tuple_string(fd, "creds.secret", config->creds.secret);
-
-	write_config_tuple_string(fd, "creds.tpm.key", config->creds.tpm.key);
-	write_config_tuple_string(fd, "creds.tpm.cert", config->creds.tpm.cert);
-
-	write_config_tuple_int(fd, "debug.ssh", config->debug.ssh);
-
-	write_config_tuple_int(fd, "updater.interval",
-			       config->updater.interval);
-	write_config_tuple_int(fd, "updater.network_timeout",
-			       config->updater.network_timeout);
-
-	write_config_tuple_int(fd, "log.push", config->log.push);
-
-	write_config_tuple_int(fd, "metadata.devmeta.interval",
-			       config->metadata.devmeta_interval);
-	write_config_tuple_int(fd, "metadata.usrmeta.interval",
-			       config->metadata.usrmeta_interval);
 
 	close(fd);
 	if (pv_fs_path_rename(tmp_path, path) < 0) {
@@ -775,7 +955,6 @@ static int pv_config_save_creds_to_file(struct pantavisor_config *config,
 
 int pv_config_load_unclaimed_creds()
 {
-	struct pantavisor *pv = pv_get_instance();
 	char path[PATH_MAX];
 	struct stat st;
 
@@ -784,7 +963,7 @@ int pv_config_load_unclaimed_creds()
 	if (stat(path, &st))
 		return 0;
 
-	if (pv_config_load_creds_from_file(path, &pv->config)) {
+	if (pv_config_load_creds_from_file(path)) {
 		pv_log(WARN, "cannot load creds from %s", path);
 		return 0;
 	}
@@ -802,7 +981,7 @@ int pv_config_save_creds()
 	else
 		pv_paths_storage_config_file(path, PATH_MAX, PANTAHUB_FNAME);
 
-	if (pv_config_save_creds_to_file(&pv->config, path)) {
+	if (pv_config_save_creds_to_file(path)) {
 		pv_log(ERROR, "cannot save creds in %s", path);
 		return -1;
 	}
@@ -812,552 +991,45 @@ int pv_config_save_creds()
 
 void pv_config_override_value(const char *key, const char *value)
 {
-	struct pantavisor *pv = pv_get_instance();
-
-	if (!key || !value)
-		return;
-
-	if (!strcmp(key, "storage.gc.reserved"))
-		pv->config.storage.gc.reserved = atoi(value);
-	else if (!strcmp(key, "storage.gc.keep_factory"))
-		pv->config.storage.gc.keep_factory = atoi(value);
-	else if (!strcmp(key, "storage.gc.threshold"))
-		pv->config.storage.gc.threshold = atoi(value);
-	else if (!strcmp(key, "storage.gc.threshold.defertime"))
-		pv->config.storage.gc.threshold_defertime = atoi(value);
-	else if (!strcmp(key, "updater.interval"))
-		pv->config.updater.interval = atoi(value);
-	else if (!strcmp(key, "log.level"))
-		pv->config.log.loglevel = atoi(value);
-	else if (!strcmp(key, "pantahub.log.push") || !strcmp(key, "log.push"))
-		pv->config.log.push = atoi(value);
-	else if (!strcmp(key, "libthttp.log.level"))
-		pv->config.libthttp.loglevel = atoi(value);
-	else if (!strcmp(key, "metadata.devmeta.interval"))
-		pv->config.metadata.devmeta_interval = atoi(value);
-	else if (!strcmp(key, "metadata.usrmeta.interval"))
-		pv->config.metadata.usrmeta_interval = atoi(value);
-	else if (!strcmp(key, "debug.ssh"))
-		pv->config.debug.ssh = atoi(value);
+	level_t level = META;
+	_set_config_by_key(key, value, (void *)&level);
 }
 
 void pv_config_free()
 {
-	struct pantavisor *pv = pv_get_instance();
-
-	if (pv->config.policy)
-		free(pv->config.policy);
-
-	if (pv->config.sys.libdir)
-		free(pv->config.sys.libdir);
-	if (pv->config.sys.etcdir)
-		free(pv->config.sys.etcdir);
-	if (pv->config.sys.usrdir)
-		free(pv->config.sys.usrdir);
-	if (pv->config.sys.rundir)
-		free(pv->config.sys.rundir);
-	if (pv->config.sys.mediadir)
-		free(pv->config.sys.mediadir);
-	if (pv->config.sys.confdir)
-		free(pv->config.sys.confdir);
-	if (pv->config.sys.apparmor_profiles)
-		free(pv->config.sys.apparmor_profiles);
-
-	if (pv->config.cache.usrmetadir)
-		free(pv->config.cache.usrmetadir);
-	if (pv->config.cache.devmetadir)
-		free(pv->config.cache.devmetadir);
-	if (pv->config.cache.dropbearcachedir)
-		free(pv->config.cache.dropbearcachedir);
-
-	if (pv->config.debug.ssh_authorized_keys)
-		free(pv->config.debug.ssh_authorized_keys);
-
-	if (pv->config.libthttp.certdir)
-		free(pv->config.libthttp.certdir);
-
-	if (pv->config.log.logdir)
-		free(pv->config.log.logdir);
-
-	if (pv->config.log.ts_filetree_fmt)
-		free(pv->config.log.ts_filetree_fmt);
-	if (pv->config.log.ts_singlefile_fmt)
-		free(pv->config.log.ts_singlefile_fmt);
-	if (pv->config.log.ts_stdout_fmt)
-		free(pv->config.log.ts_stdout_fmt);
-
-	if (pv->config.net.brdev)
-		free(pv->config.net.brdev);
-	if (pv->config.net.braddress4)
-		free(pv->config.net.braddress4);
-	if (pv->config.net.brmask4)
-		free(pv->config.net.brmask4);
-
-	if (pv->config.bl.mtd_path)
-		free(pv->config.bl.mtd_path);
-
-	if (pv->config.storage.path)
-		free(pv->config.storage.path);
-	if (pv->config.storage.fstype)
-		free(pv->config.storage.fstype);
-	if (pv->config.storage.opts)
-		free(pv->config.storage.opts);
-	if (pv->config.storage.mntpoint)
-		free(pv->config.storage.mntpoint);
-	if (pv->config.storage.mnttype)
-		free(pv->config.storage.mnttype);
-	if (pv->config.storage.logtempsize)
-		free(pv->config.storage.logtempsize);
-
-	if (pv->config.disk.voldir)
-		free(pv->config.disk.voldir);
-	if (pv->config.disk.exportsdir)
-		free(pv->config.disk.exportsdir);
-	if (pv->config.disk.writabledir)
-		free(pv->config.disk.writabledir);
-
-	if (pv->config.creds.type)
-		free(pv->config.creds.type);
-	if (pv->config.creds.host)
-		free(pv->config.creds.host);
-	if (pv->config.creds.host_proxy)
-		free(pv->config.creds.host_proxy);
-	if (pv->config.creds.id)
-		free(pv->config.creds.id);
-	if (pv->config.creds.prn)
-		free(pv->config.creds.prn);
-	if (pv->config.creds.secret)
-		free(pv->config.creds.secret);
-	if (pv->config.creds.token)
-		free(pv->config.creds.token);
-
-	if (pv->config.creds.tpm.key)
-		free(pv->config.creds.tpm.key);
-	if (pv->config.creds.tpm.cert)
-		free(pv->config.creds.tpm.cert);
-
-	if (pv->config.secureboot.truststore)
-		free(pv->config.secureboot.truststore);
-
-	if (pv->config.factory.autotok)
-		free(pv->config.factory.autotok);
+	for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+		if (entries[ci].type == STR)
+			free(entries[ci].value.s);
+	}
 }
 
-void pv_config_set_system_init_mode(init_mode_t mode)
+static void _add_config_entry_json(config_index_t ci, struct pv_json_ser *js)
 {
-	pv_get_instance()->config.sys.init_mode = mode;
-}
+	if (ci >= CI_MAX)
+		return;
 
-void pv_config_set_debug_shell(bool shell)
-{
-	pv_get_instance()->config.debug.shell = shell;
-}
-void pv_config_set_debug_shell_autologin(bool shell)
-{
-	pv_get_instance()->config.debug.shell_autologin = shell;
-}
-void pv_config_set_debug_ssh(bool ssh)
-{
-	pv_get_instance()->config.debug.ssh = ssh;
-}
+	pv_json_ser_key(js, entries[ci].key);
 
-inline void pv_config_set_creds_id(char *id)
-{
-	pv_get_instance()->config.creds.id = id;
-}
-inline void pv_config_set_creds_prn(char *prn)
-{
-	pv_get_instance()->config.creds.prn = prn;
-}
-inline void pv_config_set_creds_secret(char *secret)
-{
-	pv_get_instance()->config.creds.secret = secret;
-}
-
-char *pv_config_get_policy()
-{
-	return pv_get_instance()->config.policy;
-}
-
-init_mode_t pv_config_get_system_init_mode()
-{
-	return pv_get_instance()->config.sys.init_mode;
-}
-char *pv_config_get_system_libdir()
-{
-	return pv_get_instance()->config.sys.libdir;
-}
-char *pv_config_get_system_etcdir()
-{
-	return pv_get_instance()->config.sys.etcdir;
-}
-char *pv_config_get_system_usrdir()
-{
-	return pv_get_instance()->config.sys.usrdir;
-}
-char *pv_config_get_system_rundir()
-{
-	return pv_get_instance()->config.sys.rundir;
-}
-char *pv_config_get_system_mediadir()
-{
-	return pv_get_instance()->config.sys.mediadir;
-}
-char *pv_config_get_system_confdir()
-{
-	return pv_get_instance()->config.sys.confdir;
-}
-
-bool pv_config_get_system_early_driver_load()
-{
-	return pv_get_instance()->config.sys.auto_load_drivers;
-}
-
-bool pv_config_get_system_mount_securityfs()
-{
-	return pv_get_instance()->config.sys.mount_securityfs;
-}
-char *pv_config_get_system_apparmor_profiles()
-{
-	return pv_get_instance()->config.sys.apparmor_profiles;
-}
-bool pv_config_get_debug_shell()
-{
-	return pv_get_instance()->config.debug.shell;
-}
-bool pv_config_get_debug_shell_autologin()
-{
-	return pv_get_instance()->config.debug.shell_autologin;
-}
-bool pv_config_get_debug_ssh()
-{
-	return pv_get_instance()->config.debug.ssh;
-}
-char *pv_config_get_debug_ssh_authorized_keys()
-{
-	return pv_get_instance()->config.debug.ssh_authorized_keys;
-}
-char *pv_config_get_cache_usrmetadir()
-{
-	return pv_get_instance()->config.cache.usrmetadir;
-}
-char *pv_config_get_cache_devmetadir()
-{
-	return pv_get_instance()->config.cache.devmetadir;
-}
-char *pv_config_get_cache_dropbearcachedir()
-{
-	return pv_get_instance()->config.cache.dropbearcachedir;
-}
-
-char *pv_config_get_creds_type()
-{
-	return pv_get_instance()->config.creds.type;
-}
-char *pv_config_get_creds_host()
-{
-	return pv_get_instance()->config.creds.host;
-}
-int pv_config_get_creds_port()
-{
-	return pv_get_instance()->config.creds.port;
-}
-char *pv_config_get_creds_host_proxy()
-{
-	return pv_get_instance()->config.creds.host_proxy;
-}
-int pv_config_get_creds_port_proxy()
-{
-	return pv_get_instance()->config.creds.port_proxy;
-}
-int pv_config_get_creds_noproxyconnect()
-{
-	return pv_get_instance()->config.creds.noproxyconnect;
-}
-char *pv_config_get_creds_id()
-{
-	return pv_get_instance()->config.creds.id;
-}
-char *pv_config_get_creds_prn()
-{
-	return pv_get_instance()->config.creds.prn;
-}
-char *pv_config_get_creds_secret()
-{
-	return pv_get_instance()->config.creds.secret;
-}
-char *pv_config_get_creds_token()
-{
-	return pv_get_instance()->config.creds.token;
-}
-
-char *pv_config_get_creds_tpm_key()
-{
-	return pv_get_instance()->config.creds.tpm.key;
-}
-char *pv_config_get_creds_tpm_cert()
-{
-	return pv_get_instance()->config.creds.tpm.cert;
-}
-
-char *pv_config_get_factory_autotok()
-{
-	return pv_get_instance()->config.factory.autotok;
-}
-
-char *pv_config_get_storage_path()
-{
-	return pv_get_instance()->config.storage.path;
-}
-char *pv_config_get_storage_fstype()
-{
-	return pv_get_instance()->config.storage.fstype;
-}
-char *pv_config_get_storage_opts()
-{
-	return pv_get_instance()->config.storage.opts;
-}
-char *pv_config_get_storage_mntpoint()
-{
-	return pv_get_instance()->config.storage.mntpoint;
-}
-char *pv_config_get_storage_mnttype()
-{
-	return pv_get_instance()->config.storage.mnttype;
-}
-char *pv_config_get_storage_logtempsize()
-{
-	return pv_get_instance()->config.storage.logtempsize;
-}
-int pv_config_get_storage_wait()
-{
-	return pv_get_instance()->config.storage.wait;
-}
-
-int pv_config_get_storage_gc_reserved()
-{
-	return pv_get_instance()->config.storage.gc.reserved;
-}
-bool pv_config_get_storage_gc_keep_factory()
-{
-	return pv_get_instance()->config.storage.gc.keep_factory;
-}
-int pv_config_get_storage_gc_threshold()
-{
-	return pv_get_instance()->config.storage.gc.threshold;
-}
-int pv_config_get_storage_gc_threshold_defertime()
-{
-	return pv_get_instance()->config.storage.gc.threshold_defertime;
-}
-
-char *pv_config_get_disk_voldir()
-{
-	return pv_get_instance()->config.disk.voldir;
-}
-char *pv_config_get_disk_exportsdir()
-{
-	return pv_get_instance()->config.disk.exportsdir;
-}
-char *pv_config_get_disk_writabledir()
-{
-	return pv_get_instance()->config.disk.writabledir;
-}
-
-int pv_config_get_updater_interval()
-{
-	return pv_get_instance()->config.updater.interval;
-}
-int pv_config_get_updater_goals_timeout()
-{
-	return pv_get_instance()->config.updater.goals_timeout;
-}
-int pv_config_get_updater_network_timeout()
-{
-	return pv_get_instance()->config.updater.network_timeout;
-}
-bool pv_config_get_updater_network_use_tmp_objects()
-{
-	return pv_get_instance()->config.updater.use_tmp_objects;
-}
-int pv_config_get_updater_revision_retries()
-{
-	return pv_get_instance()->config.updater.revision_retries;
-}
-int pv_config_get_updater_revision_retry_timeout()
-{
-	return pv_get_instance()->config.updater.revision_retry_timeout;
-}
-int pv_config_get_updater_commit_delay()
-{
-	return pv_get_instance()->config.updater.commit_delay;
-}
-
-char *pv_config_get_bl_fitconfig()
-{
-	return pv_get_instance()->config.bl.fitconfig;
-}
-int pv_config_get_bl_type()
-{
-	return pv_get_instance()->config.bl.type;
-}
-bool pv_config_get_bl_mtd_only()
-{
-	return pv_get_instance()->config.bl.mtd_only;
-}
-char *pv_config_get_bl_mtd_path()
-{
-	return pv_get_instance()->config.bl.mtd_path;
-}
-
-bool pv_config_get_watchdog_enabled()
-{
-	return pv_get_instance()->config.wdt.enabled;
-}
-wdt_mode_t pv_config_get_watchdog_mode()
-{
-	return pv_get_instance()->config.wdt.mode;
-}
-int pv_config_get_watchdog_timeout()
-{
-	return pv_get_instance()->config.wdt.timeout;
-}
-
-char *pv_config_get_network_brdev()
-{
-	return pv_get_instance()->config.net.brdev;
-}
-char *pv_config_get_network_braddress4()
-{
-	return pv_get_instance()->config.net.braddress4;
-}
-char *pv_config_get_network_brmask4()
-{
-	return pv_get_instance()->config.net.brmask4;
-}
-char *pv_config_get_log_logdir()
-{
-	return pv_get_instance()->config.log.logdir;
-}
-int pv_config_get_log_logmax()
-{
-	return pv_get_instance()->config.log.logmax;
-}
-int pv_config_get_log_loglevel()
-{
-	return pv_get_instance()->config.log.loglevel;
-}
-int pv_config_get_log_logsize()
-{
-	return pv_get_instance()->config.log.logsize;
-}
-bool pv_config_get_log_push()
-{
-	return pv_get_instance()->config.log.push;
-}
-bool pv_config_get_log_capture()
-{
-	return pv_get_instance()->config.log.capture;
-}
-bool pv_config_get_log_loggers()
-{
-	return pv_get_instance()->config.log.loggers;
-}
-bool pv_config_get_log_stdout()
-{
-	return pv_get_instance()->config.log.std_out;
-}
-char *pv_config_get_log_filetree_timestamp_format()
-{
-	return pv_get_instance()->config.log.ts_filetree_fmt;
-}
-char *pv_config_get_log_singlefile_timestamp_format()
-{
-	return pv_get_instance()->config.log.ts_singlefile_fmt;
-}
-char *pv_config_get_log_stdout_timestamp_format()
-{
-	return pv_get_instance()->config.log.ts_stdout_fmt;
-}
-int pv_config_get_log_server_outputs()
-{
-	return pv_get_instance()->config.log.server.outputs;
-}
-bool pv_config_get_log_server_output_file_tree()
-{
-	return pv_get_instance()->config.log.server.outputs &
-	       LOG_SERVER_OUTPUT_FILE_TREE;
-}
-bool pv_config_get_log_server_output_single_file()
-{
-	return pv_get_instance()->config.log.server.outputs &
-	       LOG_SERVER_OUTPUT_SINGLE_FILE;
-}
-
-bool pv_config_get_log_server_output_stdout()
-{
-	return pv_get_instance()->config.log.server.outputs &
-	       LOG_SERVER_OUTPUT_STDOUT;
-}
-
-bool pv_config_get_log_capture_dmesg()
-{
-	return pv_get_instance()->config.log.dmesg;
-}
-
-int pv_config_get_libthttp_loglevel()
-{
-	return pv_get_instance()->config.libthttp.loglevel;
-}
-
-char *pv_config_get_libthttp_certdir()
-{
-	return pv_get_instance()->config.libthttp.certdir;
-}
-
-int pv_config_get_lxc_loglevel()
-{
-	return pv_get_instance()->config.lxc.log_level;
-}
-
-bool pv_config_get_control_remote()
-{
-	return pv_get_instance()->config.control.remote;
-}
-
-bool pv_config_get_control_remote_always()
-{
-	return pv_get_instance()->config.control.remote_always;
-}
-
-secureboot_mode_t pv_config_get_secureboot_mode()
-{
-	return pv_get_instance()->config.secureboot.mode;
-}
-
-bool pv_config_get_secureboot_checksum()
-{
-	return pv_get_instance()->config.secureboot.checksum;
-}
-
-bool pv_config_get_secureboot_handlers()
-{
-	return pv_get_instance()->config.secureboot.handlers;
-}
-
-char *pv_config_get_secureboot_truststore()
-{
-	return pv_get_instance()->config.secureboot.truststore;
-}
-
-int pv_config_get_metadata_devmeta_interval()
-{
-	return pv_get_instance()->config.metadata.devmeta_interval;
-}
-
-int pv_config_get_metadata_usrmeta_interval()
-{
-	return pv_get_instance()->config.metadata.usrmeta_interval;
+	switch (entries[ci].type) {
+	case BOOL:
+		pv_json_ser_bool(js, entries[ci].value.b);
+		break;
+	case BOOTLOADER:
+	case INIT_MODE:
+	case INT:
+	case LOG_SERVER_OUTPUT_UPDATE_MASK:
+	case SB_MODE:
+	case WDT_MODE:
+		pv_json_ser_number(js, entries[ci].value.i);
+		break;
+	case STR:
+		pv_json_ser_string(js, entries[ci].value.s);
+		break;
+	default:
+		pv_log(WARN, "unknown type for config entry %s",
+		       entries[ci].key);
+		pv_json_ser_string(js, NULL);
+	}
 }
 
 char *pv_config_get_json()
@@ -1368,191 +1040,9 @@ char *pv_config_get_json()
 
 	pv_json_ser_object(&js);
 	{
-		pv_json_ser_key(&js, "policy");
-		pv_json_ser_string(&js, pv_config_get_policy());
-		pv_json_ser_key(&js, "system.init.mode");
-		pv_json_ser_number(&js, pv_config_get_system_init_mode());
-		pv_json_ser_key(&js, "system.libdir");
-		pv_json_ser_string(&js, pv_config_get_system_libdir());
-		pv_json_ser_key(&js, "system.etcdir");
-		pv_json_ser_string(&js, pv_config_get_system_etcdir());
-		pv_json_ser_key(&js, "system.rundir");
-		pv_json_ser_string(&js, pv_config_get_system_rundir());
-		pv_json_ser_key(&js, "system.usrdir");
-		pv_json_ser_string(&js, pv_config_get_system_usrdir());
-		pv_json_ser_key(&js, "system.mediadir");
-		pv_json_ser_string(&js, pv_config_get_system_mediadir());
-		pv_json_ser_key(&js, "system.confdir");
-		pv_json_ser_string(&js, pv_config_get_system_confdir());
-		pv_json_ser_key(&js, "system.drivers.load_early.auto");
-		pv_json_ser_bool(&js, pv_config_get_system_early_driver_load());
-		pv_json_ser_key(&js, "system.mount.securityfs");
-		pv_json_ser_bool(&js, pv_config_get_system_mount_securityfs());
-		pv_json_ser_key(&js, "system.apparmor.profiles");
-		pv_json_ser_bool(&js, pv_config_get_system_apparmor_profiles());
-		pv_json_ser_key(&js, "debug.shell");
-		pv_json_ser_bool(&js, pv_config_get_debug_shell());
-		pv_json_ser_key(&js, "debug.shell.autologin");
-		pv_json_ser_bool(&js, pv_config_get_debug_shell_autologin());
-		pv_json_ser_key(&js, "debug.ssh");
-		pv_json_ser_bool(&js, pv_config_get_debug_ssh());
-		pv_json_ser_key(&js, "debug.ssh_authorized_keys");
-		pv_json_ser_string(&js,
-				   pv_config_get_debug_ssh_authorized_keys());
-		pv_json_ser_key(&js, "dropbear.cache.dir");
-		pv_json_ser_string(&js, pv_config_get_cache_dropbearcachedir());
-		pv_json_ser_key(&js, "cache.usrmetadir");
-		pv_json_ser_string(&js, pv_config_get_cache_usrmetadir());
-		pv_json_ser_key(&js, "cache.devmetadir");
-		pv_json_ser_string(&js, pv_config_get_cache_devmetadir());
-		pv_json_ser_key(&js, "bootloader.fitconfig");
-		pv_json_ser_string(&js, pv_config_get_bl_fitconfig());
-		pv_json_ser_key(&js, "bootloader.type");
-		pv_json_ser_number(&js, pv_config_get_bl_type());
-		pv_json_ser_key(&js, "bootloader.mtd_only");
-		pv_json_ser_bool(&js, pv_config_get_bl_mtd_only());
-		pv_json_ser_key(&js, "bootloader.mtd_env");
-		pv_json_ser_string(&js, pv_config_get_bl_mtd_path());
-		pv_json_ser_key(&js, "secureboot.mode");
-		pv_json_ser_number(&js, pv_config_get_secureboot_mode());
-		pv_json_ser_key(&js, "secureboot.truststore");
-		pv_json_ser_string(&js, pv_config_get_secureboot_truststore());
-		pv_json_ser_key(&js, "secureboot.checksum");
-		pv_json_ser_bool(&js, pv_config_get_secureboot_checksum());
-		pv_json_ser_key(&js, "secureboot.handlers");
-		pv_json_ser_bool(&js, pv_config_get_secureboot_handlers());
-		pv_json_ser_key(&js, "storage.device");
-		pv_json_ser_string(&js, pv_config_get_storage_path());
-		pv_json_ser_key(&js, "storage.fstype");
-		pv_json_ser_string(&js, pv_config_get_storage_fstype());
-		pv_json_ser_key(&js, "storage.opts");
-		pv_json_ser_string(&js, pv_config_get_storage_opts());
-		pv_json_ser_key(&js, "storage.mntpoint");
-		pv_json_ser_string(&js, pv_config_get_storage_mntpoint());
-		pv_json_ser_key(&js, "storage.mnttype");
-		pv_json_ser_string(&js, pv_config_get_storage_mnttype());
-		pv_json_ser_key(&js, "storage.logtempsize");
-		pv_json_ser_string(&js, pv_config_get_storage_logtempsize());
-		pv_json_ser_key(&js, "storage.wait");
-		pv_json_ser_number(&js, pv_config_get_storage_wait());
-		pv_json_ser_key(&js, "storage.gc.reserved");
-		pv_json_ser_number(&js, pv_config_get_storage_gc_reserved());
-		pv_json_ser_key(&js, "storage.gc.keep_factory");
-		pv_json_ser_bool(&js, pv_config_get_storage_gc_keep_factory());
-		pv_json_ser_key(&js, "storage.gc.threshold");
-		pv_json_ser_number(&js, pv_config_get_storage_gc_threshold());
-		pv_json_ser_key(&js, "storage.gc.threshold.defertime");
-		pv_json_ser_number(
-			&js, pv_config_get_storage_gc_threshold_defertime());
-		pv_json_ser_key(&js, "disk.voldir");
-		pv_json_ser_string(&js, pv_config_get_disk_voldir());
-		pv_json_ser_key(&js, "disk.exportsdir");
-		pv_json_ser_string(&js, pv_config_get_disk_exportsdir());
-		pv_json_ser_key(&js, "disk.writabledir");
-		pv_json_ser_string(&js, pv_config_get_disk_writabledir());
-		pv_json_ser_key(&js, "updater.use_tmp_objects");
-		pv_json_ser_bool(
-			&js, pv_config_get_updater_network_use_tmp_objects());
-		pv_json_ser_key(&js, "updater.goals.timeout");
-		pv_json_ser_number(&js, pv_config_get_updater_goals_timeout());
-		pv_json_ser_key(&js, "revision.retries");
-		pv_json_ser_number(&js,
-				   pv_config_get_updater_revision_retries());
-		pv_json_ser_key(&js, "revision.retries.timeout");
-		pv_json_ser_number(
-			&js, pv_config_get_updater_revision_retry_timeout());
-		pv_json_ser_key(&js, "wdt.enabled");
-		pv_json_ser_bool(&js, pv_config_get_watchdog_enabled());
-		pv_json_ser_key(&js, "wdt.mode");
-		pv_json_ser_number(&js, pv_config_get_watchdog_mode());
-		pv_json_ser_key(&js, "wdt.timeout");
-		pv_json_ser_number(&js, pv_config_get_watchdog_timeout());
-		pv_json_ser_key(&js, "net.brdev");
-		pv_json_ser_string(&js, pv_config_get_network_brdev());
-		pv_json_ser_key(&js, "net.braddress4");
-		pv_json_ser_string(&js, pv_config_get_network_braddress4());
-		pv_json_ser_key(&js, "net.brmask4");
-		pv_json_ser_string(&js, pv_config_get_network_brmask4());
-		pv_json_ser_key(&js, "lxc.log.level");
-		pv_json_ser_number(&js, pv_config_get_lxc_loglevel());
-		pv_json_ser_key(&js, "control.remote");
-		pv_json_ser_bool(&js, pv_config_get_control_remote());
-		pv_json_ser_key(&js, "control.remote.always");
-		pv_json_ser_bool(&js, pv_config_get_control_remote_always());
-
-		pv_json_ser_key(&js, "creds.type");
-		pv_json_ser_string(&js, pv_config_get_creds_type());
-		pv_json_ser_key(&js, "creds.host");
-		pv_json_ser_string(&js, pv_config_get_creds_host());
-		pv_json_ser_key(&js, "creds.port");
-		pv_json_ser_number(&js, pv_config_get_creds_port());
-		pv_json_ser_key(&js, "creds.proxy.host");
-		pv_json_ser_string(&js, pv_config_get_creds_host_proxy());
-		pv_json_ser_key(&js, "creds.proxy.port");
-		pv_json_ser_number(&js, pv_config_get_creds_port_proxy());
-		pv_json_ser_key(&js, "creds.proxy.noproxyconnect");
-		pv_json_ser_number(&js, pv_config_get_creds_noproxyconnect());
-		pv_json_ser_key(&js, "creds.id");
-		pv_json_ser_string(&js, pv_config_get_creds_id());
-		pv_json_ser_key(&js, "creds.prn");
-		pv_json_ser_string(&js, pv_config_get_creds_prn());
-		pv_json_ser_key(&js, "creds.secret");
-		pv_json_ser_string(&js, pv_config_get_creds_secret());
-		pv_json_ser_key(&js, "creds.tpm.key");
-		pv_json_ser_string(&js, pv_config_get_creds_tpm_key());
-		pv_json_ser_key(&js, "creds.tpm.cert");
-		pv_json_ser_string(&js, pv_config_get_creds_tpm_cert());
-		pv_json_ser_key(&js, "factory.autotok");
-		pv_json_ser_string(&js, pv_config_get_factory_autotok());
-		pv_json_ser_key(&js, "updater.keep_factory");
-		pv_json_ser_bool(&js, pv_config_get_storage_gc_keep_factory());
-		pv_json_ser_key(&js, "updater.interval");
-		pv_json_ser_number(&js, pv_config_get_updater_interval());
-		pv_json_ser_key(&js, "updater.network_timeout");
-		pv_json_ser_number(&js,
-				   pv_config_get_updater_network_timeout());
-		pv_json_ser_key(&js, "updater.commit.delay");
-		pv_json_ser_number(&js, pv_config_get_updater_commit_delay());
-		pv_json_ser_key(&js, "log.dir");
-		pv_json_ser_string(&js, pv_config_get_log_logdir());
-		pv_json_ser_key(&js, "log.maxsize");
-		pv_json_ser_number(&js, pv_config_get_log_logmax());
-		pv_json_ser_key(&js, "log.level");
-		pv_json_ser_number(&js, pv_config_get_log_loglevel());
-		pv_json_ser_key(&js, "log.buf_nitems");
-		pv_json_ser_number(&js, pv_config_get_log_logsize());
-		pv_json_ser_key(&js, "log.push");
-		pv_json_ser_bool(&js, pv_config_get_log_push());
-		pv_json_ser_key(&js, "log.capture");
-		pv_json_ser_bool(&js, pv_config_get_log_capture());
-		pv_json_ser_key(&js, "log.capture.dmesg");
-		pv_json_ser_bool(&js, pv_config_get_log_capture_dmesg());
-		pv_json_ser_key(&js, "log.loggers");
-		pv_json_ser_bool(&js, pv_config_get_log_loggers());
-		pv_json_ser_key(&js, "log.stdout");
-		pv_json_ser_bool(&js, pv_config_get_log_stdout());
-		pv_json_ser_key(&js, "log.filetree.timestamp.format");
-		pv_json_ser_string(
-			&js, pv_config_get_log_filetree_timestamp_format());
-		pv_json_ser_key(&js, "log.singlefile.timestamp.format");
-		pv_json_ser_string(
-			&js, pv_config_get_log_singlefile_timestamp_format());
-		pv_json_ser_key(&js, "log.stdout.timestamp.format");
-		pv_json_ser_string(&js,
-				   pv_config_get_log_stdout_timestamp_format());
-		pv_json_ser_key(&js, "log.server.outputs");
-		pv_json_ser_number(&js, pv_config_get_log_server_outputs());
-		pv_json_ser_key(&js, "libthttp.log.level");
-		pv_json_ser_number(&js, pv_config_get_libthttp_loglevel());
-		pv_json_ser_key(&js, "libthttp.certsdir");
-		pv_json_ser_string(&js, pv_config_get_libthttp_certdir());
-
-		pv_json_ser_key(&js, "metadata.devmeta.interval");
-		pv_json_ser_number(&js,
-				   pv_config_get_metadata_devmeta_interval());
-		pv_json_ser_key(&js, "metadata.usrmeta.interval");
-		pv_json_ser_number(&js,
-				   pv_config_get_metadata_usrmeta_interval());
+		for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+			_add_config_entry_json(ci, &js);
+		}
 
 		pv_json_ser_object_pop(&js);
 	}
@@ -1560,146 +1050,91 @@ char *pv_config_get_json()
 	return pv_json_ser_str(&js);
 }
 
+static void _print_config_entry(config_index_t ci)
+{
+	if (ci >= CI_MAX)
+		return;
+
+	const char *key = entries[ci].key;
+	level_t modified = entries[ci].modified;
+
+	switch (entries[ci].type) {
+	case BOOL:
+		pv_log(INFO, "%s = %d (%s)", key, entries[ci].value.b,
+		       _get_mod_level_str(modified));
+		break;
+	case BOOTLOADER:
+		pv_log(INFO, "%s = '%s' (%s)", key,
+		       _get_bootloader_type_str(entries[ci].value.i),
+		       _get_mod_level_str(modified));
+		break;
+	case INIT_MODE:
+		pv_log(INFO, "%s = '%s' (%s)", key,
+		       _get_system_init_mode_str(entries[ci].value.i),
+		       _get_mod_level_str(modified));
+		break;
+	case INT:
+		pv_log(INFO, "%s = %d (%s)", key, entries[ci].value.i,
+		       _get_mod_level_str(modified));
+		break;
+	case LOG_SERVER_OUTPUT_UPDATE_MASK:
+		pv_log(INFO, "%s = %d (%s)", key, entries[ci].value.i,
+		       _get_mod_level_str(modified));
+		break;
+	case SB_MODE:
+		pv_log(INFO, "%s = '%s' (%s)", key,
+		       _get_secureboot_mode_str(entries[ci].value.i),
+		       _get_mod_level_str(modified));
+		break;
+	case STR:
+		pv_log(INFO, "%s = '%s' (%s)", key, entries[ci].value.s,
+		       _get_mod_level_str(modified));
+		break;
+	case WDT_MODE:
+		pv_log(INFO, "%s = '%s' (%s)", key,
+		       _get_wdt_mode_str(entries[ci].value.i),
+		       _get_mod_level_str(modified));
+		break;
+	default:
+		pv_log(WARN, "unknown type for config entry %s", key);
+	}
+}
+
 void pv_config_print()
 {
-	pv_log(INFO, "policy = '%s'", pv_config_get_policy());
-	pv_log(INFO, "system.init.mode = %d", pv_config_get_system_init_mode());
-	pv_log(INFO, "system.libdir = '%s'", pv_config_get_system_libdir());
-	pv_log(INFO, "system.etcdir = '%s'", pv_config_get_system_etcdir());
-	pv_log(INFO, "system.rundir = '%s'", pv_config_get_system_rundir());
-	pv_log(INFO, "system.usrdir = '%s'", pv_config_get_system_usrdir());
-	pv_log(INFO, "system.mediadir = '%s'", pv_config_get_system_mediadir());
-	pv_log(INFO, "system.configdir = '%s'", pv_config_get_system_confdir());
-	pv_log(INFO, "system.drivers.load_early.auto = %d",
-	       pv_config_get_system_early_driver_load());
-	pv_log(INFO, "system.mount.securityfs = %d",
-	       pv_config_get_system_mount_securityfs());
-	pv_log(INFO, "system.apparmor.profiles = %s",
-	       pv_config_get_system_apparmor_profiles());
-	pv_log(INFO, "debug.shell = %d", pv_config_get_debug_shell());
-	pv_log(INFO, "debug.shell.autologin = %d",
-	       pv_config_get_debug_shell_autologin());
-	pv_log(INFO, "debug.ssh = %d", pv_config_get_debug_ssh());
-	if (pv_config_get_debug_ssh_authorized_keys())
-		pv_log(INFO, "debug.ssh_authorized_keys = %s",
-		       pv_config_get_debug_ssh_authorized_keys());
-	pv_log(INFO, "dropbear.cache.dir = '%s'",
-	       pv_config_get_cache_dropbearcachedir());
-	pv_log(INFO, "cache.usrmetadir = '%s'",
-	       pv_config_get_cache_usrmetadir());
-	pv_log(INFO, "cache.devmetadir = '%s'",
-	       pv_config_get_cache_devmetadir());
-	pv_log(INFO, "bootloader.fitconfig = %s", pv_config_get_bl_fitconfig());
-	pv_log(INFO, "bootloader.type = %d", pv_config_get_bl_type());
-	pv_log(INFO, "bootloader.mtd_only = %d", pv_config_get_bl_mtd_only());
-	pv_log(INFO, "bootloader.mtd_env = '%s'", pv_config_get_bl_mtd_path());
-	pv_log(INFO, "secureboot.mode = %d", pv_config_get_secureboot_mode());
-	pv_log(INFO, "secureboot.truststore = '%s'",
-	       pv_config_get_secureboot_truststore());
-	pv_log(INFO, "secureboot.checksum = %d",
-	       pv_config_get_secureboot_checksum());
-	pv_log(INFO, "secureboot.handlers = %d",
-	       pv_config_get_secureboot_handlers());
-	pv_log(INFO, "storage.device = '%s'", pv_config_get_storage_path());
-	pv_log(INFO, "storage.fstype = '%s'", pv_config_get_storage_fstype());
-	pv_log(INFO, "storage.opts = '%s'", pv_config_get_storage_opts());
-	pv_log(INFO, "storage.mntpoint = '%s'",
-	       pv_config_get_storage_mntpoint());
-	pv_log(INFO, "storage.mnttype = '%s'", pv_config_get_storage_mnttype());
-	pv_log(INFO, "storage.logtempsize = '%s'",
-	       pv_config_get_storage_logtempsize());
-	pv_log(INFO, "storage.wait = %d", pv_config_get_storage_wait());
-	pv_log(INFO, "storage.gc.reserved = %d",
-	       pv_config_get_storage_gc_reserved());
-	pv_log(INFO, "storage.gc.keep_factory = %d",
-	       pv_config_get_storage_gc_keep_factory());
-	pv_log(INFO, "storage.gc.threshold = %d",
-	       pv_config_get_storage_gc_threshold());
-	pv_log(INFO, "storage.gc.threshold.defertime = %d",
-	       pv_config_get_storage_gc_threshold_defertime());
-	pv_log(INFO, "disk.voldir = '%s'", pv_config_get_disk_voldir());
-	pv_log(INFO, "disk.exportsdir = '%s'", pv_config_get_disk_exportsdir());
-	pv_log(INFO, "disk.writabledir = '%s'",
-	       pv_config_get_disk_writabledir());
-	pv_log(INFO, "updater.use_tmp_objects = %d",
-	       pv_config_get_updater_network_use_tmp_objects());
-	pv_log(INFO, "updater.goals.timeout = %d",
-	       pv_config_get_updater_goals_timeout());
-	pv_log(INFO, "revision.retries = %d",
-	       pv_config_get_updater_revision_retries());
-	pv_log(INFO, "revision.retries.timeout = %d",
-	       pv_config_get_updater_revision_retry_timeout());
-	pv_log(INFO, "wdt.enabled = %d", pv_config_get_watchdog_enabled());
-	pv_log(INFO, "wdt.mode = %d", pv_config_get_watchdog_mode());
-	pv_log(INFO, "wdt.timeout = %d", pv_config_get_watchdog_timeout());
-	pv_log(INFO, "net.brdev = %d", pv_config_get_network_brdev());
-	pv_log(INFO, "net.braddress4 = '%s'",
-	       pv_config_get_network_braddress4());
-	pv_log(INFO, "net.brmask4 = '%s'", pv_config_get_network_brmask4());
-	pv_log(INFO, "lxc.log.level = %d", pv_config_get_lxc_loglevel());
-	pv_log(INFO, "control.remote = %d", pv_config_get_control_remote());
-	pv_log(INFO, "control.remote.always = %d",
-	       pv_config_get_control_remote_always());
-	pv_log(INFO, "creds.type= '%s'", pv_config_get_creds_type());
-	pv_log(INFO, "creds.host = '%s'", pv_config_get_creds_host());
-	pv_log(INFO, "creds.port = %d", pv_config_get_creds_port());
-	pv_log(INFO, "creds.host_proxy = '%s'",
-	       pv_config_get_creds_host_proxy());
-	pv_log(INFO, "creds.port_proxy = %d", pv_config_get_creds_port_proxy());
-	pv_log(INFO, "creds.noproxyconnect = %d",
-	       pv_config_get_creds_noproxyconnect());
-	pv_log(INFO, "creds.id = '%s'", pv_config_get_creds_id());
-	pv_log(INFO, "creds.prn = '%s'", pv_config_get_creds_prn());
-	pv_log(INFO, "creds.secret = '%s'", pv_config_get_creds_secret());
-	pv_log(INFO, "creds.tpm.key = '%s'", pv_config_get_creds_tpm_key());
-	pv_log(INFO, "creds.tpm.cert = '%s'", pv_config_get_creds_tpm_cert());
-	pv_log(INFO, "factory.autotok = '%s'", pv_config_get_factory_autotok());
-	pv_log(INFO, "updater.keep_factory = %d",
-	       pv_config_get_storage_gc_keep_factory());
-	pv_log(INFO, "updater.interval = %d", pv_config_get_updater_interval());
-	pv_log(INFO, "updater.network_timeout = %d",
-	       pv_config_get_updater_network_timeout());
-	pv_log(INFO, "updater.commit.delay = %d",
-	       pv_config_get_updater_commit_delay());
-	pv_log(INFO, "log.dir = '%s'", pv_config_get_log_logdir());
-	pv_log(INFO, "log.maxsize = %d", pv_config_get_log_logmax());
-	pv_log(INFO, "log.level = %d", pv_config_get_log_loglevel());
-	pv_log(INFO, "log.buf_nitems = %d", pv_config_get_log_logsize());
-	pv_log(INFO, "log.push = %d", pv_config_get_log_push());
-	pv_log(INFO, "log.capture = %d", pv_config_get_log_capture());
-	pv_log(INFO, "log.capture.dmesg = %d",
-	       pv_config_get_log_capture_dmesg());
-	pv_log(INFO, "log.loggers = %d", pv_config_get_log_loggers());
-	pv_log(INFO, "log.stdout = %d", pv_config_get_log_stdout());
-
-	pv_log(INFO, "log.filetree.timestamp.format = %s",
-	       pv_config_get_log_filetree_timestamp_format());
-	pv_log(INFO, "log.singlefile.timestamp.format = %s",
-	       pv_config_get_log_singlefile_timestamp_format());
-	pv_log(INFO, "log.stdout.timestamp.format = %s",
-	       pv_config_get_log_stdout_timestamp_format());
-	pv_log(INFO, "log.server.outputs = %d",
-	       pv_config_get_log_server_outputs());
-	pv_log(INFO, "libthttp.loglevel = %d",
-	       pv_config_get_libthttp_loglevel());
-	pv_log(INFO, "libthttp.certsdir = %s",
-	       pv_config_get_libthttp_certdir());
-	pv_log(INFO, "metadata.devmeta.interval = %d",
-	       pv_config_get_metadata_devmeta_interval());
-	pv_log(INFO, "metadata.usrmeta.interval = %d",
-	       pv_config_get_metadata_usrmeta_interval());
+	for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+		_print_config_entry(ci);
+	}
 }
 
 int pv_config_init(char *path)
 {
-	struct pantavisor *pv = pv_get_instance();
+	size_t entry_number = sizeof(entries) / sizeof(struct pv_config_entry);
+	if (CI_MAX != entry_number) {
+		pv_log(FATAL, "number of config_index_t is not %zu",
+		       entry_number);
+		return -1;
+	}
+
+	// we alloc all strings, incluiding default ones
+	// this way, we can free both default and non-default the same way
+	char *tmp;
+	for (config_index_t ci = 0; ci < CI_MAX; ci++) {
+		if ((entries[ci].type == STR) && entries[ci].value.s) {
+			tmp = strdup(entries[ci].value.s);
+			entries[ci].value.s = tmp;
+		}
+	}
+
+	// default core_pattern, overridable by config
+	_apply_config_sysctl("sysctl.kernel.core_pattern",
+			     "|/lib/pv/pvcrash --skip", NULL);
 
 	if (!path)
 		path = PV_PANTAVISOR_CONFIG_PATH;
-
 	pv_log(DEBUG, "loading config from %s\n", path);
-	if (pv_config_load_file(path, &pv->config) < 0) {
-		pv_log(FATAL, "unable to parse %s\n", path);
+	if (pv_config_load_file(path) < 0) {
+		pv_log(FATAL, "unable to load '%s'\n", path);
 		return -1;
 	}
 
@@ -1708,11 +1143,10 @@ int pv_config_init(char *path)
 
 static int pv_config_load_creds(struct pv_init *this)
 {
-	struct pantavisor *pv = pv_get_instance();
 	char path[PATH_MAX];
 	struct stat st;
 
-	if (!pv_config_get_control_remote())
+	if (!pv_config_get_bool(CI_CONTROL_REMOTE))
 		return 0;
 
 	pv_paths_storage_config_file(path, PATH_MAX, PANTAHUB_FNAME);
@@ -1722,7 +1156,7 @@ static int pv_config_load_creds(struct pv_init *this)
 		return -1;
 	}
 
-	if (pv_config_load_creds_from_file(path, &pv->config)) {
+	if (pv_config_load_creds_from_file(path)) {
 		pv_log(ERROR, "cannot load creds from %s", path);
 		return -1;
 	}
@@ -1734,7 +1168,6 @@ static int pv_config_trail(struct pv_init *this)
 {
 	int res = -1;
 	char path[PATH_MAX];
-	struct pantavisor *pv = pv_get_instance();
 	const char *rev = pv_bootloader_get_rev();
 	char *json = NULL, *config_name;
 
@@ -1756,7 +1189,7 @@ static int pv_config_trail(struct pv_init *this)
 					 config_name);
 	free(config_name);
 
-	if (pv_config_override_config_from_file(path, &pv->config)) {
+	if (pv_config_override_config_from_file(path)) {
 		pv_log(FATAL, "initrd config %s not found", path);
 		goto out;
 	}

--- a/config.h
+++ b/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Pantacor Ltd.
+ * Copyright (c) 2017-2024 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,118 +27,126 @@
 
 #include "utils/list.h"
 
-typedef enum { IM_EMBEDDED, IM_STANDALONE, IM_APPENGINE } init_mode_t;
-
-struct pantavisor_system {
-	init_mode_t init_mode;
-	char *libdir;
-	char *etcdir;
-	char *usrdir;
-	char *rundir;
-	char *mediadir;
-	char *confdir;
-	char *apparmor_profiles;
-	bool auto_load_drivers;
-	bool mount_securityfs;
-};
-
-struct pantavisor_debug {
-	bool shell;
-	bool shell_autologin;
-	bool ssh;
-	char *ssh_authorized_keys;
-};
-
-struct pantavisor_cache {
-	char *usrmetadir;
-	char *devmetadir;
-	char *dropbearcachedir;
-};
-
-struct pantavisor_factory {
-	char *autotok;
-};
-
-struct pantavisor_tpm {
-	char *key;
-	char *cert;
-};
-
-struct pantavisor_creds {
-	char *type;
-	char *host;
-	int port;
-	char *host_proxy;
-	int port_proxy;
-	int noproxyconnect;
-	char *id;
-	char *prn;
-	char *secret;
-	char *token;
-	struct pantavisor_tpm tpm;
-};
-
-struct pantavisor_gc {
-	int reserved;
-	bool keep_factory;
-	int threshold;
-	int threshold_defertime;
-};
-
-struct pantavisor_storage {
-	char *path;
-	char *fstype;
-	char *opts;
-	char *mntpoint;
-	char *mnttype;
-	char *logtempsize;
-	int wait;
-	struct pantavisor_gc gc;
-};
-
-struct pantavisor_disk {
-	char *voldir;
-	char *exportsdir;
-	char *writabledir;
-};
-
-struct pantavisor_updater {
-	int interval;
-	int goals_timeout;
-	int network_timeout;
-	bool use_tmp_objects;
-	int revision_retries;
-	int revision_retry_timeout;
-	int commit_delay;
-};
-
-enum { BL_UBOOT_PLAIN = 0, BL_UBOOT_PVK, BL_GRUB, BL_RPIAB };
-
-struct pantavisor_bootloader {
-	int type;
-	bool mtd_only;
-	char *mtd_path;
-	char *fitconfig;
-};
+// GENERIC
 
 typedef enum {
-	WDT_DISABLED,
-	WDT_SHUTDOWN,
-	WDT_STARTUP,
-	WDT_ALWAYS,
-} wdt_mode_t;
+	CI_BOOTLOADER_FITCONFIG,
+	CI_BOOTLOADER_MTD_ENV,
+	CI_BOOTLOADER_MTD_ONLY,
+	CI_BOOTLOADER_TYPE,
+	CI_CACHE_DEVMETADIR,
+	CI_CACHE_USRMETADIR,
+	CI_CONTROL_REMOTE,
+	CI_CONTROL_REMOTE_ALWAYS,
+	CI_CREDS_HOST,
+	CI_CREDS_ID,
+	CI_CREDS_PORT,
+	CI_CREDS_PROXY_HOST,
+	CI_CREDS_PROXY_NOPROXYCONNECT,
+	CI_CREDS_PROXY_PORT,
+	CI_CREDS_PRN,
+	CI_CREDS_SECRET,
+	CI_CREDS_TPM_CERT,
+	CI_CREDS_TPM_KEY,
+	CI_CREDS_TYPE,
+	CI_DEBUG_SHELL,
+	CI_DEBUG_SHELL_AUTOLOGIN,
+	CI_DEBUG_SSH,
+	CI_DEBUG_SSH_AUTHORIZED_KEYS,
+	CI_DISK_EXPORTSDIR,
+	CI_DISK_VOLDIR,
+	CI_DISK_WRITABLEDIR,
+	CI_DROPBEAR_CACHE_DIR,
+	CI_FACTORY_AUTOTOK,
+	CI_LIBTHTTP_CERTDIR,
+	CI_LIBTHTTP_LOG_LEVEL,
+	CI_LOG_CAPTURE,
+	CI_LOG_CAPTURE_DMESG,
+	CI_LOG_BUF_NITEMS,
+	CI_LOG_DIR,
+	CI_LOG_FILETREE_TS_FMT,
+	CI_LOG_LEVEL,
+	CI_LOG_LOGGERS,
+	CI_LOG_MAXSIZE,
+	CI_LOG_PUSH,
+	CI_LOG_SERVER_OUTPUTS,
+	CI_LOG_SINGLEFILE_TS_FMT,
+	CI_LOG_STDOUT,
+	CI_LOG_STDOUT_TS_FMT,
+	CI_LXC_LOG_LEVEL,
+	CI_METADATA_DEVMETA_INTERVAL,
+	CI_METADATA_USRMETA_INTERVAL,
+	CI_NET_BRADDRESS4,
+	CI_NET_BRDEV,
+	CI_NET_BRMASK4,
+	CI_POLICY,
+	CI_REVISION_RETRIES,
+	CI_REVISION_RETRIES_TIMEOUT,
+	CI_SECUREBOOT_CHECKSUM,
+	CI_SECUREBOOT_HANDLERS,
+	CI_SECUREBOOT_MODE,
+	CI_SECUREBOOT_TRUSTSTORE,
+	CI_STORAGE_DEVICE,
+	CI_STORAGE_FSTYPE,
+	CI_STORAGE_GC_KEEP_FACTORY,
+	CI_STORAGE_GC_RESERVED,
+	CI_STORAGE_GC_THRESHOLD_DEFERTIME,
+	CI_STORAGE_GC_THRESHOLD,
+	CI_STORAGE_LOGTEMPSIZE,
+	CI_STORAGE_MNTPOINT,
+	CI_STORAGE_MNTTYPE,
+	CI_STORAGE_OPTS,
+	CI_STORAGE_WAIT,
+	CI_SYSTEM_APPARMOR_PROFILES,
+	CI_SYSTEM_CONFDIR,
+	CI_SYSTEM_DRIVERS_LOAD_EARLY_AUTO,
+	CI_SYSTEM_ETCDIR,
+	CI_SYSTEM_INIT_MODE,
+	CI_SYSTEM_LIBDIR,
+	CI_SYSTEM_MEDIADIR,
+	CI_SYSTEM_MOUNT_SECURITYFS,
+	CI_SYSTEM_RUNDIR,
+	CI_SYSTEM_USRDIR,
+	CI_UPDATER_COMMIT_DELAY,
+	CI_UPDATER_GOALS_TIMEOUT,
+	CI_UPDATER_INTERVAL,
+	CI_UPDATER_NETWORK_TIMEOUT,
+	CI_UPDATER_USE_TMP_OBJECTS,
+	CI_WDT_ENABLED,
+	CI_WDT_MODE,
+	CI_WDT_TIMEOUT,
+	CI_MAX
+} config_index_t;
 
-struct pantavisor_watchdog {
-	bool enabled;
-	wdt_mode_t mode;
-	int timeout;
-};
+bool pv_config_get_bool(config_index_t ci);
+int pv_config_get_int(config_index_t ci);
+char *pv_config_get_str(config_index_t ci);
 
-struct pantavisor_network {
-	char *brdev;
-	char *braddress4;
-	char *brmask4;
-};
+// BOOTLOADER TYPE
+
+typedef enum {
+	BL_UBOOT_PLAIN = 0,
+	BL_UBOOT_PVK,
+	BL_GRUB,
+	BL_RPIAB
+} bootloader_t;
+
+bootloader_t pv_config_get_bootloader_type(void);
+char *pv_config_get_bootloader_type_str(void);
+
+// CREDS
+
+void pv_config_set_creds_id(char *id);
+void pv_config_set_creds_prn(char *prn);
+void pv_config_set_creds_secret(char *secret);
+
+// DEBUG
+
+void pv_config_set_debug_shell(bool shell);
+void pv_config_set_debug_shell_autologin(bool autologin);
+void pv_config_set_debug_ssh(bool ssh);
+
+// LOG SERVER OUTPUTS
 
 typedef enum {
 	LOG_SERVER_OUTPUT_NULL_SINK = 1 << 0,
@@ -151,39 +159,9 @@ typedef enum {
 	LOG_SERVER_OUTPUT_UPDATE = 1 << 7,
 } log_server_output_mask_t;
 
-struct pantavisor_log_server {
-	int outputs;
-};
+log_server_output_mask_t pv_config_get_log_server_outputs(void);
 
-struct pantavisor_log {
-	char *logdir;
-	int logmax;
-	int loglevel;
-	int logsize;
-	bool push;
-	bool capture;
-	bool dmesg;
-	bool loggers;
-	bool std_out;
-	char *ts_filetree_fmt;
-	char *ts_singlefile_fmt;
-	char *ts_stdout_fmt;
-	struct pantavisor_log_server server;
-};
-
-struct pantavisor_lxc {
-	int log_level;
-};
-
-struct pantavisor_control {
-	bool remote;
-	bool remote_always;
-};
-
-struct pantavisor_libthttp {
-	int loglevel;
-	char *certdir;
-};
+// SECUREBOOT MODE
 
 typedef enum {
 	SB_DISABLED,
@@ -192,38 +170,30 @@ typedef enum {
 	SB_STRICT,
 } secureboot_mode_t;
 
-struct pantavisor_secureboot {
-	secureboot_mode_t mode;
-	char *truststore;
-	bool checksum;
-	bool handlers;
-};
+secureboot_mode_t pv_config_get_secureboot_mode(void);
+char *pv_config_get_secureboot_mode_str(void);
 
-struct pantavisor_metadata {
-	int devmeta_interval;
-	int usrmeta_interval;
-};
+// SYSTEM INIT MODE
 
-struct pantavisor_config {
-	char *policy;
-	struct pantavisor_system sys;
-	struct pantavisor_debug debug;
-	struct pantavisor_cache cache;
-	struct pantavisor_bootloader bl;
-	struct pantavisor_creds creds;
-	struct pantavisor_factory factory;
-	struct pantavisor_storage storage;
-	struct pantavisor_disk disk;
-	struct pantavisor_updater updater;
-	struct pantavisor_watchdog wdt;
-	struct pantavisor_network net;
-	struct pantavisor_log log;
-	struct pantavisor_lxc lxc;
-	struct pantavisor_control control;
-	struct pantavisor_libthttp libthttp;
-	struct pantavisor_secureboot secureboot;
-	struct pantavisor_metadata metadata;
-};
+typedef enum { IM_EMBEDDED, IM_STANDALONE, IM_APPENGINE } init_mode_t;
+
+init_mode_t pv_config_get_system_init_mode(void);
+char *pv_config_get_system_init_mode_str(void);
+void pv_config_set_system_init_mode(init_mode_t mode);
+
+// WATCHDOG MODE
+
+typedef enum {
+	WDT_DISABLED,
+	WDT_SHUTDOWN,
+	WDT_STARTUP,
+	WDT_ALWAYS,
+} wdt_mode_t;
+
+wdt_mode_t pv_config_get_wdt_mode(void);
+char *pv_config_get_wdt_mode_str(void);
+
+// MAIN FUNCTIONS
 
 int pv_config_init(char *path);
 
@@ -233,124 +203,6 @@ int pv_config_save_creds(void);
 void pv_config_override_value(const char *key, const char *value);
 
 void pv_config_free(void);
-
-void pv_config_set_system_init_mode(init_mode_t mode);
-
-void pv_config_set_debug_shell(bool shell);
-void pv_config_set_debug_shell_autologin(bool autologin);
-void pv_config_set_debug_ssh(bool ssh);
-
-void pv_config_set_creds_id(char *id);
-void pv_config_set_creds_prn(char *prn);
-void pv_config_set_creds_secret(char *secret);
-
-char *pv_config_get_policy(void);
-init_mode_t pv_config_get_system_init_mode(void);
-char *pv_config_get_system_libdir(void);
-char *pv_config_get_system_etcdir(void);
-char *pv_config_get_system_usrdir(void);
-char *pv_config_get_system_rundir(void);
-char *pv_config_get_system_mediadir(void);
-char *pv_config_get_system_confdir(void);
-bool pv_config_get_system_early_driver_load(void);
-bool pv_config_get_system_mount_securityfs(void);
-char *pv_config_get_system_apparmor_profiles(void);
-
-bool pv_config_get_debug_shell(void);
-bool pv_config_get_debug_shell_autologin(void);
-bool pv_config_get_debug_ssh(void);
-char *pv_config_get_debug_ssh_authorized_keys(void);
-
-char *pv_config_get_cache_usrmetadir(void);
-char *pv_config_get_cache_devmetadir(void);
-char *pv_config_get_cache_dropbearcachedir(void);
-
-char *pv_config_get_creds_type(void);
-char *pv_config_get_creds_host(void);
-int pv_config_get_creds_port(void);
-char *pv_config_get_creds_host_proxy(void);
-int pv_config_get_creds_port_proxy(void);
-int pv_config_get_creds_noproxyconnect(void);
-char *pv_config_get_creds_id(void);
-char *pv_config_get_creds_prn(void);
-char *pv_config_get_creds_secret(void);
-char *pv_config_get_creds_token(void);
-
-char *pv_config_get_creds_tpm_key(void);
-char *pv_config_get_creds_tpm_cert(void);
-
-char *pv_config_get_factory_autotok(void);
-
-char *pv_config_get_storage_path(void);
-char *pv_config_get_storage_fstype(void);
-char *pv_config_get_storage_opts(void);
-char *pv_config_get_storage_mntpoint(void);
-char *pv_config_get_storage_mnttype(void);
-char *pv_config_get_storage_logtempsize(void);
-int pv_config_get_storage_wait(void);
-
-int pv_config_get_storage_gc_reserved(void);
-bool pv_config_get_storage_gc_keep_factory(void);
-int pv_config_get_storage_gc_threshold(void);
-int pv_config_get_storage_gc_threshold_defertime(void);
-
-char *pv_config_get_disk_voldir(void);
-char *pv_config_get_disk_exportsdir(void);
-char *pv_config_get_disk_writabledir(void);
-
-int pv_config_get_updater_interval(void);
-int pv_config_get_updater_goals_timeout(void);
-int pv_config_get_updater_network_timeout(void);
-bool pv_config_get_updater_network_use_tmp_objects(void);
-int pv_config_get_updater_revision_retries(void);
-int pv_config_get_updater_revision_retry_timeout(void);
-int pv_config_get_updater_commit_delay(void);
-
-char *pv_config_get_bl_fitconfig(void);
-int pv_config_get_bl_type(void);
-bool pv_config_get_bl_mtd_only(void);
-char *pv_config_get_bl_mtd_path(void);
-
-bool pv_config_get_watchdog_enabled(void);
-wdt_mode_t pv_config_get_watchdog_mode(void);
-int pv_config_get_watchdog_timeout(void);
-
-char *pv_config_get_network_brdev(void);
-char *pv_config_get_network_braddress4(void);
-char *pv_config_get_network_brmask4(void);
-
-char *pv_config_get_log_logdir(void);
-int pv_config_get_log_logmax(void);
-int pv_config_get_log_loglevel(void);
-int pv_config_get_log_logsize(void);
-bool pv_config_get_log_push(void);
-bool pv_config_get_log_capture(void);
-bool pv_config_get_log_loggers(void);
-bool pv_config_get_log_stdout(void);
-char *pv_config_get_log_filetree_timestamp_format(void);
-char *pv_config_get_log_singlefile_timestamp_format(void);
-char *pv_config_get_log_stdout_timestamp_format(void);
-
-char *pv_config_get_libthttp_certdir(void);
-int pv_config_get_libthttp_loglevel(void);
-
-int pv_config_get_log_server_outputs(void);
-bool pv_config_get_log_server_output_file_tree(void);
-bool pv_config_get_log_server_output_single_file(void);
-bool pv_config_get_log_server_output_stdout(void);
-bool pv_config_get_log_capture_dmesg(void);
-
-int pv_config_get_lxc_loglevel(void);
-bool pv_config_get_control_remote(void);
-bool pv_config_get_control_remote_always(void);
-
-secureboot_mode_t pv_config_get_secureboot_mode(void);
-char *pv_config_get_secureboot_truststore(void);
-bool pv_config_get_secureboot_checksum(void);
-bool pv_config_get_secureboot_handlers(void);
-
-int pv_config_get_metadata_devmeta_interval(void);
-int pv_config_get_metadata_usrmeta_interval(void);
 
 char *pv_config_get_json(void);
 void pv_config_print(void);

--- a/config_parser.c
+++ b/config_parser.c
@@ -108,28 +108,6 @@ out:
 	return NULL;
 }
 
-static struct config_item *_config_replace_item(struct dl_list *list, char *key,
-						char *value)
-{
-	struct config_item *curr = NULL;
-
-	if (key == NULL || dl_list_empty(list))
-		return NULL;
-
-	curr = _config_get_by_key(list, key);
-	if (curr) {
-		char *tmp_val = strdup(value);
-
-		if (tmp_val) {
-			free(curr->value);
-			curr->value = tmp_val;
-		}
-		return curr;
-	}
-	// not found? add it
-	return _config_add_item(list, key, value);
-}
-
 int config_parse_cmdline(struct dl_list *list, char *hint)
 {
 	struct pantavisor *pv = pv_get_instance();
@@ -155,7 +133,7 @@ int config_parse_cmdline(struct dl_list *list, char *hint)
 			nl = strchr(value, '\n');
 			if (nl) /* get rid of newline at end */
 				*nl = '\0';
-			_config_replace_item(list, key, value);
+			_config_add_item(list, key, value);
 		}
 		token = strtok_r(NULL, " ", &ptr_out);
 	}
@@ -214,7 +192,8 @@ char *config_get_value(struct dl_list *list, char *key)
 }
 
 void config_iterate_items(struct dl_list *list,
-			  int (*action)(char *key, char *value, void *opaque),
+			  int (*action)(const char *key, const char *value,
+					void *opaque),
 			  void *opaque)
 {
 	struct config_item *curr = NULL, *tmp;
@@ -231,8 +210,8 @@ void config_iterate_items(struct dl_list *list,
 }
 
 void config_iterate_items_prefix(struct dl_list *list,
-				 int (*action)(char *key, char *value,
-					       void *opaque),
+				 int (*action)(const char *key,
+					       const char *value, void *opaque),
 				 char *prefix, void *opaque)
 {
 	struct config_item *curr = NULL, *tmp;

--- a/config_parser.h
+++ b/config_parser.h
@@ -29,12 +29,13 @@ int config_parse_cmdline(struct dl_list *list, char *hint);
 int load_key_value_file(const char *path, struct dl_list *list);
 char *config_get_value(struct dl_list *list, char *key);
 void config_iterate_items(struct dl_list *list,
-			  int (*action)(char *key, char *value, void *opaque),
+			  int (*action)(const char *key, const char *value,
+					void *opaque),
 			  void *opaque);
 
 void config_iterate_items_prefix(struct dl_list *list,
-				 int (*action)(char *key, char *value,
-					       void *opaque),
+				 int (*action)(const char *key,
+					       const char *value, void *opaque),
 				 char *prefix, void *opaque);
 
 void config_clear_items(struct dl_list *list);

--- a/ctrl.c
+++ b/ctrl.c
@@ -770,7 +770,8 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 		goto error;
 	}
 
-	if (!pv_config_get_control_remote() && ((*cmd)->op == CMD_GO_REMOTE)) {
+	if (!pv_config_get_bool(CI_CONTROL_REMOTE) &&
+	    ((*cmd)->op == CMD_GO_REMOTE)) {
 		pv_ctrl_write_error_response(
 			req_fd, HTTP_STATUS_CONFLICT,
 			"Cannot do this operation when remote mode is disabled by config");

--- a/debug.c
+++ b/debug.c
@@ -72,7 +72,7 @@ void pv_debug_start_shell()
 	}
 	dprintf(con_fd, "\n");
 
-	if (c[0] == 'd' || pv_config_get_debug_shell_autologin())
+	if (c[0] == 'd' || pv_config_get_bool(CI_DEBUG_SHELL_AUTOLOGIN))
 		shell_pid =
 			tsh_run("/sbin/getty -n -l /bin/sh 0 console", 0, NULL);
 }
@@ -98,13 +98,12 @@ void pv_debug_start_ssh()
 
 	pv_log(DEBUG, "starting SSH server...");
 
-	if (!pv_config_get_debug_ssh_authorized_keys() ||
-	    !strcmp(pv_config_get_debug_ssh_authorized_keys(), "__default__"))
+	const char *keys = pv_config_get_str(CI_DEBUG_SSH_AUTHORIZED_KEYS);
+
+	if (!keys || !strcmp(keys, "__default__"))
 		pv_paths_pv_usrmeta_key(path, PATH_MAX, SSH_KEY_FNAME);
 	else
-		pv_paths_etc_ssh_file(
-			path, PATH_MAX,
-			pv_config_get_debug_ssh_authorized_keys());
+		pv_paths_etc_ssh_file(path, PATH_MAX, keys);
 
 	dbcmd = calloc(sizeof(DBCMD) + strlen(path) + 1, sizeof(char));
 	sprintf(dbcmd, DBCMD, path);
@@ -141,7 +140,7 @@ void pv_debug_stop_ssh()
 
 void pv_debug_check_ssh_running()
 {
-	if (pv_config_get_debug_ssh())
+	if (pv_config_get_bool(CI_DEBUG_SSH))
 		pv_debug_start_ssh();
 	else
 		pv_debug_stop_ssh();

--- a/drivers.c
+++ b/drivers.c
@@ -180,11 +180,11 @@ static int _pv_drivers_modprobe(char **modules, mod_action_t action)
 
 void pv_drivers_load_early()
 {
-	if (!pv_config_get_system_early_driver_load())
+	if (!pv_config_get_bool(CI_SYSTEM_DRIVERS_LOAD_EARLY_AUTO))
 		return;
 
 	// load fs module from pantavisor.conf
-	char *fstype = pv_config_get_storage_fstype();
+	char *fstype = pv_config_get_str(CI_STORAGE_FSTYPE);
 	if (pv_drivers_load_single(fstype, NULL) != 0)
 		pv_log(WARN, "cannot load filesystem module");
 

--- a/init.h
+++ b/init.h
@@ -88,4 +88,6 @@ extern struct pv_init pv_init_apparmor;
 int pv_do_execute_init(void);
 void pv_init_umount(void);
 
+void pv_init_print_cmdline(void);
+
 #endif

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -861,7 +861,7 @@ void pv_logserver_toggle(struct pantavisor *pv, const char *running_rev)
 		return;
 
 	// only start if we have log_capture configured
-	if (pv_config_get_log_capture()) {
+	if (pv_config_get_bool(CI_LOG_CAPTURE)) {
 		logserver_start(running_rev);
 	}
 }
@@ -910,7 +910,7 @@ int pv_logserver_init(const char *rev)
 	if (!rev)
 		return -1;
 
-	if (pv_config_get_log_capture()) {
+	if (pv_config_get_bool(CI_LOG_CAPTURE)) {
 		logserver.active_out = pv_config_get_log_server_outputs();
 		logserver_load_outputs();
 	}
@@ -950,7 +950,7 @@ int pv_logserver_init(const char *rev)
 	logserver_start_service(rev);
 	pv_log(DEBUG, "started log service with pid %d", (int)logserver.pid);
 
-	if (pv_config_get_log_capture_dmesg())
+	if (pv_config_get_bool(CI_LOG_CAPTURE_DMESG))
 		logserver_capture_dmesg();
 
 	return 0;
@@ -1016,7 +1016,7 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 		.src = src,
 	};
 
-	if ((level != FATAL) && (level > pv_config_get_log_loglevel()))
+	if ((level != FATAL) && (level > pv_config_get_int(CI_LOG_LEVEL)))
 		return 0;
 
 	struct buffer *log_buf = pv_buffer_get(true);
@@ -1032,8 +1032,9 @@ int pv_logserver_send_vlog(bool is_platform, char *platform, char *src,
 	     (logserver.pid < 0)) ||
 	    (pv_config_get_log_server_outputs() &
 	     LOG_SERVER_OUTPUT_STDOUT_DIRECT) ||
-	    (level == FATAL))
+	    (level == FATAL)) {
 		logserver_utils_stdout(&log);
+	}
 
 	if (logserver.pid < 1) {
 		pv_buffer_drop(log_buf);

--- a/logserver/logserver_filetree.c
+++ b/logserver/logserver_filetree.c
@@ -61,7 +61,7 @@ static char *create_dir(const struct logserver_log *log, bool is_pv)
 
 static int add_log(struct logserver_out *out, const struct logserver_log *log)
 {
-	if (log->lvl > pv_config_get_log_loglevel())
+	if (log->lvl > pv_config_get_int(CI_LOG_LEVEL))
 		return 0;
 
 	bool is_pv = !strncmp(log->plat, MAIN_PLATFORM, strlen(MAIN_PLATFORM));

--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -54,7 +54,7 @@ static char *create_dir(const struct logserver_log *log)
 
 static int add_log(struct logserver_out *out, const struct logserver_log *log)
 {
-	if (log->lvl > pv_config_get_log_loglevel())
+	if (log->lvl > pv_config_get_int(CI_LOG_LEVEL))
 		return 0;
 
 	char *path = create_dir(log);

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -92,7 +92,7 @@ int logserver_utils_open_logfile(const char *path)
 	if (fstat(fd, &st) != 0)
 		return fd;
 
-	if (st.st_size < pv_config_get_log_logmax())
+	if (st.st_size < pv_config_get_int(CI_LOG_MAXSIZE))
 		return fd;
 
 	if (compress_log(path) == 0) {
@@ -140,7 +140,7 @@ static int print_pvfmt_log(int fd, const struct logserver_log *log,
 
 int logserver_utils_print_raw(int fd, const struct logserver_log *log)
 {
-	char *ts_fmt = pv_config_get_log_filetree_timestamp_format();
+	char *ts_fmt = pv_config_get_str(CI_LOG_FILETREE_TS_FMT);
 	if (!ts_fmt)
 		return dprintf(fd, "%.*s", log->data.len, log->data.buf);
 
@@ -154,16 +154,14 @@ int logserver_utils_print_raw(int fd, const struct logserver_log *log)
 int logserver_utils_stdout(const struct logserver_log *log)
 {
 	return print_pvfmt_log(STDOUT_FILENO, log, "unknown",
-			       pv_config_get_log_stdout_timestamp_format(),
-			       true);
+			       pv_config_get_str(CI_LOG_STDOUT_TS_FMT), true);
 }
 
 int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
 				const char *src, bool lf)
 {
 	return print_pvfmt_log(fd, log, src,
-			       pv_config_get_log_filetree_timestamp_format(),
-			       lf);
+			       pv_config_get_str(CI_LOG_FILETREE_TS_FMT), lf);
 }
 
 char *logserver_utils_jsonify_log(const struct logserver_log *log)
@@ -185,8 +183,7 @@ char *logserver_utils_jsonify_log(const struct logserver_log *log)
 
 		if (logserver_timestamp_get_formated(
 			    ts, 256, &log->time,
-			    pv_config_get_log_singlefile_timestamp_format()) ==
-		    0) {
+			    pv_config_get_str(CI_LOG_SINGLEFILE_TS_FMT)) == 0) {
 			pv_json_ser_key(&js, "ts");
 			pv_json_ser_string(&js, ts);
 		}

--- a/mount.c
+++ b/mount.c
@@ -78,7 +78,7 @@ void pv_mount_umount(void)
 	if (umount(path))
 		pv_log(ERROR, "Error unmounting etc_file %s", strerror(errno));
 
-	if (pv_config_get_storage_logtempsize()) {
+	if (pv_config_get_str(CI_STORAGE_LOGTEMPSIZE)) {
 		pv_paths_storage(path, PATH_MAX);
 		size_t logmount_size = strlen(path) + strlen("/logs  ");
 		char *logmount = malloc(sizeof(char) * logmount_size);
@@ -108,11 +108,11 @@ static int pv_mount_init(struct pv_init *this)
 	 * Check that storage device has been enumerated and wait if not there yet
 	 * (RPi2 for example is too slow to pvan the MMC devices in time)
 	 */
-	for (int wait = pv_config_get_storage_wait(); wait > 0; wait--) {
+	for (int wait = pv_config_get_int(CI_STORAGE_WAIT); wait > 0; wait--) {
 		/*
 		 * storage.path will contain UUID=XXXX or LABEL=XXXX
 		 * */
-		const char *storage_path = pv_config_get_storage_path();
+		const char *storage_path = pv_config_get_str(CI_STORAGE_DEVICE);
 		if (get_blkid(&dev_info, storage_path))
 			pv_log(ERROR, "cannot get block device from '%s'",
 			       storage_path);
@@ -135,7 +135,7 @@ static int pv_mount_init(struct pv_init *this)
 
 	// attempt auto resize only if we have ext4 and in embedded init mode
 	if ((pv_config_get_system_init_mode() == IM_EMBEDDED) &&
-	    !strcmp(pv_config_get_storage_fstype(), "ext4")) {
+	    !strcmp(pv_config_get_str(CI_STORAGE_FSTYPE), "ext4")) {
 		size_t run_size = strlen("/lib/pv/pv_e2fsgrow") +
 				  strlen(dev_info.device) + 3;
 		char *run = malloc(sizeof(char) * run_size);
@@ -145,16 +145,18 @@ static int pv_mount_init(struct pv_init *this)
 		free(run);
 	}
 
-	if (!pv_config_get_storage_mnttype()) {
+	const char *mnttype = pv_config_get_str(CI_STORAGE_MNTTYPE);
+	const char *logtempsize = pv_config_get_str(CI_STORAGE_LOGTEMPSIZE);
+
+	if (!mnttype) {
 		ret = mount(dev_info.device, path,
-			    pv_config_get_storage_fstype(), 0, NULL);
+			    pv_config_get_str(CI_STORAGE_FSTYPE), 0, NULL);
 		if (ret < 0)
 			goto out;
 	} else {
 		int status;
 		size_t mntcmd_size = strlen("/btools/pvmnt.%s %s") +
-				     strlen(pv_config_get_storage_mnttype()) +
-				     strlen(path) + 1;
+				     strlen(mnttype) + strlen(path) + 1;
 		char *mntcmd = calloc(mntcmd_size, sizeof(char));
 
 		if (!mntcmd) {
@@ -162,21 +164,19 @@ static int pv_mount_init(struct pv_init *this)
 			goto out;
 		}
 		SNPRINTF_WTRUNC(mntcmd, mntcmd_size, "/btools/pvmnt.%s %s",
-				pv_config_get_storage_mnttype(), path);
+				mnttype, path);
 		pv_log(DEBUG, "mounting through helper: %s\n", mntcmd);
 		ret = tsh_run(mntcmd, 1, &status);
 		free(mntcmd);
 	}
 	free_blkid_info(&dev_info); /*Keep if device_info is required later.*/
 
-	if (pv_config_get_storage_logtempsize()) {
+	if (logtempsize) {
 		size_t logmount_size = strlen(path) + strlen("/logs  ");
 		char *logmount = malloc(sizeof(char) * logmount_size);
-		size_t opts_size = strlen(pv_config_get_storage_logtempsize()) +
-				   strlen("size=%s") + 1;
+		size_t opts_size = strlen(logtempsize) + strlen("size=%s") + 1;
 		char *opts = malloc(sizeof(char) * opts_size);
-		SNPRINTF_WTRUNC(opts, opts_size, "size=%s",
-				pv_config_get_storage_logtempsize());
+		SNPRINTF_WTRUNC(opts, opts_size, "size=%s", logtempsize);
 		SNPRINTF_WTRUNC(logmount, logmount_size, "%s%s", path, "/logs");
 		pv_fs_mkdir_p(logmount, 0755);
 		pv_log(DEBUG, "mounting tmpfs logmount: %s with opts: %s",

--- a/pantavisor.h
+++ b/pantavisor.h
@@ -42,7 +42,6 @@ struct pantavisor {
 	struct pv_update *update;
 	struct pv_state *state;
 	struct pv_cmd *cmd;
-	struct pantavisor_config config;
 	struct trail_remote *remote;
 	struct pv_metadata *metadata;
 	struct pv_connection *conn;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -82,10 +82,9 @@ static bool pv_parser_is_compatible(state_spec_t spec)
 {
 	// embedded and standalone init modes are compatible with multi1 and system1
 	// appengine init mode is only compatible with system1
-	return ((pv_config_get_system_init_mode() == IM_EMBEDDED) ||
-		(pv_config_get_system_init_mode() == IM_STANDALONE) ||
-		((pv_config_get_system_init_mode() == IM_APPENGINE) &&
-		 (spec == SPEC_SYSTEM1)));
+	init_mode_t init_mode = pv_config_get_system_init_mode();
+	return ((init_mode == IM_EMBEDDED) || (init_mode == IM_STANDALONE) ||
+		((init_mode == IM_APPENGINE) && (spec == SPEC_SYSTEM1)));
 }
 
 struct pv_state *pv_parser_get_state(const char *buf, const char *rev)
@@ -112,8 +111,8 @@ struct pv_state *pv_parser_get_state(const char *buf, const char *rev)
 
 	spec = pv_parser_convert_spec(value);
 	if (!pv_parser_is_compatible(spec)) {
-		pv_log(WARN, "spec '%s' not compatible with init mode %d",
-		       value, pv_config_get_system_init_mode());
+		pv_log(WARN, "spec '%s' not compatible with init mode %s",
+		       value, pv_config_get_system_init_mode_str());
 		goto out;
 	}
 
@@ -162,8 +161,8 @@ char *pv_parser_get_initrd_config_name(const char *buf)
 
 	spec = pv_parser_convert_spec(value);
 	if (!pv_parser_is_compatible(spec)) {
-		pv_log(WARN, "spec '%s' not compatible with init mode %d",
-		       value, pv_config_get_system_init_mode());
+		pv_log(WARN, "spec '%s' not compatible with init mode %s",
+		       value, pv_config_get_system_init_mode_str());
 		goto out;
 	}
 

--- a/parser/parser_multi1.c
+++ b/parser/parser_multi1.c
@@ -311,7 +311,7 @@ struct pv_state *multi1_parse(struct pv_state *this, const char *buf)
 			parse_platform(this, value, strlen(value));
 		else
 			pv_objects_add(this, key, value,
-				       pv_config_get_storage_mntpoint());
+				       pv_config_get_str(CI_STORAGE_MNTPOINT));
 
 		// free intermediates
 		if (key) {

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -159,9 +159,7 @@ out:
 
 static bool driver_should_parse(char *key)
 {
-	char *fitconfig;
-
-	fitconfig = pv_config_get_bl_fitconfig();
+	const char *fitconfig = pv_config_get_str(CI_BOOTLOADER_FITCONFIG);
 
 	pv_log(DEBUG, "fitconfig=%s", fitconfig);
 	if (!strcmp(key, "all") ||
@@ -427,7 +425,7 @@ static int parse_bsp(struct pv_state *s, char *value, int n)
 		goto out;
 	}
 
-	if ((pv_config_get_bl_type() == BL_RPIAB) &&
+	if ((pv_config_get_bootloader_type() == BL_RPIAB) &&
 	    !s->bsp.img.rpiab.bootimg) {
 		pv_log(ERROR, "bootimg not configured but required by config");
 		ret = 0;
@@ -1429,7 +1427,7 @@ static int parse_groups(struct pv_state *s, char *value)
 			free(tmp);
 			tmp = NULL;
 		} else {
-			timeout = pv_config_get_updater_goals_timeout();
+			timeout = pv_config_get_int(CI_UPDATER_GOALS_TIMEOUT);
 			pv_log(DEBUG,
 			       "timeout not configured. Using default value %d",
 			       timeout);
@@ -1797,7 +1795,7 @@ static struct pv_state *system1_parse_objects(struct pv_state *this,
 		} else {
 			pv_log(DEBUG, "adding object '%s'", key);
 			pv_objects_add(this, key, value,
-				       pv_config_get_storage_mntpoint());
+				       pv_config_get_str(CI_STORAGE_MNTTYPE));
 		}
 
 		// free intermediates

--- a/paths.c
+++ b/paths.c
@@ -35,8 +35,8 @@
 
 void pv_paths_pv_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_PATHF, pv_config_get_system_rundir(),
-			name);
+	SNPRINTF_WTRUNC(buf, size, PV_PATHF,
+			pv_config_get_str(CI_SYSTEM_RUNDIR), name);
 }
 
 #define PV_USRMETA_PATHF PV_PATH "/" USRMETA_DNAME "/%s"
@@ -45,14 +45,14 @@ void pv_paths_pv_file(char *buf, size_t size, const char *name)
 void pv_paths_pv_usrmeta_key(char *buf, size_t size, const char *key)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PATHF,
-			pv_config_get_system_rundir(), key);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), key);
 }
 
 void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat,
 				  const char *key)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_USRMETA_PLAT_PATHF,
-			pv_config_get_system_rundir(), plat, key);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), plat, key);
 }
 
 #define PV_DEVMETA_PATHF PV_PATH "/" DEVMETA_DNAME "/%s"
@@ -61,14 +61,14 @@ void pv_paths_pv_usrmeta_plat_key(char *buf, size_t size, const char *plat,
 void pv_paths_pv_devmeta_key(char *buf, size_t size, const char *key)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_DEVMETA_PATHF,
-			pv_config_get_system_rundir(), key);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), key);
 }
 
 void pv_paths_pv_devmeta_plat_key(char *buf, size_t size, const char *plat,
 				  const char *key)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_DEVMETA_PLAT_PATHF,
-			pv_config_get_system_rundir(), plat, key);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), plat, key);
 }
 
 #define PV_LOGS_PATHF PV_PATH "/" LOGS_DNAME "/%s"
@@ -77,22 +77,22 @@ void pv_paths_pv_devmeta_plat_key(char *buf, size_t size, const char *plat,
 
 void pv_paths_pv_log(char *buf, size_t size, const char *rev)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PATHF, pv_config_get_system_rundir(),
-			rev);
+	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PATHF,
+			pv_config_get_str(CI_SYSTEM_RUNDIR), rev);
 }
 
 void pv_paths_pv_log_plat(char *buf, size_t size, const char *rev,
 			  const char *plat)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LOGS_PLAT_PATHF,
-			pv_config_get_system_rundir(), rev, plat);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), rev, plat);
 }
 
 void pv_paths_pv_log_file(char *buf, size_t size, const char *rev,
 			  const char *plat, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LOGS_FILE_PATHF,
-			pv_config_get_system_rundir(), rev, plat, name);
+			pv_config_get_str(CI_SYSTEM_RUNDIR), rev, plat, name);
 }
 
 #define PV_STORAGE_PATHF "%s"
@@ -100,31 +100,31 @@ void pv_paths_pv_log_file(char *buf, size_t size, const char *rev,
 void pv_paths_storage(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF,
-			pv_config_get_storage_mntpoint());
+			pv_config_get_str(CI_STORAGE_MNTPOINT));
 }
 
 void pv_paths_storage_log(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF,
-			pv_config_get_log_logdir());
+			pv_config_get_str(CI_LOG_DIR));
 }
 
 void pv_paths_storage_usrmeta(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF,
-			pv_config_get_cache_usrmetadir());
+			pv_config_get_str(CI_CACHE_USRMETADIR));
 }
 
 void pv_paths_storage_devmeta(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF,
-			pv_config_get_cache_devmetadir());
+			pv_config_get_str(CI_CACHE_DEVMETADIR));
 }
 
 void pv_paths_storage_dropbear(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_PATHF,
-			pv_config_get_cache_dropbearcachedir());
+			pv_config_get_str(CI_DROPBEAR_CACHE_DIR));
 }
 
 #define PV_STORAGE_FILE_PATHF "%s/%s"
@@ -132,7 +132,7 @@ void pv_paths_storage_dropbear(char *buf, size_t size)
 void pv_paths_storage_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_FILE_PATHF,
-			pv_config_get_storage_mntpoint(), name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), name);
 }
 
 #define PV_OBJECT_PATHF "%s/objects/%s"
@@ -140,7 +140,7 @@ void pv_paths_storage_file(char *buf, size_t size, const char *name)
 void pv_paths_storage_object(char *buf, size_t size, const char *sha)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_OBJECT_PATHF,
-			pv_config_get_storage_mntpoint(), sha);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), sha);
 }
 
 #define PV_TRAILS_PATHF "%s/trails/%s"
@@ -153,42 +153,43 @@ void pv_paths_storage_object(char *buf, size_t size, const char *sha)
 void pv_paths_storage_trail(char *buf, size_t size, const char *rev)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PATHF,
-			pv_config_get_storage_mntpoint(), rev);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev);
 }
 
 void pv_paths_storage_trail_file(char *buf, size_t size, const char *rev,
 				 const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_FILE_PATHF,
-			pv_config_get_storage_mntpoint(), rev, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, name);
 }
 
 void pv_paths_storage_trail_plat_file(char *buf, size_t size, const char *rev,
 				      const char *plat, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PLAT_FILE_PATHF,
-			pv_config_get_storage_mntpoint(), rev, plat, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, plat,
+			name);
 }
 
 void pv_paths_storage_trail_config_file(char *buf, size_t size, const char *rev,
 					const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_CONFIG_PATHF,
-			pv_config_get_storage_mntpoint(), rev, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, name);
 }
 
 void pv_paths_storage_trail_pv_file(char *buf, size_t size, const char *rev,
 				    const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PV_PATHF,
-			pv_config_get_storage_mntpoint(), rev, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, name);
 }
 
 void pv_paths_storage_trail_pvr_file(char *buf, size_t size, const char *rev,
 				     const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRAILS_PVR_PATHF,
-			pv_config_get_storage_mntpoint(), rev, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, name);
 }
 
 #define PV_CONFIG_PATHF "%s/config/%s"
@@ -196,7 +197,7 @@ void pv_paths_storage_trail_pvr_file(char *buf, size_t size, const char *rev,
 void pv_paths_storage_config_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CONFIG_PATHF,
-			pv_config_get_storage_mntpoint(), name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), name);
 }
 
 #define PV_BOOT_PATHF "%s/boot/%s"
@@ -204,7 +205,7 @@ void pv_paths_storage_config_file(char *buf, size_t size, const char *name)
 void pv_paths_storage_boot_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_BOOT_PATHF,
-			pv_config_get_storage_mntpoint(), name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), name);
 }
 
 #define PV_STORAGE_DISKS_PATHF "%s/disks/"
@@ -215,27 +216,28 @@ void pv_paths_storage_boot_file(char *buf, size_t size, const char *name)
 void pv_paths_storage_disks(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_PATHF,
-			pv_config_get_storage_mntpoint());
+			pv_config_get_str(CI_STORAGE_MNTPOINT));
 }
 
 void pv_paths_storage_disks_rev(char *buf, size_t size, const char *rev)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_REV_PATHF,
-			pv_config_get_storage_mntpoint(), rev);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev);
 }
 
 void pv_paths_storage_disks_rev_file(char *buf, size_t size, const char *rev,
 				     const char *plat, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_REV_FILE_PATHF,
-			pv_config_get_storage_mntpoint(), rev, plat, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), rev, plat,
+			name);
 }
 
 void pv_paths_storage_disks_perm_file(char *buf, size_t size, const char *plat,
 				      const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_DISKS_PERM_FILE_PATHF,
-			pv_config_get_storage_mntpoint(), plat, name);
+			pv_config_get_str(CI_STORAGE_MNTPOINT), plat, name);
 }
 
 #define PV_STORAGE_CRYPT_PATHF "%s/pv/%s/%s"
@@ -247,7 +249,7 @@ void pv_paths_storage_mounted_disk_path(char *buf, size_t size,
 					const char *type, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_STORAGE_CRYPT_PATHF,
-			pv_config_get_system_mediadir(), type, name);
+			pv_config_get_str(CI_SYSTEM_MEDIADIR), type, name);
 }
 
 void pv_paths_crypt_disks_rev_file(char *buf, size_t size, const char *type,
@@ -255,8 +257,8 @@ void pv_paths_crypt_disks_rev_file(char *buf, size_t size, const char *type,
 				   const char *plat, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_REV_FILE_PATHF,
-			pv_config_get_system_mediadir(), type, dname, rev, plat,
-			name);
+			pv_config_get_str(CI_SYSTEM_MEDIADIR), type, dname, rev,
+			plat, name);
 }
 
 void pv_paths_crypt_disks_perm_file(char *buf, size_t size, const char *type,
@@ -264,8 +266,8 @@ void pv_paths_crypt_disks_perm_file(char *buf, size_t size, const char *type,
 				    const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_PERM_FILE_PATHF,
-			pv_config_get_system_mediadir(), type, dname, plat,
-			name);
+			pv_config_get_str(CI_SYSTEM_MEDIADIR), type, dname,
+			plat, name);
 }
 
 void pv_paths_crypt_disks_boot_file(char *buf, size_t size, const char *type,
@@ -273,8 +275,8 @@ void pv_paths_crypt_disks_boot_file(char *buf, size_t size, const char *type,
 				    const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CRYPT_DISKS_BOOT_FILE_PATHF,
-			pv_config_get_system_mediadir(), type, dname, plat,
-			name);
+			pv_config_get_str(CI_SYSTEM_MEDIADIR), type, dname,
+			plat, name);
 }
 
 #define PV_ROOT_PATHF "%s"
@@ -289,26 +291,26 @@ void pv_paths_root_file(char *buf, size_t size, const char *path)
 void pv_paths_volumes_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PATHF,
-			pv_config_get_disk_voldir(), name);
+			pv_config_get_str(CI_DISK_VOLDIR), name);
 }
 
 void pv_paths_volumes_plat_file(char *buf, size_t size, const char *plat,
 				const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_VOLUMES_PLAT_PATHF,
-			pv_config_get_disk_voldir(), plat, name);
+			pv_config_get_str(CI_DISK_VOLDIR), plat, name);
 }
 
 void pv_paths_exports(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_ROOT_PATHF,
-			pv_config_get_disk_exportsdir());
+			pv_config_get_str(CI_DISK_EXPORTSDIR));
 }
 
 void pv_paths_writable(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_ROOT_PATHF,
-			pv_config_get_disk_writabledir());
+			pv_config_get_str(CI_DISK_WRITABLEDIR));
 }
 
 #define PV_LIB_PLUGIN_PATHF "%s/pv_%s.so"
@@ -323,50 +325,50 @@ void pv_paths_writable(char *buf, size_t size)
 void pv_paths_lib_plugin(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_PLUGIN_PATHF,
-			pv_config_get_system_libdir(), name);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), name);
 }
 
 void pv_paths_lib_modules(char *buf, size_t size, const char *release)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_MODULES_PATHF,
-			pv_config_get_system_libdir(), release);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), release);
 }
 
 void pv_paths_lib_crypt(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_CRYPT_PATHF,
-			pv_config_get_system_libdir(), name);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), name);
 }
 
 void pv_paths_lib_volmount(char *buf, size_t size, const char *type,
 			   const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_VOLMOUNT_PATHF,
-			pv_config_get_system_libdir(), type, name);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), type, name);
 }
 
 void pv_paths_lib_hook(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOK_PATHF,
-			pv_config_get_system_libdir(), name);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), name);
 }
 
 void pv_paths_lib_hooks_early_spawn(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_HOOKS_EARLY_SPAWN_PATHF,
-			pv_config_get_system_libdir(), name);
+			pv_config_get_str(CI_SYSTEM_LIBDIR), name);
 }
 
 void pv_paths_lib_lxc_rootfs_mount(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_LXC_ROOTFS_MOUNT_PATHF,
-			pv_config_get_system_usrdir());
+			pv_config_get_str(CI_SYSTEM_USRDIR));
 }
 
 void pv_paths_lib_lxc_lxcpath(char *buf, size_t size)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_LIB_LXC_LXCPATH_PATHF,
-			pv_config_get_system_usrdir());
+			pv_config_get_str(CI_SYSTEM_USRDIR));
 }
 
 #define PV_ETC_PATHF "%s/%s"
@@ -375,20 +377,20 @@ void pv_paths_lib_lxc_lxcpath(char *buf, size_t size)
 
 void pv_paths_etc_file(char *buf, size_t size, const char *name)
 {
-	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF, pv_config_get_system_etcdir(),
-			name);
+	SNPRINTF_WTRUNC(buf, size, PV_ETC_PATHF,
+			pv_config_get_str(CI_SYSTEM_ETCDIR), name);
 }
 
 void pv_paths_etc_policy_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_ETC_POLICY_PATHF,
-			pv_config_get_system_etcdir(), name);
+			pv_config_get_str(CI_SYSTEM_ETCDIR), name);
 }
 
 void pv_paths_etc_ssh_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_ETC_SSH_PATHF,
-			pv_config_get_system_etcdir(), name);
+			pv_config_get_str(CI_SYSTEM_ETCDIR), name);
 }
 
 #define PV_CONFIGS_PATHF "%s/%s"
@@ -396,7 +398,7 @@ void pv_paths_etc_ssh_file(char *buf, size_t size, const char *name)
 void pv_paths_configs_file(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CONFIGS_PATHF,
-			pv_config_get_system_confdir(), name);
+			pv_config_get_str(CI_SYSTEM_CONFDIR), name);
 }
 
 #define PV_CERT_PATHF "%s/%s"
@@ -404,7 +406,7 @@ void pv_paths_configs_file(char *buf, size_t size, const char *name)
 void pv_paths_cert(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_CERT_PATHF,
-			pv_config_get_libthttp_certdir(), name);
+			pv_config_get_str(CI_LIBTHTTP_CERTDIR), name);
 }
 
 #define PV_TRUST_CERTS_PATHF "%s/%s/%s.crt"
@@ -412,7 +414,8 @@ void pv_paths_cert(char *buf, size_t size, const char *name)
 void pv_paths_secureboot_trust_crts(char *buf, size_t size, const char *name)
 {
 	SNPRINTF_WTRUNC(buf, size, PV_TRUST_CERTS_PATHF,
-			pv_config_get_system_etcdir(), PVS_TRUST_DNAME, name);
+			pv_config_get_str(CI_SYSTEM_ETCDIR), PVS_TRUST_DNAME,
+			name);
 }
 
 #define PV_TMP_PATHF "%s.tmp"

--- a/ph_logger.c
+++ b/ph_logger.c
@@ -612,7 +612,7 @@ static int ph_logger_push_revision(char *revision)
 
 static void log_libthttp(int level, const char *fmt, va_list args)
 {
-	if (level > pv_config_get_libthttp_loglevel())
+	if (level > pv_config_get_int(CI_LIBTHTTP_LOG_LEVEL))
 		return;
 
 	vlog(MODULE_NAME, DEBUG, fmt, args);
@@ -826,8 +826,10 @@ void ph_logger_toggle(char *rev)
 	if (!pv)
 		return;
 
-	if (pv_config_get_log_push() &&
-	    pv_config_get_log_server_output_file_tree() && pv->remote_mode) {
+	if (pv_config_get_bool(CI_LOG_PUSH) &&
+	    (pv_config_get_log_server_outputs() &
+	     LOG_SERVER_OUTPUT_FILE_TREE) &&
+	    pv->remote_mode) {
 		ph_logger_start_cloud(pv, rev);
 	} else {
 		ph_logger_stop_lenient();

--- a/plugins/pv_lxc.h
+++ b/plugins/pv_lxc.h
@@ -36,6 +36,9 @@ void pv_set_pv_paths_fn(
 	void *fn_pv_paths_configs_file, void *fn_pv_paths_lib_lxc_rootfs_mount,
 	void *fn_pv_paths_lib_lxc_lxcpath);
 
+void pv_set_pv_conf_loglevel_fn(int loglevel);
+void pv_set_pv_conf_capture_fn(bool capture);
+
 void *pv_start_container(struct pv_platform *p, const char *rev,
 			 char *conf_file, int logfd, void *data);
 void *pv_stop_container(struct pv_platform *p, char *conf_file, void *data);

--- a/signature.c
+++ b/signature.c
@@ -597,8 +597,8 @@ static int pv_signature_parse_certs(struct dl_list *certs_raw,
 		       serial);
 	} while ((cacerts_i = cacerts_i->next) != 0);
 
-	pv_paths_secureboot_trust_crts(path, PATH_MAX,
-				       pv_config_get_secureboot_truststore());
+	pv_paths_secureboot_trust_crts(
+		path, PATH_MAX, pv_config_get_str(CI_SECUREBOOT_TRUSTSTORE));
 	pv_log(DEBUG, "parsing secureboot.truststore certs from %s", path);
 	res = mbedtls_x509_crt_parse_file(&cacerts, path);
 	if (res) {

--- a/state.c
+++ b/state.c
@@ -1131,7 +1131,8 @@ static char *_pv_state_get_novalidate_list(char *rev)
 	struct dirent *dp;
 	DIR *volmountdir;
 
-	if (getenv("pv_verityoff") || !pv_config_get_secureboot_handlers())
+	if (getenv("pv_verityoff") ||
+	    !pv_config_get_bool(CI_SECUREBOOT_HANDLERS))
 		return NULL;
 
 	pv_paths_lib_volmount(hdl_path, PATH_MAX, "verity", "");
@@ -1228,7 +1229,8 @@ bool pv_state_validate_checksum(struct pv_state *s)
 	char *validate_list = NULL;
 	bool ret = false;
 
-	if (getenv("pv_quickboot") || !pv_config_get_secureboot_checksum()) {
+	if (getenv("pv_quickboot") ||
+	    !pv_config_get_bool(CI_SECUREBOOT_CHECKSUM)) {
 		pv_log(DEBUG, "state objects and JSONs checksum disabled");
 		ret = true;
 		goto out;

--- a/storage.c
+++ b/storage.c
@@ -233,7 +233,8 @@ static struct pv_storage *pv_storage_new()
 		if (this->total)
 			this->free_percentage =
 				(this->free * 100) / this->total;
-		this->reserved_percentage = pv_config_get_storage_gc_reserved();
+		this->reserved_percentage =
+			pv_config_get_int(CI_STORAGE_GC_RESERVED);
 		this->reserved =
 			(this->total * this->reserved_percentage) / 100;
 		if (this->free > this->reserved)
@@ -241,7 +242,7 @@ static struct pv_storage *pv_storage_new()
 		if (this->total)
 			this->real_free_percentage =
 				(this->real_free * 100) / this->total;
-		this->threshold = pv_config_get_storage_gc_threshold();
+		this->threshold = pv_config_get_int(CI_STORAGE_GC_THRESHOLD);
 		return this;
 	}
 
@@ -308,7 +309,7 @@ int pv_storage_gc_run()
 		    (s && !strncmp(r->path, s->rev, len)) ||
 		    (u && !strncmp(r->path, u->rev, len)) ||
 		    !strncmp(r->path, pv_bootloader_get_done(), len) ||
-		    (pv_config_get_storage_gc_keep_factory() &&
+		    (pv_config_get_bool(CI_STORAGE_GC_KEEP_FACTORY) &&
 		     !strncmp(r->path, "0", len)))
 			continue;
 
@@ -352,15 +353,14 @@ void pv_storage_gc_defer_run_threshold()
 {
 	struct pantavisor *pv = pv_get_instance();
 
-	timer_start(&threshold_timer,
-		    pv_config_get_storage_gc_threshold_defertime(), 0,
-		    RELATIV_TIMER);
+	int defertime = pv_config_get_int(CI_STORAGE_GC_THRESHOLD_DEFERTIME);
+	timer_start(&threshold_timer, defertime, 0, RELATIV_TIMER);
 
 	if (!pv->loading_objects) {
 		pv->loading_objects = true;
 		pv_log(INFO,
 		       "disabled garbage collector threshold. Will be available again in %d seconds",
-		       pv_config_get_storage_gc_threshold_defertime());
+		       defertime);
 	}
 }
 
@@ -408,7 +408,7 @@ void pv_storage_gc_run_threshold()
 		pv_log(INFO, "garbage collector enabled again");
 	}
 
-	if (!pv_config_get_storage_gc_threshold() || pv->loading_objects)
+	if (!pv_config_get_int(CI_STORAGE_GC_THRESHOLD) || pv->loading_objects)
 		goto out;
 
 	if (storage && (storage->real_free_percentage < storage->threshold)) {
@@ -781,7 +781,7 @@ void pv_storage_init_trail_pvr()
 
 	// save .pvr/config with that links trail contents and system paths
 	SNPRINTF_WTRUNC(config, PATH_MAX, PVR_CONFIGF,
-			pv_config_get_storage_mntpoint());
+			pv_config_get_str(CI_STORAGE_MNTPOINT));
 	if (pv_fs_file_save(path, config, 0644) < 0)
 		pv_log(WARN, "could not save file %s: %s", path,
 		       strerror(errno));
@@ -1121,8 +1121,8 @@ static int pv_storage_init(struct pv_init *this)
 		       strerror(errno));
 
 	pv_paths_pv_file(path, PATH_MAX, DEVICE_ID_FNAME);
-	if (!pv_config_get_creds_prn() ||
-	    !strcmp(pv_config_get_creds_prn(), "")) {
+	const char *prn = pv_config_get_str(CI_CREDS_PRN);
+	if (!prn || !strcmp(prn, "")) {
 		pv->unclaimed = true;
 		if (pv_fs_file_save(path, "", 0444) < 0)
 			pv_log(WARN, "could not save file %s: %s", path,
@@ -1130,14 +1130,15 @@ static int pv_storage_init(struct pv_init *this)
 	} else {
 		pv->unclaimed = false;
 		SNPRINTF_WTRUNC(tmp, sizeof(tmp), "%s\n",
-				pv_config_get_creds_id());
+				pv_config_get_str(CI_CREDS_ID));
 		if (pv_fs_file_save(path, tmp, 0444) < 0)
 			pv_log(WARN, "could not save file %s: %s", path,
 			       strerror(errno));
 	}
 	pv_paths_pv_file(path, PATH_MAX, PHHOST_FNAME);
 	SNPRINTF_WTRUNC(tmp, sizeof(tmp), "https://%s:%d\n",
-			pv_config_get_creds_host(), pv_config_get_creds_port());
+			pv_config_get_str(CI_CREDS_HOST),
+			pv_config_get_int(CI_CREDS_PORT));
 	if (pv_fs_file_save(path, tmp, 0444) < 0)
 		pv_log(WARN, "could not save file %s: %s", path,
 		       strerror(errno));

--- a/uboot.c
+++ b/uboot.c
@@ -71,10 +71,10 @@ static int uboot_init()
 	pv_log(DEBUG, "uboot.txt@%s", uboot_txt);
 
 	// get mtd_path from config or else use default
-	single_env = pv_config_get_bl_mtd_only();
-	if (pv_config_get_bl_mtd_path())
-		memcpy(mtd_env_str, pv_config_get_bl_mtd_path(),
-		       strlen(pv_config_get_bl_mtd_path()));
+	single_env = pv_config_get_bool(CI_BOOTLOADER_MTD_ONLY);
+	const char *mtd_path = pv_config_get_str(CI_BOOTLOADER_MTD_ENV);
+	if (mtd_path)
+		memcpy(mtd_env_str, mtd_path, strlen(mtd_path));
 	else
 		memcpy(mtd_env_str, MTD_ENV, sizeof(MTD_ENV));
 

--- a/volumes.c
+++ b/volumes.c
@@ -220,8 +220,9 @@ int pv_volume_mount(struct pv_volume *v)
 			pv_fs_mkdir_p(mntpoint, 0755);
 			ret = mount(path, mntpoint, NULL, MS_BIND | MS_REC,
 				    NULL);
-		} else if (handler && (!getenv("pv_verityoff") &&
-				       pv_config_get_secureboot_handlers())) {
+		} else if (handler &&
+			   (!getenv("pv_verityoff") &&
+			    pv_config_get_bool(CI_SECUREBOOT_HANDLERS))) {
 			pv_log(INFO, "with '%s' handler", handler);
 
 			if (!partname) {

--- a/wdt.c
+++ b/wdt.c
@@ -39,8 +39,8 @@ static int pv_wdt_fd = -1;
 
 int pv_wdt_start()
 {
-	if (!pv_config_get_watchdog_enabled() ||
-	    (pv_config_get_watchdog_mode() == WDT_DISABLED))
+	if (!pv_config_get_bool(CI_WDT_ENABLED) ||
+	    (pv_config_get_wdt_mode() == WDT_DISABLED))
 		return 0;
 
 	if (pv_wdt_fd >= 0)
@@ -52,7 +52,7 @@ int pv_wdt_start()
 		return -1;
 	}
 
-	int timeout = pv_config_get_watchdog_timeout();
+	int timeout = pv_config_get_int(CI_WDT_TIMEOUT);
 	ioctl(pv_wdt_fd, WDIOC_SETTIMEOUT, &timeout);
 	ioctl(pv_wdt_fd, WDIOC_GETTIMEOUT, &timeout);
 


### PR DESCRIPTION
This PR proposes a total refactor of Pantavisor configuration, transforming the old struct into a lookup table that aims at reducing code duplication when adding or modifying config keys. This is the format for each config entry:

```
{ INT, "log.level", PV_CONF | RUN_TIME, 0, .value.i = 0 },
```

The idea is that we can set in each row the type, key, where can that key be modified (in this case, pantavisor.conf and run time), where that key was modified (to be filled up by Pantavisor) and its default value.

Each key has to be also added to the index list, to keep the access at O(1).

```
 CI_LOG_LEVEL,
```

Then, that key is get from the rest of the code using generic functions depending on its type:

```
pv_config_get_int(CI_LOG_LEVEL)
```

This greatly reduces the amount of code to maintain in config.c and the number of changes when adding new keys that we have now: one for pantavisor.conf, another for config trail, user metadata, json format, log format...

It also opens the doors to easily add other improvements to the config system, such as:
* save configuration to device metadata
* add a generic pvcontrol command to change config that gets back to previous value after reboot
* allow for easily adding new formats to present config using pvcontrol
* showing the string-to-enum keys (wdt.mode, log.server.outputs) as strings so reading logs or pvcontrol output is easier