### PR TITLE
fix: not loading Pantacor Hub creds between reboots

### DIFF
--- a/pantahub.h
+++ b/pantahub.h
@@ -45,4 +45,6 @@ void pv_ph_update_hint_file(struct pantavisor *pv, char *c);
 int pv_ph_upload_metadata(struct pantavisor *pv, char *metadata);
 struct pv_connection *pv_get_instance_connection(void);
 
+int pv_pantahub_init(void);
+
 #endif

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -281,6 +281,12 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 			pv_log(ERROR, "creds load failed");
 			goto out;
 		}
+
+		if (pv_pantahub_init()) {
+			pv_log(ERROR,
+			       "pantahub client could not be initialized");
+			goto out;
+		}
 	}
 
 	// load configuration that lives in revision
@@ -289,13 +295,10 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	// reload remote bool after non reboot updates, when we don't load config again
 	pv->remote_mode = pv_config_get_bool(PV_CONTROL_REMOTE);
 	pv->loading_objects = false;
-	pv->state->local = !pv_config_get_bool(PV_CONTROL_REMOTE);
-	;
 
 	// we know if we are in local if the running revision has the local format
 	if (pv_storage_is_revision_local(pv->state->rev)) {
 		pv_log(DEBUG, "running local revision %s", pv->state->rev);
-		pv->state->local = true;
 		pv->remote_mode = false;
 		if (pv_config_get_bool(PV_CONTROL_REMOTE_ALWAYS)) {
 			pv_log(DEBUG,

--- a/state.c
+++ b/state.c
@@ -72,7 +72,6 @@ struct pv_state *pv_state_new(const char *rev, state_spec_t spec)
 		dl_list_init(&s->groups);
 		dl_list_init(&s->bsp.drivers);
 		s->using_runlevels = false;
-		s->local = false;
 		s->done = false;
 	}
 

--- a/state.h
+++ b/state.h
@@ -63,7 +63,6 @@ struct pv_state {
 	struct dl_list groups; //pv_group
 	bool using_runlevels;
 	int tryonce;
-	bool local;
 	bool done;
 };
 

--- a/storage.c
+++ b/storage.c
@@ -1111,8 +1111,7 @@ void pv_storage_umount()
 
 static int pv_storage_init(struct pv_init *this)
 {
-	struct pantavisor *pv = pv_get_instance();
-	char tmp[256], path[PATH_MAX];
+	char path[PATH_MAX];
 
 	// create hints
 	pv_paths_pv_file(path, PATH_MAX, CHALLENGE_FNAME);
@@ -1121,25 +1120,12 @@ static int pv_storage_init(struct pv_init *this)
 		       strerror(errno));
 
 	pv_paths_pv_file(path, PATH_MAX, DEVICE_ID_FNAME);
-	const char *prn = pv_config_get_str(PH_CREDS_PRN);
-	if (!prn || !strcmp(prn, "")) {
-		pv->unclaimed = true;
-		if (pv_fs_file_save(path, "", 0444) < 0)
-			pv_log(WARN, "could not save file %s: %s", path,
-			       strerror(errno));
-	} else {
-		pv->unclaimed = false;
-		SNPRINTF_WTRUNC(tmp, sizeof(tmp), "%s\n",
-				pv_config_get_str(PH_CREDS_ID));
-		if (pv_fs_file_save(path, tmp, 0444) < 0)
-			pv_log(WARN, "could not save file %s: %s", path,
-			       strerror(errno));
-	}
+	if (pv_fs_file_save(path, "", 0444) < 0)
+		pv_log(WARN, "could not save file %s: %s", path,
+		       strerror(errno));
+
 	pv_paths_pv_file(path, PATH_MAX, PHHOST_FNAME);
-	SNPRINTF_WTRUNC(tmp, sizeof(tmp), "https://%s:%d\n",
-			pv_config_get_str(PH_CREDS_HOST),
-			pv_config_get_int(PH_CREDS_PORT));
-	if (pv_fs_file_save(path, tmp, 0444) < 0)
+	if (pv_fs_file_save(path, "", 0444) < 0)
 		pv_log(WARN, "could not save file %s: %s", path,
 		       strerror(errno));
 


### PR DESCRIPTION
This PR fixes a regression introduced in [453](https://github.com/pantavisor/pantavisor/pull/453).

After that PR, pantahub.config file is loaded in a later stage during bootup initialization, specifically after status JSON is loaded, once we have the device.json volume information. At the time, this meant moving all processes that were using PH_*config keys after that new loading point. In that development, some of those were missing, and are causing now the following symptoms:

* Remote claimed devices not recovering its stored credentials after reboots, including update reboots. In this case, the device would create new claiming credentials, resetting the claiming process.
* Remote claimed devices not being able to boot up both local and remote revisions. This would cause a freeze because Pantavisor would try to report on the local revision to the cloud without having the needed credentials.

The patch to fix those contains these changes:

* pantahub.c: avoid using PH_CREDS_ID and PH_CREDS_HOST when NULL.
* pantahub.c: implement new function to initialize the pv_pantavisor unclaimed bool variable, the /pv/device-id and /pv/pantahub-host files based on PH_CREDS_PRN, PH_CREDS_ID and PH_CREDS_HOST/PH_CREDS_PORT respectively.
* pantavisor.c: initialize Pantacor Hub client after pantahub.config is loaded.
* pantavisor.c: remove unused pv_state local variable settings.
* state.c: remove unused pv_state local variable setting.
* state.h: remove unused local variable from pv_state.
* storage.c: all early initialization set up based on PH_CREDS_PRN, PH_CREDS_ID, PH_CREDS_HOST and PH_CREDS_PORT has been moved to the initialization of Pantacor Hub, after loading pantahub.config. Now implented in pantahub.c. Doing it before the config file loading was causing the unclaimed variable to be wrongly set as false even if the device was already claimed, resetting the claiming process for the device.
* updater.c: pv_update endpoint is now initialized on demand and only if PH_CREDS_ID is not NULL. This was causing a freeze when trying to report updates to an already claimed device whose PH_CREDS_ID was still NULL before the being loaded from pantahub.config.
* updater.c: avoid sending the progress update to the cloud when doing a local update to an already claimed device after a reboot update. This is achieved by removing the checking of pending local, which was only set to true during the installation of the update, so, not after the update reboot, and substituting it by the one stored in pv_update. As this was the only use for the pv_state local bool, now it can be removed from state.h.
* updater.c: updates can be initialized without having loaded PH_CREDS_ID. This can happen both in local devices and in remote devices when pantahub.config is not yet loaded. From now on, the decision to set an update as local or remote is based on the revision name only (all local revisions starts with the "locals/" prefix).