### PR TITLE
fix: open object .tmp file using conflicting O_EXCL and O_TRUNC flags

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -468,23 +468,14 @@ static int pv_ctrl_process_put_file(int req_fd, size_t content_length,
 	if (expect_continue)
 		pv_ctrl_write_cont_response(req_fd);
 
-	obj_fd = open(file_path, O_CREAT | O_EXCL | O_WRONLY | O_TRUNC, 0644);
+	obj_fd = open(file_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 	if (obj_fd < 0) {
-		// skip clean if the error was about the file already existing
-		if (errno == EEXIST) {
-			pv_ctrl_consume_req(req_fd, content_length);
-			pv_log(ERROR, "'%s' already exists", file_path);
-			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR,
-						     "File already exists");
-			goto out;
-		} else {
-			pv_ctrl_consume_req(req_fd, content_length);
-			pv_log(ERROR, "'%s' could not be created: %s",
-			       file_path, strerror(errno));
-			pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR,
-						     "Cannot create file");
-			goto clean;
-		}
+		pv_ctrl_consume_req(req_fd, content_length);
+		pv_log(ERROR, "'%s' could not be created: %s",
+		       file_path, strerror(errno));
+		pv_ctrl_write_error_response(req_fd, HTTP_STATUS_ERROR,
+					     "Cannot create file");
+		goto clean;
 	}
 
 	memset(req, 0, sizeof(req));


### PR DESCRIPTION
This PR fixes a freeze that occurred when putting an object using pvcontrol whose .tmp file already existed in /storage, due to a porwercycle or any other interruption that could make the transfer stop unexpectedly.

The freeze was happening in the open function from standard library because of conflicting flags that would result in undefined behavior:

```
obj_fd = open(file_path, O_CREAT | O_EXCL | O_WRONLY | O_TRUNC, 0644);
```

In this case, we are using O_EXCL, to return an EEXIST error in case the file to create already existed, plus O_TRUNC, to erase the file and create it with size 0.

As these two are mutually exclusive, we are removing the O_EXCL flag and the subsequent code to handle EEXIST. In case a .tmp file exists, we will just overwrite it. In case the object itself exist, we already have a provision for that earlier in code.