### PR TITLE
fix: sysctl write missing trailing character

### DIFF
--- a/config.c
+++ b/config.c
@@ -631,7 +631,7 @@ static int _apply_config_sysctl(const char *key, const char *value,
 		return -1;
 	}
 
-	write(fd, value, strlen(value));
+	write(fd, value, strlen(value) + 1);
 	close(fd);
 	free(path);
 


### PR DESCRIPTION
Although cmdline config plays well with empty values, sysctl was not writing those values into /proc/sys because we were using strlen(value). With this change, we include the trailing character to fix the problem.