### PR TITLE
Fix malformed strings

### DIFF
--- a/init.c
+++ b/init.c
@@ -177,8 +177,8 @@ static void signal_handler(int signal)
 				continue;
 			sleep(1);
 			pv_log(WARN,
-			       "Respawn of critical service failed %d: %s", pid,
-			       strerror(errno));
+			       "Respawn of critical service failed %d: %s",
+			       pid, strerror(errno));
 		}
 	}
 }

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -840,11 +840,11 @@ static void logserver_start(const char *running_revision)
 	if (logserver.pid == -1) {
 		logserver_start_service(running_revision);
 		pv_log(DEBUG, "starting log service with pid %d",
-		       (int)logserver.pid);
+		       logserver.pid);
 
 		if (logserver.pid > 0) {
 			pv_log(DEBUG, "started log service with pid %d",
-			       (int)logserver.pid);
+			       logserver.pid);
 		} else {
 			pv_log(ERROR, "unable to start log service");
 		}
@@ -964,7 +964,7 @@ int pv_logserver_init(const char *rev)
 	dl_list_init(&logserver.fdlst);
 	dl_list_init(&logserver.tmplst);
 	logserver_start_service(rev);
-	pv_log(DEBUG, "started log service with pid %d", (int)logserver.pid);
+	pv_log(DEBUG, "started log service with pid %d", logserver.pid);
 
 	if (pv_config_get_bool(PV_LOG_CAPTURE_DMESG))
 		logserver_capture_dmesg();

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -486,8 +486,8 @@ static pv_state_t pv_wait_update()
 				timer_current_state(&timer_commit);
 			if (!tstate.fin) {
 				pv_log(INFO,
-				       "committing new update in %lld seconds",
-				       (long long)tstate.sec);
+				       "committing new update in %jd seconds",
+				       (intmax_t)tstate.sec);
 				return PV_STATE_WAIT;
 			}
 		}
@@ -518,8 +518,8 @@ static pv_state_t pv_wait_network(struct pantavisor *pv)
 				return PV_STATE_ROLLBACK;
 			}
 			pv_log(WARN,
-			       "no connection. Will rollback in %d seconds",
-			       tstate.sec);
+			       "no connection. Will rollback in %jd seconds",
+			       (intmax_t)tstate.sec);
 			// or we directly rollback is connection is not stable during testing
 		} else if (pv_update_is_testing(pv->update)) {
 			pv_log(ERROR,
@@ -603,8 +603,8 @@ static pv_state_t _pv_wait(struct pantavisor *pv)
 		tstate = timer_current_state(&t);
 		if (tstate.fin)
 			pv_log(DEBUG,
-			       "network operations are taking %d seconds!",
-			       5 + tstate.sec);
+			       "network operations are taking %jd seconds!",
+			       (intmax_t)(5 + tstate.sec));
 	} else {
 		// process ongoing updates, if any
 		next_state = pv_wait_update();

--- a/platforms.c
+++ b/platforms.c
@@ -541,7 +541,7 @@ static int __start_pvlogger_for_platform(struct pv_platform *platform,
 			}
 		}
 		start_pvlogger(log_info, (log_info->islxc ? log_info->name :
-								  platform->name));
+							    platform->name));
 		_exit(0);
 	}
 	log_info->logger_pid = pid;

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -100,7 +100,8 @@ static int set_logger_xattr(struct log *log)
 
 	if (pos < 0)
 		return 0;
-	SNPRINTF_WTRUNC(place_holder, sizeof(place_holder), "%" PRId64, pos);
+	SNPRINTF_WTRUNC(place_holder, sizeof(place_holder), "%jd",
+			(intmax_t)pos);
 
 	return setxattr(fname, PV_LOGGER_POS_XATTR, place_holder,
 			strlen(place_holder), 0);
@@ -177,7 +178,7 @@ static int get_logger_xattr(struct log *log)
 	if (getxattr(fname, PV_LOGGER_POS_XATTR, buf, 32) < 0) {
 		pv_log(DEBUG, "Attribute %s not present", PV_LOGGER_POS_XATTR);
 	} else {
-		sscanf(buf, "%" PRId64, &stored_pos);
+		sscanf(buf, "%jd", &stored_pos);
 	}
 	return stored_pos;
 }
@@ -199,8 +200,8 @@ static int pvlogger_start(struct log *log, int was_init_ok)
 		if (st.st_size < stored_pos)
 			stored_pos = 0;
 	}
-	pv_log(DEBUG, "pvlogger %s seeking to position %" PRId64 "\n",
-	       module_name, stored_pos);
+	pv_log(DEBUG, "pvlogger %s seeking to position %jd\n", module_name,
+	       (intmax_t)stored_pos);
 	fseek(log->backing_file, stored_pos, SEEK_SET);
 out:
 	return was_init_ok;
@@ -417,7 +418,7 @@ pv_new_log(bool islxc, struct pv_logger_config *logger_config, const char *name)
 			trunc_val = pv_log_get_config_item(logger_config,
 							   "maxsize");
 			if (trunc_val)
-				sscanf(trunc_val, "%" PRId64,
+				sscanf(trunc_val, "%jd",
 				       &log_info->truncate_size);
 		}
 	}

--- a/rpiab.c
+++ b/rpiab.c
@@ -52,7 +52,7 @@
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #else
 #define pv_log(level, msg, ...)                                                \
-	printf("%s[%d]: ", MODULE_NAME, level);                                \
+	printf("%s[%d]: ", MODULE_NAME, level);                     \
 	printf(msg "\n", ##__VA_ARGS__)
 #endif
 #include "log.h"
@@ -123,7 +123,7 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 	}
 	fclose(f);
 	is_tryboot = bswap_32(is_tryboot);
-	pv_log(DEBUG, "RPI Tryboot state: %d", is_tryboot);
+	pv_log(DEBUG, "RPI Tryboot state: %ju", is_tryboot);
 
 	f = fopen(paths->boot_mode, "r");
 	if (!f) {
@@ -141,7 +141,7 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 	}
 	fclose(f);
 	boot_mode = bswap_32(boot_mode);
-	pv_log(DEBUG, "RPI Boot Mode: %d", boot_mode);
+	pv_log(DEBUG, "RPI Boot Mode: %ju", boot_mode);
 
 	// for now we only support boot mode sd card (1) and usb disk (4)
 	if (boot_mode & 4) {
@@ -149,7 +149,7 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 		paths->bootimg[1] = strdup("/dev/sda2");
 		paths->bootimg[2] = strdup("/dev/sda3");
 	} else if (!(boot_mode & 1)) {
-		pv_log(ERROR, "Boot mode not supported: %d", boot_mode);
+		pv_log(ERROR, "Boot mode not supported: %ju", boot_mode);
 		return -1;
 	}
 
@@ -169,7 +169,7 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 	}
 	fclose(f);
 	partition = bswap_32(partition);
-	pv_log(DEBUG, "RPI Partition booted: %d", partition);
+	pv_log(DEBUG, "RPI Partition booted: %ju", partition);
 
 	// now we extract autoboot.txt from partition 0 with mcopy
 	s = snprintf(cmdbuf, 0, "mcopy -n -i %s ::autoboot.txt %s",
@@ -193,7 +193,7 @@ static int rpiab_init_fw(struct rpiab_paths *paths)
 
 	if (s1 != s) {
 		pv_log(ERROR,
-		       "Error producing cmdbuf. size does not match expected size( %d != %d)",
+		       "Error producing cmdbuf. size does not match expected size (%zd != %zd)",
 		       s, s1);
 		free(cmdbuf);
 		return -2;
@@ -794,7 +794,7 @@ static int _rpiab_setrev_trybootimg(char *rev)
 	// support 128 chars long pv_rev=... string
 	if (s > sizeof(cmdline_buf) - 129) {
 		pv_log(ERROR,
-		       "cmdline.txt too large. we only support up to %llu bytes",
+		       "cmdline.txt too large. we only support up to %zu bytes",
 		       sizeof(cmdline_buf) - 129);
 		return -1;
 	}

--- a/signature.c
+++ b/signature.c
@@ -851,7 +851,7 @@ static bool pv_signature_verify_sha(const char *payload,
 		goto out;
 	}
 
-	pv_log(DEBUG, "signature length is %d", olen);
+	pv_log(DEBUG, "signature length is %zd", olen);
 
 	res = mbedtls_pk_verify(pk, mdtype, hash, 0,
 				(unsigned char *)sig_decoded, olen);

--- a/state.c
+++ b/state.c
@@ -1312,7 +1312,7 @@ bool pv_state_validate_checksum(struct pv_state *s)
 		char needle[PATH_MAX + 67];
 		if (snprintf(needle, sizeof(char) * ARRAY_LEN(needle), "%s %s",
 			     o->name, o->id) >= ARRAY_LEN(needle)) {
-			pv_log(ERROR, "too long filename: for pv state: %d",
+			pv_log(ERROR, "too long filename: for pv state: %zd",
 			       strlen(o->name));
 			goto out;
 		}

--- a/storage.c
+++ b/storage.c
@@ -105,8 +105,8 @@ static int pv_storage_gc_objects(struct pantavisor *pv)
 
 		reclaimed += st.st_size;
 		pv_fs_path_remove(path, false);
-		pv_log(DEBUG, "removed unused object '%s', reclaimed %lu bytes",
-		       path, st.st_size);
+		pv_log(DEBUG, "removed unused object '%s', reclaimed %jd bytes",
+		       path, (intmax_t)st.st_size);
 	}
 
 out:
@@ -251,13 +251,13 @@ static struct pv_storage *pv_storage_new()
 
 static void pv_storage_print(struct pv_storage *storage)
 {
-	pv_log(DEBUG, "total disk space: %d B", storage->total);
-	pv_log(DEBUG, "free disk space: %d B (%d%% of total)", storage->free,
-	       storage->free_percentage);
-	pv_log(DEBUG, "reserved disk space: %d B (%d%% of total)",
-	       storage->reserved, storage->reserved_percentage);
-	pv_log(INFO, "real free disk space: %d B (%d%% of total)",
-	       storage->real_free, storage->real_free_percentage);
+	pv_log(DEBUG, "total disk space: %jd B", (intmax_t)storage->total);
+	pv_log(DEBUG, "free disk space: %jd B (%d%% of total)",
+	       (intmax_t)storage->free, storage->free_percentage);
+	pv_log(DEBUG, "reserved disk space: %jd B (%d%% of total)",
+	       (intmax_t)storage->reserved, storage->reserved_percentage);
+	pv_log(INFO, "real free disk space: %jd B (%d%% of total)",
+	       (intmax_t)storage->real_free, storage->real_free_percentage);
 }
 
 off_t pv_storage_get_free()
@@ -334,16 +334,16 @@ off_t pv_storage_gc_run_needed(off_t needed)
 
 	if (needed > available) {
 		pv_log(WARN,
-		       "%d B needed but only %d B available. Freeing up space...",
-		       needed, available);
+		       "%jd B needed but only %jd B available. Freeing up space...",
+		       (intmax_t)needed, (intmax_t)available);
 		pv_storage_gc_run();
 
 		available = pv_storage_get_free();
 
 		if (needed > available)
 			pv_log(ERROR,
-			       "still %d B needed but only %d B available",
-			       needed, available);
+			       "still %jd B needed but only %jd B available",
+			       (intmax_t)needed, (intmax_t)available);
 	}
 
 	return available;

--- a/uboot.c
+++ b/uboot.c
@@ -90,7 +90,7 @@ static int uboot_init()
 
 	ret = read(fd, buf, sizeof(MTD_MATCH));
 	if (ret < 0) {
-		pv_log(ERROR, "Failed to read from %d bytes from /proc/mtd",
+		pv_log(ERROR, "Failed to read from %zd bytes from /proc/mtd",
 		       sizeof(MTD_MATCH));
 		return -2;
 	}

--- a/updater.c
+++ b/updater.c
@@ -797,10 +797,10 @@ static int trail_get_new_steps(struct pantavisor *pv)
 	long current_rev = strtol(pv->state->rev, NULL, 10);
 
 	if (!errno && (new_rev <= current_rev)) {
-		pv_log(WARN, "running revision %d but trying to update to %d",
+		pv_log(WARN, "running revision %ld but trying to update to %ld",
 		       current_rev, new_rev);
 		if (new_rev < current_rev) {
-			pv_log(WARN, "setting revision %d as stale", new_rev);
+			pv_log(WARN, "setting revision %ld as stale", new_rev);
 			pv_update_set_status(update, UPDATE_STALE_REVISION);
 		}
 		wrong_revision = true;
@@ -1341,7 +1341,7 @@ static int pv_update_check_download_retry(struct pv_update *update)
 		return 0;
 	}
 
-	pv_log(INFO, "retrying in %d seconds", timer_state.sec);
+	pv_log(INFO, "retrying in %jd seconds", (intmax_t)timer_state.sec);
 	return 1;
 }
 
@@ -1844,16 +1844,15 @@ static int trail_check_update_size(struct pantavisor *pv)
 	char msg[UPDATE_PROGRESS_STATUS_MSG_SIZE];
 
 	update_size = get_update_size(pv->update);
-	pv_log(INFO, "update size: %" PRIu64 " B", update_size);
+	pv_log(INFO, "update size: %jd B", (intmax_t)update_size);
 
 	free_size = pv_storage_gc_run_needed(update_size);
 
 	if (update_size > free_size) {
 		pv_log(ERROR, "cannot process update. Aborting...");
 		SNPRINTF_WTRUNC(msg, sizeof(msg),
-				"Space required %" PRIu64
-				" B, available %" PRIu64 " B",
-				update_size, free_size);
+				"Space required %jd B, available %jd B",
+				(intmax_t)update_size, (intmax_t)free_size);
 		pv_update_set_status_msg(pv->update, UPDATE_NO_SPACE, msg);
 		return -1;
 	}


### PR DESCRIPTION
This PR fix all wrong string formatter applied to logs, snprintf, printf and any other function where a formatter was used.

For special types like `time_t` or `off_t` formatter was replaced with `%jd` or `%ju` for `intmax_t` or `uintmax_t` as far as I know, this is the best option in a modern C code base