### PR TITLE
WIP: New binary protocol to logserver with a small header

### DIFF
--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -29,8 +29,6 @@
 #include <stdbool.h>
 #include <time.h>
 
-#define LOGSERVER_LOG_PROTOCOL_V1 0
-
 #ifdef DEBUG
 #define WARN_ONCE(msg, args...)                                                \
 	do {                                                                   \
@@ -49,13 +47,8 @@ struct logserver_data {
 	int len;
 };
 
-typedef enum {
-	LOG_PROTOCOL_LEGACY = 0,
-	LOG_PROTOCOL_CMD = 256
-} log_protocol_code_t;
-
 struct logserver_log {
-	log_protocol_code_t code;
+	int code;
 	int lvl;
 	uint64_t tsec;
 	uint32_t tnano;


### PR DESCRIPTION
New binary protocol for logserver:
* Include a small header to ensure to identify the messages from other data
* Limit the size of the log messages (see LOGSERVER_MAX_MSG_LEN)
* Improve how messages are parsed
* All new messages (commands, fd subscriptions and logs) use the new protocol