### PR TITLE
Sets automatically ignore_loglevel and printk_devkmsg=on when is needed

### DIFF
--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -343,3 +343,25 @@ char *logserver_utils_output_to_str(int out_type)
 
 	return "unknown";
 }
+
+static int write_option(const char *path, const char *op)
+{
+	int fd = open(path, O_WRONLY);
+	if (fd < 0)
+		return -2;
+	int len = write(fd, op, strlen(op));
+	close(fd);
+
+	return len < 0 ? len : 0;
+}
+
+int logserver_utils_printk_devmsg_on()
+{
+	return write_option("/proc/sys/kernel/printk_devkmsg", "on\n");
+}
+
+int logserver_utils_ignore_loglevel()
+{
+	return write_option("/sys/module/printk/parameters/ignore_loglevel",
+			    "Y");
+}

--- a/logserver/logserver_utils.h
+++ b/logserver/logserver_utils.h
@@ -35,5 +35,7 @@ int logserver_utils_print_raw(int fd, const struct logserver_log *log);
 char *logserver_utils_jsonify_log(const struct logserver_log *log);
 char *logserver_utils_output_to_str(int out_type);
 int logserver_utils_stdout(const struct logserver_log *log);
+int logserver_utils_printk_devmsg_on(void);
+int logserver_utils_ignore_loglevel(void);
 
 #endif


### PR DESCRIPTION
This PR allow to logserver set `ignore_loglevel` and `printk_devkmsg=on` when is needed, this is when some of the stdout* outputs is active (both options in this case) or when pv_capture_dmesg is true (only `printk_devkmsg=on`)