### PR TITLE
Fix interger overflows

### DIFF
--- a/platforms.c
+++ b/platforms.c
@@ -493,7 +493,7 @@ static int __start_pvlogger_for_platform(struct pv_platform *platform,
 	 * fork, and set the mount namespace for
 	 * pv_logger.
 	 * */
-	int container_pid = platform->init_pid;
+	pid_t container_pid = platform->init_pid;
 	sigset_t oldmask;
 
 	if (!log_info)


### PR DESCRIPTION
Fix some possible integer overflows in memory assigns, and maybe the most relevant in the libthttp.

**IMPORTANT:** to merge this PR, please fist check and merge this: https://gitlab.com/pantacor/libthttp/-/merge_requests/49 which implements the solution in the libthttp side