### PR TITLE
Fixes problems found to update the toolchain

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -470,8 +470,8 @@ static pv_state_t pv_wait_update()
 				timer_current_state(&timer_commit);
 			if (!tstate.fin) {
 				pv_log(INFO,
-				       "committing new update in %d seconds",
-				       tstate.sec);
+				       "committing new update in %lld seconds",
+				       (long long)tstate.sec);
 				return PV_STATE_WAIT;
 			}
 		}

--- a/rpiab.c
+++ b/rpiab.c
@@ -236,7 +236,6 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 	if (!f) {
 		pv_log(INFO, "Cannot open tryboot state on RPI: %s",
 		       strerror(errno));
-		fclose(f);
 		return -1;
 	}
 

--- a/updater.c
+++ b/updater.c
@@ -456,7 +456,7 @@ static char *pv_update_get_progress_json(struct pv_update_progress *progress)
 		pv_json_ser_string(&js, progress->msg);
 		pv_json_ser_key(&js, "progress");
 		pv_json_ser_number(&js, progress->progress);
-		if (progress->data && (strlen(progress->data) > 0)) {
+		if (strlen(progress->data) > 0) {
 			pv_json_ser_key(&js, "data");
 			pv_json_ser_string(&js, progress->data);
 		}


### PR DESCRIPTION
* Remove unnecessary fclose(), on rpiab.c:239
* Remove an "always true" condition , on updater.c:466 

Both are warning (and errors due to -werror) with the new compiler