### PR TITLE
Format /dev/kmsg logs in the same way as dmesg

### DIFF
--- a/logserver/logserver_singlefile.c
+++ b/logserver/logserver_singlefile.c
@@ -69,11 +69,9 @@ static int add_log(struct logserver_out *out, const struct logserver_log *log)
 		return -1;
 	}
 
-	char *json = logserver_utils_jsonify_log(log);
-	int len = dprintf(fd, "%s\n", json);
+	int len = logserver_utils_print_json_fmt(fd, log);
 
 	close(fd);
-	free(json);
 	free(path);
 
 	return len;

--- a/logserver/logserver_utils.h
+++ b/logserver/logserver_utils.h
@@ -30,6 +30,7 @@
 int logserver_utils_open_logfile(const char *path);
 int logserver_utils_print_pvfmt(int fd, const struct logserver_log *log,
 				const char *src, bool lf);
+int logserver_utils_print_json_fmt(int fd, const struct logserver_log *log);
 int logserver_utils_print_raw(int fd, const struct logserver_log *log);
 char *logserver_utils_jsonify_log(const struct logserver_log *log);
 char *logserver_utils_output_to_str(int out_type);


### PR DESCRIPTION
* Adds a new parser for /dev/kmsg, extracting the timestamp and formatting it in the same way that the `dmesg` command does it
* Splits logs with multiple lines (like `/dev/kmsg`)