### PR TITLE
Improve error reporting

### DIFF
--- a/pvtx/pvtx_buffer.c
+++ b/pvtx/pvtx_buffer.c
@@ -46,6 +46,25 @@ static int get_buf_size(const char *env, size_t min, size_t max)
 	return size;
 }
 
+int pv_pvtx_buffer_realloc(struct pv_pvtx_buffer *buf, size_t new_size)
+{
+	if (!buf)
+		return -1;
+
+	if (!buf->data)
+		return -1;
+
+	char *tmp = realloc(buf->data, (new_size + 1) * sizeof(char));
+
+	if(!tmp)
+		return -1;
+
+	buf->data = tmp;
+	buf->size = new_size;
+
+	return 0;
+}
+
 struct pv_pvtx_buffer *pv_pvtx_buffer_new(size_t size)
 {
 	if (size < 0)

--- a/pvtx/pvtx_buffer.h
+++ b/pvtx/pvtx_buffer.h
@@ -34,5 +34,6 @@ struct pv_pvtx_buffer *pv_pvtx_buffer_new(size_t size);
 struct pv_pvtx_buffer *pv_pvtx_buffer_from_env(const char *env, size_t min,
 					       size_t max, size_t rounging);
 void pv_pvtx_buffer_free(struct pv_pvtx_buffer *buf);
+int pv_pvtx_buffer_realloc(struct pv_pvtx_buffer *buf, size_t new_size);
 
 #endif

--- a/pvtx/pvtx_error.c
+++ b/pvtx/pvtx_error.c
@@ -31,3 +31,19 @@ void pv_pvtx_error_clear(struct pv_pvtx_error *err)
 {
 	memset(err, 0, sizeof(struct pv_pvtx_error));
 }
+
+void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *file,
+			   int line, const char *tmpl, ...)
+{
+	char old_buf[PV_PVTX_ERROR_MAX_LEN] = { 0 };
+	memccpy(old_buf, err->str, '\0', PV_PVTX_ERROR_MAX_LEN);
+
+	char new_buf[PV_PVTX_ERROR_MAX_LEN] = { 0 };
+	va_list list;
+	va_start(list, tmpl);
+	vsnprintf(new_buf, PV_PVTX_ERROR_MAX_LEN, tmpl, list);
+	va_end(list);
+
+	pv_pvtx_error_set(err, err->code, file, line, "%s: %s", new_buf,
+			  old_buf);
+}

--- a/pvtx/pvtx_error.h
+++ b/pvtx/pvtx_error.h
@@ -22,7 +22,7 @@
 
 #ifndef PV_PVTX_ERROR_H
 #define PV_PVTX_ERROR_H
-#define PV_PVTX_ERROR_MAX_LEN (512)
+#define PV_PVTX_ERROR_MAX_LEN (1024)
 
 struct pv_pvtx_error {
 	int code;
@@ -30,11 +30,16 @@ struct pv_pvtx_error {
 };
 
 #define PVTX_ERROR_SET(err, code, tmpl, ...)                                   \
-	pv_pvtx_error_set(err, code, __FILE__, __LINE__, tmpl,            \
-			  ##__VA_ARGS__)
+	pv_pvtx_error_set(err, code, __FILE__, __LINE__, tmpl, ##__VA_ARGS__)
+
+#define PVTX_ERROR_PREPEND(err, tmpl, ...)                                     \
+	pv_pvtx_error_prepend(err, __FILE__, __LINE__, tmpl, ##__VA_ARGS__)
 
 void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *file,
 		       int line, const char *tmpl, ...);
 void pv_pvtx_error_clear(struct pv_pvtx_error *err);
+
+void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *file,
+			   int line, const char *tmpl, ...);
 
 #endif

--- a/pvtx/pvtx_state.h
+++ b/pvtx/pvtx_state.h
@@ -23,6 +23,8 @@
 #ifndef PV_PVTX_STATE_H
 #define PV_PVTX_STATE_H
 
+#include "pvtx_error.h"
+
 #include <stddef.h>
 
 #define PVTX_STATE_EMPTY "{\"#spec\":\"pantavisor-service-system@1\"}"
@@ -33,8 +35,9 @@ struct pv_pvtx_state {
 	struct pv_pvtx_state_priv *priv;
 };
 
-struct pv_pvtx_state *pv_pvtx_state_from_str(const char *str, size_t len);
-struct pv_pvtx_state *pv_pvtx_state_from_file(const char *path);
+struct pv_pvtx_state *pv_pvtx_state_from_str(const char *str, size_t len,
+					     struct pv_pvtx_error *err);
+struct pv_pvtx_state *pv_pvtx_state_from_file(const char *path, struct pv_pvtx_error *err);
 
 void pv_pvtx_state_free(struct pv_pvtx_state *st);
 


### PR DESCRIPTION
Now pvtx show pv-ctrl errors complete, including all the body
example:

```
# pvtx add container_xyz.tar.gz
ERROR: 422 Unprocessable Entity
Response: {"Error":"Object has bad checksum"}
(pvtx_ctrl.c:263)
```
Also adds PVTX_ERROR_PREPEND to prepend errors to the current ones