### PR TITLE
feat: support to update and commit

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -786,6 +786,7 @@ static int pv_ctrl_check_command(int req_fd, struct pv_cmd **cmd)
 	    (((*cmd)->op == CMD_REBOOT_DEVICE) ||
 	     ((*cmd)->op == CMD_POWEROFF_DEVICE) ||
 	     ((*cmd)->op == CMD_LOCAL_RUN) || ((*cmd)->op == CMD_LOCAL_APPLY) ||
+	     ((*cmd)->op == CMD_LOCAL_RUN_COMMIT) ||
 	     ((*cmd)->op == CMD_MAKE_FACTORY))) {
 		pv_ctrl_write_error_response(
 			req_fd, HTTP_STATUS_CONFLICT,

--- a/ctrl.h
+++ b/ctrl.h
@@ -39,6 +39,7 @@ typedef enum {
 	CMD_DISABLE_SSH = 10,
 	CMD_GO_REMOTE = 11,
 	CMD_DEFER_REBOOT = 12,
+	CMD_LOCAL_RUN_COMMIT = 13,
 	MAX_CMD_OP
 } pv_cmd_operation_t;
 
@@ -67,7 +68,8 @@ pv_ctrl_string_cmd_operation(const pv_cmd_operation_t op)
 					 "ENABLE_SSH",
 					 "DISABLE_SSH",
 					 "GO_REMOTE",
-					 "DEFER_REBOOT" };
+					 "DEFER_REBOOT",
+					 "LOCAL_RUN_COMMIT" };
 	return strings[op];
 }
 

--- a/updater.c
+++ b/updater.c
@@ -723,6 +723,7 @@ static struct pv_update *pv_update_new(const char *rev, bool local)
 		u->rev = strdup(rev);
 		u->retries = 0;
 		u->local = local;
+		u->needs_commit = false;
 
 		if (pv_storage_is_revision_local(rev)) {
 			u->local = true;
@@ -2151,4 +2152,18 @@ bool pv_update_is_testing(struct pv_update *u)
 {
 	return (u && ((u->status == UPDATE_TESTING_REBOOT) ||
 		      (u->status == UPDATE_TESTING_NONREBOOT)));
+}
+
+void pv_update_set_needs_commit(struct pv_update *update)
+{
+	if (!update) {
+		pv_log(DEBUG, "update does not exist");
+		return;
+	}
+	update->needs_commit = true;
+}
+
+bool pv_update_get_needs_commit(struct pv_update *update)
+{
+	return update->needs_commit;
 }

--- a/updater.h
+++ b/updater.h
@@ -96,6 +96,7 @@ struct pv_update {
 	int retries;
 	struct download_info total;
 	bool local;
+	bool needs_commit;
 };
 
 struct trail_remote {
@@ -122,10 +123,12 @@ int pv_update_finish(struct pantavisor *pv);
 bool pv_update_is_transitioning(struct pv_update *u);
 bool pv_update_is_trying(struct pv_update *u);
 bool pv_update_is_testing(struct pv_update *u);
+bool pv_update_get_needs_commit(struct pv_update *update);
 
 void pv_update_set_status_msg(struct pv_update *update,
 			      enum update_status status, const char *msg);
 void pv_update_set_status(struct pv_update *update, enum update_status status);
 void pv_update_set_factory_status(void);
+void pv_update_set_needs_commit(struct pv_update *update);
 
 #endif


### PR DESCRIPTION
This feature enable, using pvcontrol, a way for applying the rev rebooting after the command.

On `pvcontrol` we will run as the following: `pvcontrol cmd run-commit <rev>` . MR for pvr-sdk is [here](https://gitlab.com/pantacor/pv-platforms/pvr-sdk/-/merge_requests/104) 

I add a new entry on pv_update structed, so when we use run-commit we set mark that, after applying the rev, we will reboot the system.

The flow is the same as a normal `pv_update` 

I'm a little confused about the `CMD_LOCAL_APPLY` it looks same with  `CMD_LOCAL_RUN` but there are some differences. What is that about?

I don't know if I'm missing any edge case during test.