### PR TITLE
fix: several memory problems unearthed by valgrind mem check

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -196,6 +196,8 @@ int pv_bootloader_fail_update()
 
 void pv_bootloader_remove()
 {
+	ops->free();
+
 	if (pv_bootloader.pv_rev)
 		free(pv_bootloader.pv_rev);
 	if (pv_bootloader.pv_try)

--- a/bootloader.h
+++ b/bootloader.h
@@ -25,6 +25,7 @@
 #include <stdbool.h>
 
 struct bl_ops {
+	void (*free)(void);
 	int (*init)(void);
 
 	/* old primitive semantic */

--- a/buffer.h
+++ b/buffer.h
@@ -38,6 +38,7 @@ struct buffer *pv_buffer_get(bool large);
 
 void pv_buffer_drop(struct buffer *);
 
+void pv_buffer_close(void);
 void pv_buffer_init(int items, int size);
 
 static void __drop_buff(struct buffer **buf)

--- a/grub.c
+++ b/grub.c
@@ -44,6 +44,12 @@
 
 static char *grub_env = 0;
 
+static void grub_free()
+{
+	if (grub_env)
+		free(grub_env);
+}
+
 static int grub_init()
 {
 	int fd, ret;
@@ -251,6 +257,7 @@ static int grub_flush_env(void)
 }
 
 const struct bl_ops grub_ops = {
+	.free = grub_free,
 	.init = grub_init,
 	.set_env_key = grub_set_env_key,
 	.unset_env_key = grub_unset_env_key,

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -1237,6 +1237,7 @@ static int logserver_send_subs_msg(int type, int fd, const char *platform,
 		char buf[CMSG_SPACE(sizeof(int))];
 		struct cmsghdr align;
 	} ctrl;
+	memset(&ctrl, 0, sizeof(ctrl));
 
 	struct msghdr msg = {
 		.msg_name = NULL,
@@ -1254,6 +1255,8 @@ static int logserver_send_subs_msg(int type, int fd, const char *platform,
 	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
 
 	int sockfd = logserver_open_client_socket(LOGFD_FNAME);
+	if (sockfd < 0)
+		return -1;
 
 	int r = sendmsg(sockfd, &msg, 0);
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -62,6 +62,7 @@
 #include "mount.h"
 #include "debug.h"
 #include "cgroup.h"
+#include "buffer.h"
 
 #include "parser/parser.h"
 
@@ -936,6 +937,7 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, shutdown_type_t t)
 
 	// free up memory
 	pv_bootloader_remove();
+	pv_buffer_close();
 
 	// at this point, we can shutdown if not in appengine
 	if (init_mode != IM_APPENGINE) {

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -344,7 +344,7 @@ static int parse_disks(struct pv_state *s, char *value)
 			diskv = NULL;
 		}
 
-		if (diskv) {
+		if (str) {
 			free(str);
 			str = NULL;
 		}

--- a/platforms.c
+++ b/platforms.c
@@ -251,6 +251,7 @@ void pv_platform_free(struct pv_platform *p)
 			free(*c);
 			c++;
 		}
+		free(p->configs);
 	}
 
 	dl_list_for_each_safe(d, tmp, &p->drivers, struct pv_platform_driver,

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -365,9 +365,10 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 		}
 		close(fd);
 		fd = open(tmp_cmd, O_CREAT | O_RDWR | O_SYNC, 0644);
-		if (fd >= 0)
+		if (fd >= 0) {
 			write(fd, new, strlen(new));
-		close(fd);
+			close(fd);
+		}
 		free(new);
 		free(buf);
 	}

--- a/rpiab.c
+++ b/rpiab.c
@@ -338,6 +338,10 @@ bestguess:
 	return 0;
 }
 
+static void rpiab_free()
+{
+}
+
 static int rpiab_init()
 {
 	char *b;
@@ -1007,6 +1011,7 @@ static int rpiab_fail_update()
 }
 
 const struct bl_ops rpiab_ops = {
+	.free = rpiab_free,
 	.init = rpiab_init,
 	.set_env_key = rpiab_set_env_key,
 	.unset_env_key = rpiab_unset_env_key,

--- a/state.c
+++ b/state.c
@@ -1174,6 +1174,7 @@ static char *pv_state_add_novalidate_obj(char *nv_list, size_t nv_size,
 
 	nv_list = tmp;
 	memcpy(nv_list + nv_size, entry, entry_size);
+	nv_list[nv_size + entry_size] = '\0';
 
 	return nv_list;
 }

--- a/uboot.c
+++ b/uboot.c
@@ -53,6 +53,12 @@ static int single_env;
 #define MTD_ENV_SIZE 65536
 #define UBOOT_ENV_SIZE 1024
 
+static void uboot_free()
+{
+	if (uboot_txt)
+		free(uboot_txt);
+}
+
 static int uboot_init()
 {
 	int fd, ret;
@@ -316,6 +322,7 @@ static int uboot_flush_env(void)
 }
 
 const struct bl_ops uboot_ops = {
+	.free = uboot_free,
 	.init = uboot_init,
 	.set_env_key = uboot_set_env_key,
 	.unset_env_key = uboot_unset_env_key,

--- a/ubootab.c
+++ b/ubootab.c
@@ -220,6 +220,10 @@ out:
 	return ret;
 }
 
+static void ubootab_free()
+{
+}
+
 static int ubootab_init()
 {
 	if (ubootab.init)
@@ -446,6 +450,7 @@ static int ubootab_flush_env()
 }
 
 const struct bl_ops ubootab_ops = {
+	.free = ubootab_free,
 	.init = ubootab_init,
 	.set_env_key = ubootab_set_env_key,
 	.unset_env_key = ubootab_unset_env_key,


### PR DESCRIPTION
This PR fixes the memory warnings detected by Valgrind during Pantavisor bootup and shut down (no containers):

* bootloader: global strings not being freed before power off.
* buffer: global struct and buf not being freed before power off.
* logserver: msg not initialized to 0 in logserver_send_subs_msg.
* logserver: ignoring open socket error in logserver_send_subs_msg.
* parser: str being freed when NULL.
* platforms: config being freed but not the list of configs itself.
* pv_lxc: closing fd in case of open error in pv_setup_lxc_container.
* state: novalidate list trailing byte not being initialized.