### PR TITLE
fix: ph logger not working with tmpfs logs

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -910,6 +910,7 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 	// force stop childs
 	pv_state_stop_force(pv->state);
 	ph_logger_stop_force();
+	ph_logger_close();
 
 	// close pvctrl
 	pv_ctrl_socket_close(pv->ctrl_fd);
@@ -1046,6 +1047,8 @@ static int pv_pantavisor_init(struct pv_init *this)
 	pv->hard_poweroff = false;
 
 	pv_cgroup_print();
+
+	ph_logger_init();
 
 out:
 	return 0;

--- a/ph_logger.h
+++ b/ph_logger.h
@@ -32,6 +32,9 @@
 
 #define PH_LOGGER_POS_XATTR "trusted.ph.logger.pos"
 
+void ph_logger_init(void);
+void ph_logger_close(void);
+
 void ph_logger_toggle(char *rev);
 void ph_logger_stop_lenient(void);
 void ph_logger_stop_force(void);


### PR DESCRIPTION
This PR fixes ph_logger not being compatible with tmpfs (because of xattr).

The code in charge of managing the offset of the devices, which relied completely on writing/reading xattr from files,  has been moved to two functions:

*  _save_log_file_pos: it saves the offset on memory and as an xattr in files if possible by config.
* _load_log_file_pos: it loads the offset from memory, of not available from xattr, it takes 0 as the initial point.

The offsets are stored in memory as a list of paths and position offsets in ph_logger struct.