### PR TITLE
Add dynamic buffer to read and write operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,8 @@ set(PVTX_COMMON_SOURCES
 	pvtx/pvtx_utils/base64.c
 	pvtx/pvtx_utils/sha256-internal.c
 	pvtx/pvtx_utils/jsmn.c
+	pvtx/pvtx_buffer.h
+	pvtx/pvtx_buffer.c
 	pvtx/pvtx_ctrl.c
 	pvtx/pvtx_ctrl.h
 	pvtx/pvtx_error.c

--- a/pvtx/pvtx.c
+++ b/pvtx/pvtx.c
@@ -249,6 +249,15 @@ static int cmd_help(int argc, char **argv)
 	printf("  %-22s", "process");
 	printf("Process the current queue.\n");
 
+	printf("Environment Variables:\n");
+	printf("  %-22s", "PVTXDIR");
+	printf("Temporary directory where PVTX store transaction related data\n");
+	printf("  %-22s", "PVTX_OBJECT_BUF_SIZE");
+	printf("Size of the buffer used to save objects. Min 512B max 10485760B (10M)\n");
+	printf("  %-22s", "PVTX_CTRL_BUF_SIZE");
+	printf("Size of the buffer used to get and post data to pv-ctrl.\n");
+	printf("%-24s%s\n", " ", "Min 16384B (16K) max 10485760B (10M)\n");
+
 	return 0;
 }
 
@@ -336,6 +345,12 @@ static int pv_pvtx_process_args(int argc, char **argv)
 
 	char *op = argv[1];
 	struct commands *cmd = &normal;
+
+	if (!strlen(op)) {
+		fprintf(stderr, "ERROR: empty command\n\n");
+		cmd_help(argc, argv);
+		exit(1);
+	}
 
 	if (!strncmp(op, "queue", strlen(op))) {
 		op = argv[2];

--- a/pvtx/pvtx_buffer.c
+++ b/pvtx/pvtx_buffer.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "pvtx_buffer.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+static int get_buf_size(const char *env, size_t min, size_t max)
+{
+	char *size_str = getenv(env);
+	if (!size_str)
+		return min;
+
+	errno = 0;
+	int size = strtol(size_str, NULL, 10);
+	if (errno != 0 || size < min)
+		return min;
+	if (size > max)
+		return max;
+
+	return size;
+}
+
+struct pv_pvtx_buffer *pv_pvtx_buffer_new(size_t size)
+{
+	if (size < 0)
+		return NULL;
+
+	struct pv_pvtx_buffer *buf = calloc(1, sizeof(struct pv_pvtx_buffer));
+	if (!buf)
+		return NULL;
+
+	// the extra block is to be "string compatible"
+	buf->data = calloc(size + 1, sizeof(char));
+	if (!buf->data) {
+		pv_pvtx_buffer_free(buf);
+		return NULL;
+	}
+
+	buf->size = size;
+
+	return buf;
+}
+
+struct pv_pvtx_buffer *pv_pvtx_buffer_from_env(const char *env, size_t min,
+					       size_t max, size_t rounding)
+{
+	size_t size = get_buf_size(env, min, max);
+
+	if (size % rounding)
+		size = (size | (rounding - 1)) + 1;
+
+	return pv_pvtx_buffer_new(size);
+}
+
+void pv_pvtx_buffer_free(struct pv_pvtx_buffer *buf)
+{
+	if (!buf)
+		return;
+
+	if (buf->data)
+		free(buf->data);
+
+	free(buf);
+}

--- a/pvtx/pvtx_buffer.h
+++ b/pvtx/pvtx_buffer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PV_PVTX_BUFFER_H
+#define PV_PVTX_BUFFER_H
+
+#include <stddef.h>
+
+struct pv_pvtx_buffer {
+	void *data;
+	size_t size;
+};
+
+struct pv_pvtx_buffer *pv_pvtx_buffer_new(size_t size);
+struct pv_pvtx_buffer *pv_pvtx_buffer_from_env(const char *env, size_t min,
+					       size_t max, size_t rounging);
+void pv_pvtx_buffer_free(struct pv_pvtx_buffer *buf);
+
+#endif

--- a/pvtx/pvtx_tar.h
+++ b/pvtx/pvtx_tar.h
@@ -76,7 +76,7 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_path(const char *path,
 					  struct pv_pvtx_error *err);
 int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con);
 ssize_t pv_pvtx_tar_content_read_block(struct pv_pvtx_tar_content *con,
-				       void *buf);
+				       void *buf, ssize_t size);
 ssize_t pv_pvtx_tar_content_read_object(struct pv_pvtx_tar_content *con,
 					void *buf);
 


### PR DESCRIPTION
Add dynamic buffer to read and write operations

Dynamic buffers are implemented to send and receive objects and json from pv-ctrl (pvtx_ctrl) and to read and write objects to folders (pvtx_txn), those buffers can be set to use different sizes, although they have minimum and maximum values. The following table shows a small summary for each one:

| variable name        |        operation       |    minimum   |     maximum     |
|----------------------|------------------------|--------------|-----------------|
| PVTX_CTRL_BUF_SIZE   | for pv-ctrl operations | 16384B (16K) | 10485760 (10M)  |
| PVTX_OBJECT_BUF_SIZE | for write/read objects | 512B         | 10485760B (10M) |

