### PR TITLE
Moves timestamp at the beginning of the lines

### DIFF
--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -112,17 +112,17 @@ static int print_pvfmt_log(int fd, const struct logserver_log *log,
 
 	if (ts_fmt) {
 		if (lf)
-			fmt = "[%s] %" PRId64 " %s [%s]\t -- [%s]: %.*s\n";
+			fmt = "[%s] [%s] %" PRId64 " %s\t -- [%s]: %.*s\n";
 		else
-			fmt = "[%s] %" PRId64 " %s [%s]\t -- [%s]: %.*s";
+			fmt = "[%s] [%s] %" PRId64 " %s\t -- [%s]: %.*s";
 
 		char ts[256] = { 0 };
 		if (logserver_timestamp_get_formated(ts, 256, &log->time,
 						     ts_fmt) != 0)
 			strncpy(ts, "--", 3);
 
-		len = dprintf(fd, fmt, log->plat, log->tsec,
-			      pv_log_level_name(log->lvl), ts, util_src,
+		len = dprintf(fd, fmt, ts, log->plat, log->tsec,
+			      pv_log_level_name(log->lvl), util_src,
 			      log->data.len, log->data.buf);
 	} else {
 		if (lf)


### PR DESCRIPTION
Now Pantavisor log looks like this:

```
[1970-01-01T00:23:20] [pantavisor] 10 DEBUG      -- [logserver]: starting logserver loop
[1970-01-01T00:23:20] [pantavisor] 10 DEBUG      -- [logserver]: started log service with pid 79
[1970-01-01T00:23:20] [pantavisor] 10 DEBUG      -- [log]: initialized pantavisor logs...
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: ______           _              _
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: | ___ \         | |            (_)
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: | |_/ /_ _ _ __ | |_ __ ___   ___ ___  ___  _ __
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: |  __/ _` | '_ \| __/ _` \ \ / / / __|/ _ \| '__|
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: | | | (_| | | | | || (_| |\ V /| \__ \ (_) | |
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: \_|  \__,_|_| |_|\__\__,_| \_/ |_|___/\___/|_|
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]:
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]: Pantavisor (TM) (019-291-g3cb27d0-240613) - pantavisor.io
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [log]:
[1970-01-01T00:23:20] [pantavisor] 10 DEBUG      -- [bootloader]: rev=locals/pbox-1718274713;try=locals/pbox-1718274713;done=locals/pbox-1718275257
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [config]: PH_CREDS_HOST = '192.168.53.1' (default)
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [config]: PH_CREDS_ID = '(null)' (default)
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [config]: PH_CREDS_PORT = 12365 (default)
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [config]: PH_CREDS_PROXY_HOST = '(null)' (default)
[1970-01-01T00:23:20] [pantavisor] 10 INFO       -- [config]: PH_CREDS_PROXY_NOPROXYCONNECT = 0 (default)
```