### PR TITLE
fix: ctrl requests overwriting not yet processed commands

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -726,6 +726,7 @@ static pv_state_t _pv_command(struct pantavisor *pv)
 		pv_log(WARN, "unknown command received. Ignoring...");
 	}
 out:
+	// free processing command so we can take further ones
 	pv_ctrl_free_cmd(pv->cmd);
 	pv->cmd = NULL;
 	return next_state;


### PR DESCRIPTION
This PR fixes a regression introduced with the event loop, as now we are able to process several ctrl requests in between two PV_STATE_WAIT iterations. The last request received before a PV_STATE_WAIT would overwrite any commands (pvcontrol cmd run-gc, reboot, run, etc.) sent after the previous PV_STATE_WAIT.

To fix this, no more than one command in between two PV_STATE_WAIT is now allowed. Furthermore, a 409 HTTP error code will be returned in case the user tries this.