### PR TITLE
fix: REST using libevent callback to clean up context

### DIFF
--- a/ctrl.c
+++ b/ctrl.c
@@ -1479,7 +1479,7 @@ out:
 
 void pv_ctrl_socket_read(int fd, short event, void *arg)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)pv_ctrl_socket_read);
+	pv_log(DEBUG, "run event: cb=%p", (void *)pv_ctrl_socket_read);
 
 	int req_fd = 0, ret;
 

--- a/event/event.c
+++ b/event/event.c
@@ -125,7 +125,7 @@ void pv_event_one_shot(event_callback_fn cb)
 	struct timeval when = { 0, 0 };
 	event_base_once(base, -1, EV_TIMEOUT, cb, NULL, &when);
 
-	pv_log(DEBUG, "added event: type='one shot' cb=%p", (void *)cb);
+	pv_log(DEBUG, "add event: type='one shot' cb=%p", (void *)cb);
 }
 
 struct event_base *pv_event_get_base()

--- a/event/event_rest.h
+++ b/event/event_rest.h
@@ -25,10 +25,13 @@
 #include <event2/event.h>
 #include <event2/http.h>
 
+int pv_event_rest_init(void);
+void pv_event_rest_cleanup(void);
+
 int pv_event_rest_send(enum evhttp_cmd_type op, const char *uri,
 		       const char *token, const char *body,
 		       void (*cb)(struct evhttp_request *, void *));
-int pv_event_rest_recv(struct evhttp_request *req, void *mbedtls_ctx, char *out,
+int pv_event_rest_recv(struct evhttp_request *req, void *ctx, char *out,
 		       int max_len);
 
 #endif

--- a/event/event_socket.c
+++ b/event/event_socket.c
@@ -46,8 +46,7 @@ void pv_event_socket_listen(event_socket_t *listener, evutil_socket_t fd,
 	event_add(listener->ev, NULL);
 	listener->fd = fd;
 
-	pv_log(DEBUG, "added event: type='listener' cb=%p fd=%d", (void *)cb,
-	       fd);
+	pv_log(DEBUG, "add event: type='listener' cb=%p fd=%d", (void *)cb, fd);
 }
 
 void pv_event_socket_ignore(event_socket_t *listener)

--- a/event/event_timer.c
+++ b/event/event_timer.c
@@ -55,7 +55,7 @@ void pv_event_timer_run(event_timer_t *timer, int next_interval,
 	}
 	timer->interval = next_interval;
 
-	pv_log(DEBUG, "added event: type='timer' cb=%p interval=%d", (void *)cb,
+	pv_log(DEBUG, "add event: type='timer' cb=%p interval=%d", (void *)cb,
 	       next_interval);
 }
 

--- a/pantahub/pantahub.c
+++ b/pantahub/pantahub.c
@@ -53,6 +53,7 @@
 #include "metadata.h"
 
 #include "event/event.h"
+#include "event/event_rest.h"
 
 #include "pantahub/pantahub_proto.h"
 
@@ -683,6 +684,8 @@ int pv_pantahub_close()
 
 	pv_pantahub_proto_close_session();
 
+	pv_event_rest_cleanup();
+
 	free(ph);
 	global_ph = NULL;
 
@@ -709,12 +712,17 @@ static void _next_state(ph_state_t state)
 
 static void _run_state_init()
 {
+	if (pv_event_rest_init()) {
+		pv_log(ERROR, "HTTP REST initialization failed");
+		_next_state(PH_STATE_INIT);
+	}
+
 	_next_state(PH_STATE_LOGIN);
 }
 
 static void _login_event_cb(evutil_socket_t fd, short event, void *arg)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_login_event_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_login_event_cb);
 	pv_pantahub_proto_open_session();
 }
 
@@ -734,13 +742,13 @@ static void _run_state_login()
 
 static void _usrmeta_event_cb(evutil_socket_t fd, short event, void *arg)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_usrmeta_event_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_usrmeta_event_cb);
 	pv_pantahub_proto_get_usrmeta();
 }
 
 static void _devmeta_event_cb(evutil_socket_t fd, short event, void *arg)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_devmeta_event_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_devmeta_event_cb);
 	pv_pantahub_proto_set_devmeta();
 }
 

--- a/pantahub/pantahub_proto.c
+++ b/pantahub/pantahub_proto.c
@@ -66,7 +66,7 @@ out:
 
 static void _recv_post_auth_cb(struct evhttp_request *req, void *ctx)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_recv_post_auth_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_recv_post_auth_cb);
 
 	char buffer[TMP_BUF_LEN] = { 0 };
 	int res = pv_event_rest_recv(req, ctx, buffer, TMP_BUF_LEN);
@@ -128,7 +128,7 @@ void pv_pantahub_proto_close_session()
 
 static void _recv_get_usrmeta_cb(struct evhttp_request *req, void *ctx)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_recv_get_usrmeta_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_recv_get_usrmeta_cb);
 
 	char buffer[TMP_BUF_LEN] = { 0 };
 	int res = pv_event_rest_recv(req, ctx, buffer, TMP_BUF_LEN);
@@ -165,7 +165,7 @@ void pv_pantahub_proto_get_usrmeta()
 
 static void _recv_set_devmeta_cb(struct evhttp_request *req, void *ctx)
 {
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_recv_set_devmeta_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_recv_set_devmeta_cb);
 
 	char buffer[TMP_BUF_LEN] = { 0 };
 	int res = pv_event_rest_recv(req, ctx, buffer, TMP_BUF_LEN);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -950,7 +950,7 @@ static void _pv_run_state_cb(evutil_socket_t fd, short events, void *arg)
 
 	pv_wdt_kick();
 
-	pv_log(DEBUG, "run event: cb '%p'", (void *)_pv_run_state_cb);
+	pv_log(DEBUG, "run event: cb=%p", (void *)_pv_run_state_cb);
 	pv_log(DEBUG, "next state: '%s'", pv_state_string(state));
 	pv_state_t next_state = state_table[state](pv);
 


### PR DESCRIPTION
This PR removes the need to allocate and de-allocate a context struct per HTTPS REST request. Therefore, we can stop using the finalize callback added by us in libevent.

It initializes and cleans up Mbed TLS context (which is now common for all requests) at the start and at the end of the Pantacor Hub state machine. It also leaves the management of bev, evcon and ssl to the internal mechanisms of libevent.