### PR TITLE
Preserve the canonical format

### DIFF
--- a/pvtx/pvtx_state.h
+++ b/pvtx/pvtx_state.h
@@ -25,7 +25,7 @@
 
 #include <stddef.h>
 
-#define PVTX_STATE_EMPTY "{\"#spec\": \"pantavisor-service-system@1\"}"
+#define PVTX_STATE_EMPTY "{\"#spec\":\"pantavisor-service-system@1\"}"
 
 struct pv_pvtx_state {
 	char *json;


### PR DESCRIPTION
Remove the extra space in the json header used to create the state json to preserve the canonical format