### PR TITLE
Atomic file ops in PVTX

### DIFF
--- a/pvtx/pvtx.c
+++ b/pvtx/pvtx.c
@@ -209,7 +209,7 @@ static int cmd_deploy(int argc, char **argv)
 
 static int cmd_help(int argc, char **argv)
 {
-	printf("Usage: %s COMMAND [SUB-COMMAND] args...\n\n", argv[0]);
+	printf("LUsage: %s COMMAND [SUB-COMMAND] args...\n\n", argv[0]);
 	printf("Commands:\n");
 
 	printf("  %-22s", "begin <base> [object]");

--- a/pvtx/pvtx_error.c
+++ b/pvtx/pvtx_error.c
@@ -4,14 +4,19 @@
 #include <stdio.h>
 #include <string.h>
 
-void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *tmpl,
-		       ...)
+void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *func,
+		       int line, const char *tmpl, ...)
 {
 	pv_pvtx_error_clear(err);
 
+	int n = 0;
+	if (func)
+		n = snprintf(err->str, PV_PVTX_ERROR_MAX_LEN, "[%s:%d]: ", func,
+			     line);
+
 	va_list list;
 	va_start(list, tmpl);
-	vsnprintf(err->str, PV_PVTX_ERROR_MAX_LEN, tmpl, list);
+	vsnprintf(err->str + n, PV_PVTX_ERROR_MAX_LEN - n, tmpl, list);
 	va_end(list);
 
 	err->code = code;

--- a/pvtx/pvtx_error.h
+++ b/pvtx/pvtx_error.h
@@ -22,17 +22,18 @@
 
 #ifndef PV_PVTX_ERROR_H
 #define PV_PVTX_ERROR_H
-#define PV_PVTX_ERROR_MAX_LEN (128)
+#define PV_PVTX_ERROR_MAX_LEN (512)
 
-// code == 0: no error
-// code > 0: code is an errno
-// code < 0: code is an unknown or custom error
 struct pv_pvtx_error {
 	int code;
 	char str[PV_PVTX_ERROR_MAX_LEN];
 };
 
-void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *, ...);
+#define PVTX_ERROR_SET(err, code, tmpl, ...)                                   \
+	pv_pvtx_error_set(err, code, __func__, __LINE__, tmpl, ##__VA_ARGS__)
+
+void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *func,
+		       int line, const char *tmpl, ...);
 void pv_pvtx_error_clear(struct pv_pvtx_error *err);
 
 #endif

--- a/pvtx/pvtx_state.c
+++ b/pvtx/pvtx_state.c
@@ -220,11 +220,17 @@ void pv_pvtx_state_free(struct pv_pvtx_state *st)
 struct pv_pvtx_state *pv_pvtx_state_from_file(const char *path)
 {
 	int fd = open(path, O_RDONLY);
-	if (!fd)
+	if (fd < 0)
 		return NULL;
 
 	struct stat st = { 0 };
 	if (fstat(fd, &st) != 0) {
+		close(fd);
+		return NULL;
+	}
+
+	// minimum possible json is [] or {}
+	if (st.st_size < 2) {
 		close(fd);
 		return NULL;
 	}

--- a/utils/fs.h
+++ b/utils/fs.h
@@ -36,7 +36,8 @@ int pv_fs_mkbasedir_p(const char *path, mode_t mode);
 int pv_fs_path_remove(const char *path, bool recursive);
 int pv_fs_path_rename(const char *src_path, const char *dst_path);
 off_t pv_fs_path_get_size(const char *path);
-int pv_fs_file_tmp(char *tmp, const char *fname);
+int pv_fs_file_tmp(const char *fname, char *tmp);
+int pv_fs_path_tmpdir(const char *fname, char *tmp);
 char *pv_fs_file_load(const char *path, off_t max);
 int pv_fs_file_save(const char *fname, const char *data, mode_t mode);
 int pv_fs_file_copy(const char *src, const char *dst, mode_t mode);
@@ -59,7 +60,11 @@ bool pv_fs_file_is_same(const char *path1, const char *path2);
 void pv_fs_basename(const char *path, char *base);
 void pv_fs_dirname(const char *path, char *parent);
 void pv_fs_extension(const char *path, char *ext);
+
 void *pv_fs_file_read(const char *path, size_t *size);
-int pv_fs_file_write(const char *path, void *buf, ssize_t size);
+
+int pv_fs_file_write_no_sync(const char *path, void *buf, ssize_t size);
+int pv_fs_path_remove_recursive_no_sync(const char *path);
+int pv_fs_file_copy_no_sync(const char *src, const char *dst, mode_t mode);
 
 #endif


### PR DESCRIPTION
Adds secure operation over files, doing all the work behind the scenes using temporal files and then moving it using rename(3)
The Idea it's to avoid the data lost while files are being created.

The changes introduced are:
* Improve the current function in utils/fs to create temporal files.
* Adds new function to create temporal directories. 
* Add "write in temporal then move" logic to all critical operations

**Update**:
* Adds PV_FS_NO_SYNC macro to avoid call sync() in the utils/fs functions, so if this macro is defined the developer is responsible to call sync() when is needed 
