### PR TITLE
Improve the creation of "no validate" list

### DIFF
--- a/scripts/volmount/verity/dm
+++ b/scripts/volmount/verity/dm
@@ -93,36 +93,6 @@ do_umount_squash() {
 #   os/lxc.container.conf 4bd0b8e9569f5e4fa861964d051de0ade9626c6c578748c4608120b0a4afc4c9
 #   os/root.squashfs 01adb13a943f2b5816816921130b2766de7e3ab316a96472e3828c425da0d241
 #   os/root.squashfs.docker-digest d4e408d65d821e43a7dc76755afbd8fa3726cfee9335fb9fe04dec8f83e0cbee
-novalidatelist() {
-	trailstepdir=$1
-	tmpf=`mktemp -t islazyverify.jsonsh.XXXXXXXXXXX`
-	cat $trailstepdir/.pvr/json | JSON.sh -l > $tmpf
-	cat $tmpf \
-		| grep -v \[[^[:space:]]*,[^[:space:]]*] \
-		| grep -v '\[\"#spec\"][[:space:]]' \
-		| sed -e 's#^\["\([[:alnum:]/._-]*\)"\][[:space:]]*"\([a-f0-9]*\)"#\1 \2#;' \
-		> $tmpf.objects
-	cat $tmpf \
-		| grep -E '(,"root-volume"|,"volumes"|,"modules"|,"firmware").*"dm:' \
-		| sed -e 's/^\["\([^/]*\)\/.*[[:space:]]"dm:/\1\//;s/"$//' > $tmpf.filter
-
-	rm -f $tmpf.matchesobjects
-	cat $tmpf.filter | while read -r line; do
-		grep "$line " $tmpf.objects >> $tmpf.matchedobjects
-	done
-	grep -E '(^bsp/pantavisor|^bsp/kernel.img|^bsp/fit-image.its)' $tmpf.objects \
-		>> $tmpf.matchedobjects
-
-	cat $tmpf.matchedobjects | \
-	    sort -u
-	rm -f $tmpf $tmpf.*
-}
-
-
-# return format is a path to sha map with whitespace, e.g.
-#   os/lxc.container.conf 4bd0b8e9569f5e4fa861964d051de0ade9626c6c578748c4608120b0a4afc4c9
-#   os/root.squashfs 01adb13a943f2b5816816921130b2766de7e3ab316a96472e3828c425da0d241
-#   os/root.squashfs.docker-digest d4e408d65d821e43a7dc76755afbd8fa3726cfee9335fb9fe04dec8f83e0cbee
 verifylist() {
 	trailstepdir=$1
 	tmpf=`mktemp -t islazyverify.jsonsh.XXXXXXXXXXX`
@@ -155,9 +125,6 @@ case $op in
 		;;
 	umount)
 		do_umount_squash $2 $3
-		;;
-	novalidatelist)
-		novalidatelist $2
 		;;
 	verifylist)
 		verifylist $2

--- a/utils/str.c
+++ b/utils/str.c
@@ -23,6 +23,7 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include "str.h"
 
 char *pv_str_replace_char(char *str, int len, char which, char what)
@@ -83,6 +84,33 @@ int pv_str_count_list(char **list)
 		list++;
 	}
 
+	return len;
+}
+
+int pv_str_fmt_build(char **str, const char *fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+
+	int len = vsnprintf(NULL, 0, fmt, args) + 1;
+	if (len < 0)
+		goto out;
+
+	*str = calloc(len, sizeof(char));
+	if (!*str)
+		goto out;
+
+	va_end(args);
+	va_start(args, fmt);
+
+	len = vsnprintf(*str, len, fmt, args);
+	if (len < 0) {
+		free(*str);
+		*str = NULL;
+		goto out;
+	}
+out:
+	va_end(args);
 	return len;
 }
 

--- a/utils/str.h
+++ b/utils/str.h
@@ -68,6 +68,7 @@ void pv_str_unescape_to_ascii(char *buf, int size);
 char *pv_str_replace_char(char *str, int len, char which, char what);
 char *pv_str_skip_prefix(char *str, const char *key);
 int pv_str_count_list(char **list);
+int pv_str_fmt_build(char **str, const char *fmt, ...);
 
 /* prints seconds since beginning of epoch in buf */
 size_t epochsecstring(char *buf, size_t len, time_t t);


### PR DESCRIPTION
This PR introduces a new method to obtain the "no validation list" (NVL) without using the `dm` script. The process is based on the current `pv_state` present in the `pantavisor` structure, where 2 lists are used to build the NVL `pv_object` list and `pv_json` list.
First, the known objects are added using the expressions found in the `dm` script. Then, objects with type = `dm-verity` in the `pv_json` list are located in the `pv_object` list and added to the NVL.
