### PR TITLE
allow quotes to accept special characters in cmdline values

### DIFF
--- a/config.c
+++ b/config.c
@@ -262,20 +262,19 @@ bool pv_config_get_bool(config_index_t ci)
 	return entries[ci].value.b;
 }
 
-static void _set_config_by_entry_bool(struct pv_config_entry *entry, bool value,
-				      level_t modified)
+static void _set_config_by_entry_bool(struct pv_config_entry *entry, bool value)
 {
 	if (!entry)
 		return;
 
 	entry->value.b = value;
-	entry->modified = modified;
 }
 
 static void _set_config_by_index_bool(config_index_t ci, bool value,
 				      level_t modified)
 {
-	_set_config_by_entry_bool(&entries[ci], value, modified);
+	entries[ci].modified = modified;
+	_set_config_by_entry_bool(&entries[ci], value);
 }
 
 int pv_config_get_int(config_index_t ci)
@@ -283,14 +282,12 @@ int pv_config_get_int(config_index_t ci)
 	return entries[ci].value.i;
 }
 
-static void _set_config_by_entry_int(struct pv_config_entry *entry, int value,
-				     level_t modified)
+static void _set_config_by_entry_int(struct pv_config_entry *entry, int value)
 {
 	if (!entry)
 		return;
 
 	entry->value.i = value;
-	entry->modified = modified;
 }
 
 char *pv_config_get_str(config_index_t ci)
@@ -299,7 +296,7 @@ char *pv_config_get_str(config_index_t ci)
 }
 
 static void _set_config_by_entry_str(struct pv_config_entry *entry,
-				     const char *value, level_t modified)
+				     const char *value)
 {
 	if (!entry)
 		return;
@@ -307,13 +304,13 @@ static void _set_config_by_entry_str(struct pv_config_entry *entry,
 	if (entry->value.s)
 		free(entry->value.s);
 	entry->value.s = strdup(value);
-	entry->modified = modified;
 }
 
 static void _set_config_by_index_str(config_index_t ci, const char *value,
 				     level_t modified)
 {
-	_set_config_by_entry_str(&entries[ci], value, modified);
+	entries[ci].modified = modified;
+	_set_config_by_entry_str(&entries[ci], value);
 }
 
 bootloader_t pv_config_get_bootloader_type()
@@ -343,8 +340,7 @@ char *pv_config_get_bootloader_type_str(void)
 }
 
 static void _set_config_by_entry_bootloader_type(struct pv_config_entry *entry,
-						 const char *value,
-						 level_t modified)
+						 const char *value)
 {
 	if (!entry)
 		return;
@@ -395,7 +391,7 @@ log_server_output_mask_t pv_config_get_log_server_outputs()
 
 static void
 _set_config_by_entry_log_server_outputs(struct pv_config_entry *entry,
-					const char *value, level_t modified)
+					const char *value)
 {
 	if (!entry)
 		return;
@@ -467,8 +463,7 @@ char *pv_config_get_secureboot_mode_str(void)
 }
 
 static void _set_config_by_entry_secureboot_mode(struct pv_config_entry *entry,
-						 const char *value,
-						 level_t modified)
+						 const char *value)
 {
 	if (!entry)
 		return;
@@ -513,7 +508,7 @@ char *pv_config_get_system_init_mode_str(void)
 }
 
 static void _set_config_by_entry_init_mode(struct pv_config_entry *entry,
-					   const char *value, level_t modified)
+					   const char *value)
 {
 	if (!entry)
 		return;
@@ -564,7 +559,7 @@ char *pv_config_get_wdt_mode_str(void)
 }
 
 static void _set_config_by_entry_wdt_mode(struct pv_config_entry *entry,
-					  const char *value, level_t modified)
+					  const char *value)
 {
 	if (!entry)
 		return;
@@ -725,30 +720,32 @@ static int _set_config_by_entry(struct pv_config_entry *entry,
 		}
 	}
 
+	entry->modified = modified;
+
 	switch (entry->type) {
 	case BOOL:
-		_set_config_by_entry_bool(entry, value_int, modified);
+		_set_config_by_entry_bool(entry, value_int);
 		break;
 	case BOOTLOADER:
-		_set_config_by_entry_bootloader_type(entry, value, modified);
+		_set_config_by_entry_bootloader_type(entry, value);
 		break;
 	case INIT_MODE:
-		_set_config_by_entry_init_mode(entry, value, modified);
+		_set_config_by_entry_init_mode(entry, value);
 		break;
 	case INT:
-		_set_config_by_entry_int(entry, value_int, modified);
+		_set_config_by_entry_int(entry, value_int);
 		break;
 	case LOG_SERVER_OUTPUT_UPDATE_MASK:
-		_set_config_by_entry_log_server_outputs(entry, value, modified);
+		_set_config_by_entry_log_server_outputs(entry, value);
 		break;
 	case SB_MODE:
-		_set_config_by_entry_secureboot_mode(entry, value, modified);
+		_set_config_by_entry_secureboot_mode(entry, value);
 		break;
 	case STR:
-		_set_config_by_entry_str(entry, value, modified);
+		_set_config_by_entry_str(entry, value);
 		break;
 	case WDT_MODE:
-		_set_config_by_entry_wdt_mode(entry, value, modified);
+		_set_config_by_entry_wdt_mode(entry, value);
 		break;
 	default:
 		pv_log(WARN, "unknown config type %d for key '%s'", entry->type,

--- a/config_parser.c.orig
+++ b/config_parser.c.orig
@@ -108,12 +108,14 @@ out:
 	return NULL;
 }
 
+<<<<<<< HEAD
+=======
 static struct config_item *_config_replace_item(struct dl_list *list, char *key,
 						char *value)
 {
 	struct config_item *curr = NULL;
 
-	if (key == NULL || list == NULL)
+	if (key == NULL || dl_list_empty(list))
 		return NULL;
 
 	curr = _config_get_by_key(list, key);
@@ -130,12 +132,12 @@ static struct config_item *_config_replace_item(struct dl_list *list, char *key,
 	return _config_add_item(list, key, value);
 }
 
-static char *_skip_spaces(char *cmdline)
+static char *_skip_spaces(const char *cmdline)
 {
 	char *c = cmdline;
 
 	while (*c != '\0') {
-		if (*c != ' ')
+		if (*c != ' ');
 			break;
 		c++;
 	}
@@ -143,39 +145,36 @@ static char *_skip_spaces(char *cmdline)
 	return c;
 }
 
-static char *_parse_item(char *cmdline, char **key, char **value)
+static char *_parse_item(const char *cmdline, char **key, char **value)
 {
 	char *c = cmdline;
+	char *key = NULL *value = NULL;
 	bool quoted = false, equaled = false;
-	*key = NULL;
-	*value = NULL;
 
 	while (*c != '\0') {
-		if ((*c == '"') && !quoted) {
-			// quote
-			quoted = true;
-		} else if ((*c == '"') && quoted) {
-			// unquote
-			quoted = false;
-			*c = '\0';
-		} else if (((*c == ' ') || (*c == '\n')) && !quoted) {
-			// value end
-			*c = '\0';
-			c++;
-			break;
-		} else if ((*c == '=') && !equaled) {
-			// key end
+		if (*c == '"')
+			quoted = !quoted;
+		else if ((*c == '=') && !quoted) {
 			equaled = true;
 			*c = '\0';
-		} else if (!(*key) && !equaled) {
-			// key begin
-			*key = c;
-		} else if (!(*value) && equaled) {
-			// value begin
-			*value = c;
+		} else if (((*c == ' ') || (*c == '\n')) && !quoted) {
+			*c = '\0';
+			break;
+		} else {
+			if (!(*key) && !equaled)
+				*key = c;
+			else if (!(*value) && equaled)
+				*value = c;
 		}
 
 		c++;
+	}
+
+	// cmdline ended without closing a quote
+	if (quoted) {
+		*key = NULL;
+		*value = NULL;
+		return c;
 	}
 
 	// if = is present we keep the empty value
@@ -185,24 +184,50 @@ static char *_parse_item(char *cmdline, char **key, char **value)
 	return c;
 }
 
-static char *_remove_hint_from_key(const char *hint, char *key)
+static char *_remove_hint_from_key(const char *hint, const char *key)
 {
-	int hint_len = strlen(hint);
+	int hint_len = strlen(key);
 	int key_len = strlen(key);
 
 	if (hint_len >= key_len)
 		return NULL;
 
 	if (!pv_str_startswith(hint, hint_len, key))
-		return NULL;
+		return NULL
 
 	char *k = key + hint_len;
 	return k;
 }
 
+>>>>>>> 91a3b47 (allow quotes to accept special characters in cmdline values)
 int config_parse_cmdline(struct dl_list *list, char *hint)
 {
 	struct pantavisor *pv = pv_get_instance();
+	char *buf = NULL, *k = NULL, *nl = NULL;
+	char *ptr_out = NULL, *ptr_in = NULL;
+	char *token = NULL, *key = NULL, *value = NULL;
+
+
+<<<<<<< HEAD
+	while (token) {
+		if (strncmp(hint, token, strlen(hint)) == 0) {
+			k = token + strlen(hint);
+			key = strtok_r(k, "=", &ptr_in);
+			value = strtok_r(NULL, "\0", &ptr_in);
+			/*
+			 * for things like XYZ= there would be nothing
+			 * in the value as strtok returns only non-empty
+			 * strings.
+			 * */
+			if (!value)
+				value = ""; /*We keep the key but give it an empty value*/
+			nl = strchr(value, '\n');
+			if (nl) /* get rid of newline at end */
+				*nl = '\0';
+			_config_add_item(list, key, value);
+		}
+		token = strtok_r(NULL, " ", &ptr_out);
+=======
 	char *buf = strdup(pv->cmdline);
 	char *cmdline = buf;
 	char *key = NULL, *value = NULL;
@@ -218,6 +243,7 @@ int config_parse_cmdline(struct dl_list *list, char *hint)
 		key = _remove_hint_from_key(hint, key);
 		if (key)
 			_config_replace_item(list, key, value);
+>>>>>>> 91a3b47 (allow quotes to accept special characters in cmdline values)
 	}
 
 	free(buf);


### PR DESCRIPTION
This PR contains a modification of the cmdline parser to support quoted configuration arguments.

Syntax rules have been kept as similar as the Linux Kernel cmdline as possible:

* Any number of spaces between items is allowed.
* The ' ' special character is used as a separator between items.
* The '"' special character is used to escape separators, using two between each config item or between the value.
* The '"' between items, and values are discarded after parsing the cmdline.
* The '=' special character cannot be escaped.
* The first '=' found separates the key and the value of an item, while the rest of '=' are part of the value.
* Empty keys are not allowed.

While keeping Pantavisor special rules for backwards compatibility with the current configuration syntax:

* Items without '=' are ignored.
* The '\n' special character is used as an equivalent to the ' ' separator.
* Items need to have a prefix ("pv_" or "ph_") to be acknowledged by Pantavisor.
* Empty values are allowed and substituted by an empty string.
* The processed keys depend on the set of Pantavisor configuration keys.