### PR TITLE
Bump minumum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the minimum required version of CMake
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 # Set the project name and version
 project(pantavisor VERSION 019)


### PR DESCRIPTION
A deprecation warning suggest that the compatibility with CMake < 3.10 will be removed, so this commit bump the minimum version to avoid that future problem.
The warning appears as soon as Pantavisor build is set:
```
$ cmake -DPANTAVISOR_RUNTIME=OFF -DPANTAVISOR_PVTX=OFF -DPANTAVISOR_PVTX_STATIC=ON ..
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```