### PR TITLE
fix: escape bad formatted JSON devmeta

### DIFF
--- a/metadata.c
+++ b/metadata.c
@@ -914,8 +914,7 @@ int pv_metadata_upload_devmeta(struct pantavisor *pv)
 		char *val = pv_json_format(info->value, strlen(info->value));
 
 		if (key && val) {
-			// if value is a regular string
-			if (info->value[0] != '{') {
+			if (!pv_json_is_valid(info->value)) {
 				int frag_len = strlen(key) + strlen(val) +
 					       // 2 pairs of quotes
 					       2 * 2 +
@@ -928,7 +927,6 @@ int pv_metadata_upload_devmeta(struct pantavisor *pv)
 					len += frag_len;
 					json_avail -= frag_len;
 				}
-				// if value is a json
 			} else {
 				int frag_len = strlen(info->key) +
 					       strlen(info->value) +
@@ -1112,8 +1110,7 @@ static char *pv_metadata_get_meta_string(struct dl_list *meta_list)
 		if (!curr->value)
 			continue;
 
-		if (curr->value[0] != '{') {
-			// value is a plain string
+		if (!pv_json_is_valid(curr->value)) {
 			char *escaped = pv_json_format(curr->value,
 						       strlen(curr->value));
 			if (!escaped)
@@ -1124,7 +1121,6 @@ static char *pv_metadata_get_meta_string(struct dl_list *meta_list)
 					"\"%s\":\"%s\",", curr->key, escaped);
 			free(escaped);
 		} else {
-			// value is a json
 			line_len = strlen(curr->key) + strlen(curr->value) + 4;
 			json = realloc(json, len + line_len + 1);
 			SNPRINTF_WTRUNC(&json[len], line_len + 1, "\"%s\":%s,",

--- a/utils/json.c
+++ b/utils/json.c
@@ -217,6 +217,29 @@ out:
 	return json_string;
 }
 
+bool pv_json_is_valid(const char *json)
+{
+	bool ret = false;
+
+	int tokc;
+	jsmntok_t *tokv = NULL;
+
+	if (jsmnutil_parse_json(json, &tokv, &tokc) < 0)
+		goto out;
+
+	// this way, we don't take plain strings as valid, as that
+	// is considered JSMN_PRIMITIVE by the library
+	if((tokv->type != JSMN_OBJECT) && (tokv->type != JSMN_ARRAY))
+		goto out;
+
+	ret = true;
+
+out:
+	if (tokv)
+		free(tokv);
+	return ret;
+}
+
 void pv_json_ser_init(struct pv_json_ser *js, size_t size)
 {
 	if (!js)

--- a/utils/json.h
+++ b/utils/json.h
@@ -39,6 +39,8 @@ char *pv_json_get_value(const char *buf, const char *key, jsmntok_t *tok,
 			int tokc);
 char *pv_json_array_get_one_str(const char *buf, int *n, jsmntok_t **tok);
 
+bool pv_json_is_valid(const char *json);
+
 struct pv_json_ser {
 	jsonb b;
 	size_t block_size;


### PR DESCRIPTION
When storing bad formatted JSON in device metadata, Pantavisor was unable to upload it as the HTTP request was bad formatted too. Escaping bad formatted JSON in these cases will solve this.

It also affected pvcontrol, which is now returning a JSON that contains escaped bad formatted JSONs too.