### PR TITLE
feature: pantahub.config can be stored in a volume

### DIFF
--- a/config.h
+++ b/config.h
@@ -95,6 +95,7 @@ typedef enum {
 	PV_STORAGE_LOGTEMPSIZE,
 	PV_STORAGE_MNTPOINT,
 	PV_STORAGE_MNTTYPE,
+	PV_STORAGE_PHCONFIG_VOL,
 	PV_STORAGE_WAIT,
 	PV_SYSTEM_APPARMOR_PROFILES,
 	PV_SYSTEM_CONFDIR,
@@ -195,6 +196,7 @@ int pv_config_init(char *path);
 
 int pv_config_load_update(const char *rev, const char *trail_config);
 
+int pv_config_load_creds(void);
 int pv_config_load_unclaimed_creds(void);
 int pv_config_save_creds(void);
 

--- a/init.c
+++ b/init.c
@@ -476,10 +476,10 @@ loop:
  * order.
  */
 struct pv_init *pv_init_tbl[] = {
-	&pv_init_mount,	  &pv_init_creds,    &ph_init_mount,
-	&pv_init_bl,	  &pv_init_log,	     &pv_init_apparmor,
-	&pv_init_storage, &pv_init_ctrl,     &pv_init_network,
-	&pv_init_volume,  &pv_init_platform, &pv_init_pantavisor,
+	&pv_init_mount,	     &pv_init_bl,      &pv_init_log,
+	&pv_init_apparmor,   &pv_init_storage, &pv_init_ctrl,
+	&pv_init_network,    &pv_init_volume,  &pv_init_platform,
+	&pv_init_pantavisor,
 };
 
 int pv_do_execute_init()

--- a/mount.c
+++ b/mount.c
@@ -43,7 +43,7 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #include "log.h"
 
-static int ph_mount_init(struct pv_init *this)
+static int _mount_pv_dir_interfaces()
 {
 	struct stat st;
 	char storage_path[PATH_MAX], pv_path[PATH_MAX];
@@ -97,8 +97,10 @@ static int pv_mount_init(struct pv_init *this)
 	char path[PATH_MAX];
 	int ret = -1;
 
-	if (pv_config_get_system_init_mode() == IM_APPENGINE)
-		return 0;
+	if (pv_config_get_system_init_mode() == IM_APPENGINE) {
+		ret = 0;
+		goto out;
+	}
 
 	// Create storage mountpoint and mount device
 	pv_paths_storage(path, PATH_MAX);
@@ -189,15 +191,11 @@ static int pv_mount_init(struct pv_init *this)
 out:
 	if (ret < 0)
 		exit_error(errno, "Could not mount trails storage");
+	_mount_pv_dir_interfaces();
 	return 0;
 }
 
 struct pv_init pv_init_mount = {
 	.init_fn = pv_mount_init,
-	.flags = 0,
-};
-
-struct pv_init ph_init_mount = {
-	.init_fn = ph_mount_init,
 	.flags = 0,
 };

--- a/paths.h
+++ b/paths.h
@@ -31,6 +31,9 @@
 #define PVCTRL_FNAME "pv-ctrl"
 #define LOGCTRL_FNAME "pv-ctrl-log"
 #define LOGFD_FNAME "pv-fd-log"
+#define PHCONFIG_DNAME "phconfig"
+#define UNCLAIMED_FNAME "phconfig/unclaimed.config"
+#define PANTAHUB_FNAME "phconfig/pantahub.config"
 
 void pv_paths_pv_file(char *buf, size_t size, const char *name);
 
@@ -91,9 +94,6 @@ void pv_paths_storage_trail_pv_file(char *buf, size_t size, const char *rev,
 void pv_paths_storage_trail_pvr_file(char *buf, size_t size, const char *rev,
 				     const char *name);
 
-#define UNCLAIMED_FNAME "unclaimed.config"
-#define PANTAHUB_FNAME "pantahub.config"
-
 void pv_paths_storage_config_file(char *buf, size_t size, const char *name);
 
 #define GRUBENV_FNAME "grubenv"
@@ -135,6 +135,7 @@ void pv_paths_lib_lxc_lxcpath(char *buf, size_t size);
 #define BSP_DNAME "bsp"
 #define USRMETAVOL_DNAME "pv--usrmeta"
 #define DEVMETAVOL_DNAME "pv--devmeta"
+#define PHCONFIGVOL_DNAME "pv--phconfig"
 
 void pv_paths_root_file(char *buf, size_t size, const char *path);
 void pv_paths_volumes_file(char *buf, size_t size, const char *name);

--- a/state.c
+++ b/state.c
@@ -1315,6 +1315,23 @@ int pv_state_interpret_signal(struct pv_state *s, const char *name,
 	return 0;
 }
 
+struct pv_volume *pv_state_search_volume(struct pv_state *s, const char *name)
+{
+	if (!s)
+		return NULL;
+
+	struct pv_volume *v, *tmp;
+
+	dl_list_for_each_safe(v, tmp, &s->volumes, struct pv_volume, list)
+	{
+		if (pv_str_matches(name, strlen(name), v->name,
+				   strlen(v->name)))
+			return v;
+	}
+
+	return NULL;
+}
+
 char *pv_state_get_containers_json(struct pv_state *s)
 {
 	struct pv_json_ser js;

--- a/state.h
+++ b/state.h
@@ -97,6 +97,8 @@ plat_goal_state_t pv_state_check_goals(struct pv_state *s);
 int pv_state_interpret_signal(struct pv_state *s, const char *name,
 			      const char *signal, const char *payload);
 
+struct pv_volume *pv_state_search_volume(struct pv_state *s, const char *name);
+
 void pv_state_print(struct pv_state *s);
 char *pv_state_get_containers_json(struct pv_state *s);
 char *pv_state_get_groups_json(struct pv_state *s);


### PR DESCRIPTION
This PR enables the storage of pantahub.config and unclaimed.config files in a volume, which allows to set that volume into a crypt disk.

The feature is enabled the same way one would assign metadata to a volume in device.json so, it is enabled at the revision checkout level:

```
{
    "disks": [...],  
    "groups": [...],  
    "volumes": {
        "pv--phconfig": {
            "disk": "secrets",
            "persistence": "permanent"
        }
    }   
}
```

A new optional config key has been added to force the feature enablement. When true, a revision without the "pv--phconfig" volume will not be bootable:

```
PV_STORAGE_PHCONFIG_VOL=1
```

The changes that have been necessary to get this can be summarized like this:

* Pantavisor now works with pantahub.config and unclaimed.config in a new location in /pv/phconfig/
* If a volume with the name "pv--phconfig" exists in device.json, it is mounted on /pv/phconfig/
* If not, the legacy /storage/config is used only in when enabled by config with PV_STORAGE_PHCONFIG=1
* The initialization of pantahub.config and unclaimed.config has been moved from the INIT state to the RUN state, so we load them after the revision has been initialized and therefore we have the volumes information. It is still before OEM config loading, to keep the previous override order
* Default values for PH_CREDS_HOST and PH_CREDS_PORT in config have been changed to "api.pantahub.com" and 443 respectively so communication with Pantacor Hub is possible by default