### PR TITLE
allow sysctl config from env

### DIFF
--- a/config_parser.h
+++ b/config_parser.h
@@ -33,12 +33,12 @@ void config_iterate_items(struct dl_list *list,
 			  int (*action)(const char *key, const char *value,
 					void *opaque),
 			  void *opaque);
-
 void config_iterate_items_prefix(struct dl_list *list,
 				 int (*action)(const char *key,
 					       const char *value, void *opaque),
 				 char *prefix, void *opaque);
-
 void config_clear_items(struct dl_list *list);
+
+char *pv_config_parser_sysctl_key(const char *key);
 
 #endif


### PR DESCRIPTION
This PR adds the sysctl config keys to the [Linux env configurable list](https://github.com/pantavisor/pantavisor/pull/429):

* The old format (e.g: "sysctl.kernel.core_pattern") is still supported.
* A new env friendly format (e.g: "PV_SYSCTL_KERNEL_CORE_PATTERN") is now supported. This is parsed by checking for existing dirs when reaching a '_' character. If true, then it is switched with a '/'.