### PR TITLE
fix: new HTTP client not using dynamic buffer allocation

### DIFF
--- a/event/event_rest.h
+++ b/event/event_rest.h
@@ -31,7 +31,7 @@ void pv_event_rest_cleanup(void);
 int pv_event_rest_send(enum evhttp_cmd_type op, const char *uri,
 		       const char *token, const char *body,
 		       void (*cb)(struct evhttp_request *, void *));
-int pv_event_rest_recv(struct evhttp_request *req, void *ctx, char *out,
-		       int max_len);
+int pv_event_rest_recv(struct evhttp_request *req, void *ctx, char **out,
+		       size_t max_len);
 
 #endif


### PR DESCRIPTION
Use dynamic buffer for HTTP body temporary buffers.