### PR TITLE
refactor: reduce the scope of usermeta requests to hub

### DIFF
--- a/metadata.c
+++ b/metadata.c
@@ -683,22 +683,10 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 	int ret = 0, tokc, n;
 	jsmntok_t *tokv;
 	jsmntok_t **keys, **key_i;
-	char *um, *key = NULL, *value;
+	char *key = NULL, *value;
 
-	// parse user metadata json
-	jsmnutil_parse_json(buf, &tokv, &tokc);
-	um = pv_json_get_value(buf, "user-meta", tokv, tokc);
-
-	if (!um) {
-		ret = -1;
-		goto out;
-	}
-
-	if (tokv)
-		free(tokv);
-
-	ret = jsmnutil_parse_json(um, &tokv, &tokc);
-	keys = jsmnutil_get_object_keys(um, tokv);
+	ret = jsmnutil_parse_json(buf, &tokv, &tokc);
+	keys = jsmnutil_get_object_keys(buf, tokv);
 
 	key_i = keys;
 	while (*key_i) {
@@ -709,7 +697,7 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 		if (!key)
 			break;
 
-		strncpy(key, um + (*key_i)->start, n);
+		strncpy(key, buf + (*key_i)->start, n);
 
 		// copy value
 		n = (*key_i + 1)->end - (*key_i + 1)->start;
@@ -717,7 +705,7 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 		if (!value)
 			break;
 
-		strncpy(value, um + (*key_i + 1)->start, n);
+		strncpy(value, buf + (*key_i + 1)->start, n);
 		pv_str_unescape_to_ascii(value, n);
 
 		// add or update metadata
@@ -742,8 +730,6 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 	jsmnutil_tokv_free(keys);
 
 out:
-	if (um)
-		free(um);
 	if (tokv)
 		free(tokv);
 	if (key)

--- a/pantahub.c
+++ b/pantahub.c
@@ -238,20 +238,23 @@ int pv_ph_device_get_meta(struct pantavisor *pv)
 	if (!ph_client_init(pv))
 		goto out;
 
-	req = trest_make_request(THTTP_METHOD_GET, endpoint, 0);
+	char buf[256];
+	SNPRINTF_WTRUNC(buf, sizeof(buf), "%s%s", endpoint, "/user-meta");
+
+	req = trest_make_request(THTTP_METHOD_GET, buf, 0);
 
 	res = trest_do_json_request(client, req);
 	if (!res) {
 		pv_log(WARN, "HTTP request GET %s could not be initialized",
-		       endpoint);
+		       buf);
 	} else if (!res->code && res->status != TREST_AUTH_STATUS_OK) {
 		pv_log(WARN, "HTTP request GET %s could not auth (status=%d)",
-		       endpoint, res->status);
+		       buf, res->status);
 		ph_client_free();
 	} else if (res->code != THTTP_STATUS_OK) {
 		pv_log(WARN,
 		       "request GET %s returned HTTP error (code=%d; body='%s')",
-		       endpoint, res->code, res->body);
+		       buf, res->code, res->body);
 	} else {
 		pv_metadata_parse_usermeta(res->body);
 		ret = 0;


### PR DESCRIPTION
Before this commit, we were parsing the user metadata from the response of GET /device/id. This can be optimized with the new /device/id/user-meta endpoint, which returns the user metadata only.