### PR TITLE
fix: avoid checksum calculation over the same file

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -466,31 +466,21 @@ out:
 	return ret;
 }
 
-static bool pv_storage_validate_objects_object_checksum(char *checksum)
-{
-	char path[PATH_MAX];
-
-	pv_paths_storage_object(path, PATH_MAX, checksum);
-	pv_log(DEBUG, "validating checksum for object %s", path);
-	return !pv_storage_validate_file_checksum(path, checksum);
-}
-
 bool pv_storage_validate_trails_object_checksum(const char *rev,
 						const char *name,
 						char *checksum)
 {
-	char path[PATH_MAX];
+	char trail[PATH_MAX] = { 0 };
+	char object[PATH_MAX] = { 0 };
 
-	// validate object in pool to match
-	if (!pv_storage_validate_objects_object_checksum(checksum)) {
-		pv_log(ERROR, "object %s with checksum %s failed", name,
-		       checksum);
+	pv_paths_storage_trail_file(trail, PATH_MAX, rev, name);
+	pv_paths_storage_object(object, PATH_MAX, checksum);
+
+	if (!pv_fs_file_is_same(trail, object))
 		return false;
-	}
 
-	pv_paths_storage_trail_file(path, PATH_MAX, rev, name);
-	pv_log(DEBUG, "validating checksum for object in trail %s", path);
-	return !pv_storage_validate_file_checksum(path, checksum);
+	pv_log(DEBUG, "validating checksum for %s and %s", object, trail);
+	return !pv_storage_validate_file_checksum(trail, checksum);
 }
 
 bool pv_storage_validate_trails_json_value(const char *rev, const char *name,

--- a/utils/fs.c
+++ b/utils/fs.c
@@ -432,3 +432,27 @@ int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode)
 		return -1;
 	return open(fname, flags, mode);
 }
+
+static int pv_fs_file_inode_get(const char *path, ino_t *inode)
+{
+	struct stat st = { 0 };
+	if (stat(path, &st) != 0)
+		return -1;
+
+	*inode = st.st_ino;
+	return 0;
+}
+
+bool pv_fs_file_is_same(const char *path1, const char *path2)
+{
+	ino_t ino1;
+	ino_t ino2;
+
+	if (pv_fs_file_inode_get(path1, &ino1) != 0)
+		return false;
+
+	if (pv_fs_file_inode_get(path2, &ino2) != 0)
+		return false;
+
+	return ino1 == ino2;
+}

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -55,5 +55,6 @@ int pv_fs_file_lock(int fd);
 int pv_fs_file_unlock(int fd);
 int pv_fs_file_gzip(const char *fname, const char *target_name);
 int pv_fs_file_check_and_open(const char *fname, int flags, mode_t mode);
+bool pv_fs_file_is_same(const char *path1, const char *path2);
 
 #endif


### PR DESCRIPTION
Create an array to store the inode of each file with an already calculated checksum to avoid the recalculation 