### PR TITLE
avoid running export.sh hook when defined in run.json

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -1221,6 +1221,14 @@ static int do_action_for_drivers(struct json_key_action *jka, char *value)
 	return 0;
 }
 
+static int do_action_for_export(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+	struct pv_platform *platform = *bundle->platform;
+	platform->export = true;
+	return 0;
+}
+
 static int parse_platform(struct pv_state *s, char *buf, int n)
 {
 	char *config = NULL, *shares = NULL;
@@ -1262,6 +1270,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_storage, false),
 		ADD_JKA_ENTRY("drivers", JSMN_OBJECT, &bundle,
 			      do_action_for_drivers, false),
+		ADD_JKA_ENTRY("exports", JSMN_ARRAY, &bundle,
+			      do_action_for_export, false),
 		ADD_JKA_NULL_ENTRY()
 	};
 

--- a/platforms.c
+++ b/platforms.c
@@ -189,6 +189,7 @@ struct pv_platform *pv_platform_add(struct pv_state *s, char *name)
 		p->restart_policy = RESTART_NONE;
 		p->updated = false;
 		p->state = s;
+		p->export = false;
 		dl_list_init(&p->drivers);
 		dl_list_init(&p->logger_list);
 		dl_list_init(&p->logger_configs);

--- a/platforms.h
+++ b/platforms.h
@@ -98,6 +98,7 @@ struct pv_platform {
 	restart_policy_t restart_policy;
 	bool updated;
 	bool automodfw; // auto mount modfw
+	bool export;
 	struct timer timer_status_goal;
 	struct dl_list drivers; // pv_platform_driver
 	struct dl_list list; // pv_platform

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -387,9 +387,16 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 	if (!d)
 		return;
 
+	const char *export_hook = "export.sh";
+
 	while ((dir = readdir(d)) != NULL) {
 		if (!strcmp(dir->d_name, ".") || !strcmp(dir->d_name, ".."))
 			continue;
+
+		if (!p->export &&
+		    !strncmp(export_hook, dir->d_name, strlen(export_hook)))
+			continue;
+
 		__pv_paths_lib_hook(path, PATH_MAX, dir->d_name);
 		c->set_config_item(c, "lxc.hook.mount", path);
 	}


### PR DESCRIPTION
The field `export` (bool) is added to pv_platform to avoid run the export hook when the platform has not a export definition.
* the field is initialized as false (platforms.c)
* the field is set to true during the state json parsing. (parser_system1.c)
* export hook is not added if the export is false. (pv_lxc.c)