### PR TITLE
new request in ctrl to return the new config format table

### DIFF
--- a/config.h
+++ b/config.h
@@ -202,6 +202,7 @@ void pv_config_override_value(const char *key, const char *value);
 
 void pv_config_free(void);
 
+char *pv_config_get_alias_json(void);
 char *pv_config_get_json(void);
 void pv_config_print(void);
 

--- a/ctrl.c
+++ b/ctrl.c
@@ -76,6 +76,7 @@
 #define ENDPOINT_DEVICE_META "/device-meta"
 #define ENDPOINT_BUILDINFO "/buildinfo"
 #define ENDPOINT_CONFIG "/config"
+#define ENDPOINT_CONFIG2 "/config2"
 #define ENDPOINT_DRIVERS "/drivers"
 
 #define HTTP_RES_OK "HTTP/1.1 200 OK\r\n\r\n"
@@ -1300,6 +1301,15 @@ pv_ctrl_process_endpoint_and_reply(int req_fd, const char *method,
 		} else
 			goto err_me;
 	} else if (pv_str_matches(ENDPOINT_CONFIG, strlen(ENDPOINT_CONFIG),
+				  path, path_len)) {
+		if (!strncmp("GET", method, method_len)) {
+			if (!mgmt)
+				goto err_pr;
+			pv_ctrl_process_get_string(req_fd,
+						   pv_config_get_alias_json());
+		} else
+			goto err_me;
+	} else if (pv_str_matches(ENDPOINT_CONFIG2, strlen(ENDPOINT_CONFIG2),
 				  path, path_len)) {
 		if (!strncmp("GET", method, method_len)) {
 			if (!mgmt)


### PR DESCRIPTION
As pvcontrol config ls will keep returning the old config format (e.g. creds.host=api.pantahub.com) for backwards compatibility reasons, this PR offers a new request to return the new format, adding at which level the item was set.

For example:

```
[
  {
    "key": "PH_CREDS_HOST",
    "value": "api.pantahub.com",
    "modified": "ph conf file"
  },
  ...
  {
    "key": "PV_DEBUG_SHELL_AUTOLOGIN",
    "value": "0",
    "modified": "default"
  },
  ...
  {
    "key": "PV_UPDATER_GOALS_TIMEOUT",
    "value": "10",
    "modified": "pv conf file"
  },
  ...
]
```