### PR TITLE
Fix warnings and errors after the toolchain migration

### DIFF
--- a/blkid.c
+++ b/blkid.c
@@ -45,7 +45,7 @@
 
 #include "blkid.h"
 #include "utils/math.h"
-#include "str.h"
+#include "utils/str.h"
 #include "log.h"
 #include "utils/fs.h"
 #include "config.h"
@@ -256,7 +256,7 @@ static char *get_ubifs_dev_path(const char *dev, const char *vol,
 {
 	glob_t files = { 0 };
 	char glob_exp[PATH_MAX] = { 0 };
-	snprintf(glob_exp, PATH_MAX, "%s/%s_*", ubi_sys_path, dev);
+	SNPRINTF_WTRUNC(glob_exp, PATH_MAX, "%s/%s_*", ubi_sys_path, dev);
 
 	int err = glob(glob_exp, 0, NULL, &files);
 	if (err != 0 && err != GLOB_NOMATCH) {

--- a/rpiab.c
+++ b/rpiab.c
@@ -360,11 +360,11 @@ static int rpiab_init()
 
 	hay = getenv("PVTEST_PATH_TMP");
 	if (hay) {
-		size_t s = snprintf(b, 1, "%s/autoboot.txt", hay) + 1;
+		size_t s = snprintf(NULL, 0, "%s/autoboot.txt", hay) + 1;
 		b = realloc(b, s);
 		snprintf(b, s, "%s/autoboot.txt", hay);
 		paths.autoboot_tmp = strdup(b);
-		s = snprintf(b, 1, "%s/cmdline.txt", hay) + 1;
+		s = snprintf(NULL, 0, "%s/cmdline.txt", hay) + 1;
 		b = realloc(b, s);
 		snprintf(b, s, "%s/cmdline.txt", hay);
 		paths.cmdline_tmp = strdup(b);
@@ -374,11 +374,11 @@ static int rpiab_init()
 
 	hay = getenv("PVTEST_PATH_DEVICE_TREE_BOOTLOADER");
 	if (hay) {
-		size_t s = snprintf(b, 1, "%s/partition", hay) + 1;
+		size_t s = snprintf(NULL, 0, "%s/partition", hay) + 1;
 		b = realloc(b, s);
 		snprintf(b, s, "%s/partition", hay);
 		paths.dtb_partition = strdup(b);
-		s = snprintf(b, 1, "%s/tryboot", hay) + 1;
+		s = snprintf(NULL, 0, "%s/tryboot", hay) + 1;
 		b = realloc(b, s);
 		snprintf(b, s, "%s/tryboot", hay);
 		paths.dtb_tryboot = strdup(b);
@@ -389,7 +389,7 @@ static int rpiab_init()
 
 	hay = getenv("PVTEST_PATH_STORAGE_BOOT");
 	if (hay) {
-		size_t s = snprintf(b, 1, "%s/rpiab.txt", hay) + 1;
+		size_t s = snprintf(NULL, 0, "%s/rpiab.txt", hay) + 1;
 		b = realloc(b, s);
 		snprintf(b, s, "%s/rpiab.txt", hay);
 		paths.rpiab_txt = strdup(b);

--- a/signature.c
+++ b/signature.c
@@ -631,7 +631,7 @@ static int _get_cn(struct mbedtls_x509_crt *cert, char *cn, int len)
 		if ((!mbedtls_oid_get_attr_short_name(&name->oid, &oid_name)) &&
 		    (pv_str_matches("CN", strlen("CN"), oid_name,
 				    strlen(oid_name)))) {
-			SNPRINTF_WTRUNC(cn, len, "%.*s", name->val.len,
+			SNPRINTF_WTRUNC(cn, len, "%.*s", (int)name->val.len,
 					name->val.p);
 		}
 	} while ((name = name->next) != 0);

--- a/uboot.c
+++ b/uboot.c
@@ -219,7 +219,7 @@ static int uboot_set_env_key(char *key, char *value)
 		i += len;
 	}
 
-	SNPRINTF_WTRUNC(v, sizeof(v), "%s=%s\0", key, value);
+	SNPRINTF_WTRUNC(v, sizeof(v), "%s=%s", key, value);
 
 	memcpy(d, v, strlen(v) + 1);
 


### PR DESCRIPTION
1. Fixes possible truncation in snprintf now the new size is PATH_MAX + NAME_MAX + 2 (for the glob expression) + 1 (the 0) in blkid.c:258
2. Fixes the way how the new string size is acquired in rpiab.c:363, 367, 377, 381, 392
3. Addscast to match the right type in signature.c:634
4. Removes spurious \0 in snprintf call