### PR TITLE
feat(ipam): implement IP address management for containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ add_executable(pantavisor
 			grub.c
 			init.c
 			init.h
+			ipam.c
+			ipam.h
 			jsons.c
 			jsons.h
 			log.c

--- a/docs/overview/containers.md
+++ b/docs/overview/containers.md
@@ -50,6 +50,15 @@ Container rootfs directories can be mounted back into the host using the `export
 
 This opens the possibility to share directories between containers and Pantavisor itself.
 
+## Networking
+
+Containers can opt into IP networking by declaring a named pool in their `run.json`. Pantavisor's [IPAM subsystem](ipam.md) allocates an address from the pool's subnet, derives a deterministic MAC, creates the bridge, and — for pools with `nat: true` — installs a MASQUERADE rule so the container can reach the external network. Stop/start and auto-recovery preserve the assigned IP by reusing the lease keyed on the container name.
+
+See also:
+- [IPAM technical overview](ipam.md) — pools, leases, lifecycle
+- [Pantavisor IPAM reference](../reference/pantavisor-ipam.md) — schema, fields, error handling
+- [Inter-container communication (xconnect)](xconnect.md) — service-level mediation on top of (or instead of) flat IP reachability
+
 ## Groups
 
 Containers can be [grouped](../../../reference/legacy/pantavisor-state-format-v2.md#containerrunjson).

--- a/docs/overview/ipam.md
+++ b/docs/overview/ipam.md
@@ -74,6 +74,14 @@ A container opts into a pool from its `run.json` (typically generated via `args.
 
 Static IP and MAC overrides are available under `interfaces[]` — see the reference for exact field names.
 
+## Coexistence with backend-native static IPs
+
+A pool's subnet may overlap with a bridge that is also used by containers with backend-native networking — most commonly, the legacy `lxcbr0` bridge on `10.0.3.0/24` that BSPs ship with. Such containers hard-code their address in `lxc.container.conf` as `lxc.net.0.ipv4.address = <X.Y.Z.W>`, and IPAM must not hand the same address to a pool-using container.
+
+Pantavisor handles this automatically. At startup, right after `pv_ipam_setup_bridges()` runs, a **reservation walk** visits every container and asks the backend plugin to enumerate its hard-coded IPv4 addresses. Each enumerated address that falls inside a pool's subnet is added to that pool's lease list as a tagged reservation (`pv:static:<container>`), so `pv_ipam_allocate()`'s `is_ip_available()` check already skips it without any change to the allocator. Addresses outside any pool's subnet are logged at DEBUG and ignored — those containers are managing their own networking on a bridge pantavisor doesn't know about, and that's fine.
+
+The plugin hook is optional — backends that don't provide it simply contribute nothing to the reservation set, and the pool allocates from the full subnet minus the gateway and any existing leases.
+
 ## Pre-start validation
 
 A container that opts into an IPAM pool **must not** bake `lxc.net.*` entries into its `lxc.container.conf`. Pantavisor owns the container's network namespace when IPAM is in use and injects its own `lxc.net.0.*` at start time; silently overwriting a user-baked entry would leak orphan attributes (e.g. `lxc.net.0.macvlan.mode` from the previous type), and silently ignores the user's stated intent.

--- a/docs/overview/ipam.md
+++ b/docs/overview/ipam.md
@@ -1,0 +1,96 @@
+---
+nav_order: 9.5
+---
+# IPAM — Container IP Address Management
+
+Pantavisor includes an IP Address Management (IPAM) subsystem that assigns networking resources to [containers](containers.md) at start time. Containers declare a named **pool** in their manifest; pantavisor allocates an IP from that pool, sets up the backing bridge, and wires the interface into the container's network namespace.
+
+## Why IPAM?
+
+Without IPAM, each container's networking had to be hand-configured in its `lxc.container.conf` — bridge name, IP, MAC, gateway, namespace handling, all baked per-revision. That is painful for multi-container setups, fragile across BSPs, and leaks implementation details into application images.
+
+IPAM replaces this with a declarative model:
+
+- The device declares **pools** (subnet + bridge + optional NAT) centrally in `device.json`.
+- Each container just says "attach me to pool *internal*" in its `run.json` — by name.
+- Pantavisor handles IP allocation, MAC derivation, bridge creation, NAT, and — in a follow-up — cross-pool isolation.
+
+The allocation is keyed by `(pool, container_name)` and persisted in-memory, so a container keeps its IP across stop/start cycles and auto-recovery restarts.
+
+## How It Works
+
+Setup runs once at pantavisor init, per revision:
+
+1. The parser reads `network.pools` from `device.json` and registers each pool in the IPAM registry.
+2. `pv_ipam_setup_bridges()` walks the registry, creates each bridge with the configured gateway IP, and — if the pool has `nat: true` — installs a MASQUERADE rule via nftables (iptables fallback).
+3. For every container that declares `PV_NETWORK_POOL`, the platform parser stores the pool name on `struct pv_platform_network_iface`. No network work happens yet.
+
+Per-container setup runs at `pv_platform_start`:
+
+1. A backend-plugin hook (see [Pre-start validation](#pre-start-validation)) gets a chance to reject the container if its baked config conflicts with IPAM.
+2. The IPAM allocator looks up the pool, picks the next free IP (or reserves a requested static one), and records the lease.
+3. A deterministic MAC is derived from the IP (`02:00:<IP_OCTETS>`), unless a static MAC was provided.
+4. The LXC plugin reads the assigned IP/MAC/bridge off the platform's network interfaces and injects `lxc.net.0.*` into the LXC config at start time. `'net'` is stripped from `lxc.namespace.keep` so the container gets its own netns.
+
+## Pools
+
+A pool is a named L3 segment with a bridge and optional NAT:
+
+```json
+{
+  "network": {
+    "pools": {
+      "internal": {
+        "type": "bridge",
+        "bridge": "pvbr0",
+        "subnet": "10.0.5.0/24",
+        "gateway": "10.0.5.1",
+        "nat": true
+      }
+    }
+  }
+}
+```
+
+The `nat` flag is independent per pool — you can have one pool that reaches the external network through a MASQUERADE rule, and another that is only routable on its own bridge.
+
+Today only `type: "bridge"` is wired up end-to-end. A `macvlan` type is sketched in the schema for future work.
+
+See [Pantavisor IPAM reference](../reference/pantavisor-ipam.md) for the full schema.
+
+## Per-Container Configuration
+
+A container opts into a pool from its `run.json` (typically generated via `args.json` / `PV_NETWORK_POOL`):
+
+```json
+{
+  "network": {
+    "mode": "pool",
+    "pool": "internal",
+    "hostname": "my-container"
+  }
+}
+```
+
+Static IP and MAC overrides are available under `interfaces[]` — see the reference for exact field names.
+
+## Pre-start validation
+
+A container that opts into an IPAM pool **must not** bake `lxc.net.*` entries into its `lxc.container.conf`. Pantavisor owns the container's network namespace when IPAM is in use and injects its own `lxc.net.0.*` at start time; silently overwriting a user-baked entry would leak orphan attributes (e.g. `lxc.net.0.macvlan.mode` from the previous type), and silently ignores the user's stated intent.
+
+The refusal is enforced through a plugin hook on the container backend (LXC today). If the backend plugin detects a conflict, it returns non-zero, `pv_platform_start` returns `-1`, and the error bubbles up through `pv_state_run` → `_pv_run` into `PV_STATE_ROLLBACK` (in a TESTING update) or `PV_STATE_REBOOT` (steady state) — the same path as an unknown pool reference.
+
+`lxc.namespace.keep = net` (present in pvr's default template) is not treated as a conflict; pantavisor strips `net` from the keep list at runtime when it injects the veth.
+
+Short version: **if a container declares a pool, don't hand-roll `lxc.net.*` in its image. If it hand-rolls `lxc.net.*`, don't declare a pool.**
+
+## Lifecycle
+
+- **Stop / start via the container-control API**: the lease is preserved. The container comes back with the same IP.
+- **Auto-recovery restart** (both immediate and delayed): also preserves the IP by reusing the existing lease in `pv_ipam_allocate`.
+- **Platform teardown** (state transition / reboot / rollback): releases the lease. The new revision's allocation starts clean.
+- **Unknown pool reference**: the container is refused at start time; the revision is torn down and rolled back in TESTING.
+
+## Isolation (follow-up)
+
+Today the kernel's default `FORWARD` policy is `ACCEPT`, so containers in different pools can reach each other at L3. That is a gap, tracked as a separate effort that defaults all pools to isolated and expects cross-pool service access to go through the [xconnect service mesh](xconnect.md) rather than flat routing.

--- a/docs/reference/pantavisor-ipam.md
+++ b/docs/reference/pantavisor-ipam.md
@@ -1,0 +1,139 @@
+# Pantavisor IPAM
+
+Reference for the IP Address Management (IPAM) subsystem: `device.json` pool schema, per-container `run.json` / `args.json` schema, lifecycle behaviors, and backend-plugin hook.
+
+For the narrative overview, see [Technical Overview — IPAM](../overview/ipam.md).
+
+## `device.json` — Pools
+
+Pools are declared under `network.pools`, keyed by pool name:
+
+```json
+{
+  "network": {
+    "pools": {
+      "internal": {
+        "type": "bridge",
+        "bridge": "pvbr0",
+        "subnet": "10.0.5.0/24",
+        "gateway": "10.0.5.1",
+        "nat": true
+      },
+      "lab": {
+        "type": "bridge",
+        "bridge": "pvbr1",
+        "subnet": "10.0.6.0/24",
+        "gateway": "10.0.6.1",
+        "nat": false
+      }
+    }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | yes | Pool backend. `"bridge"` is the supported value today; `"macvlan"` is reserved for future use. |
+| `bridge` | string | for `type=bridge` | Host-side bridge interface name. Pantavisor creates it if missing and assigns `gateway` to it. |
+| `parent` | string | for `type=macvlan` | Parent netdev for macvlan. |
+| `subnet` | string | yes | CIDR, e.g. `"10.0.5.0/24"`. |
+| `gateway` | string | yes | Host-side bridge IP, within the subnet. Served as the gateway for containers on this pool. |
+| `nat` | bool | no (default `false`) | When `true`, installs a MASQUERADE rule so containers in this pool can reach the external network through the host. When `false`, the pool is bridge-local only. |
+
+Pools are validated at parse time and registered in the in-memory IPAM registry; setup runs during `pv_ipam_setup_bridges()` in pantavisor init.
+
+## `run.json` — Per-Container Network
+
+A container declares how it attaches to IPAM under a top-level `network` block:
+
+```json
+{
+  "network": {
+    "mode": "pool",
+    "pool": "internal",
+    "hostname": "my-container"
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mode` | string | yes | Networking mode. `"pool"` opts the container into IPAM-managed networking. `"host"` uses the host netns. `"none"` leaves pantavisor out of the network setup entirely. |
+| `pool` | string | for `mode=pool` | Name of a pool declared in `device.json`. If the pool does not exist at start time the container is refused. |
+| `hostname` | string | no | Value assigned to `lxc.uts.name`; sets the container's hostname. |
+| `interfaces` | array | no | Per-interface overrides (static IP, static MAC). See below. |
+
+### `interfaces[]` overrides
+
+When the defaults (eth0, auto-allocated IP, derived MAC) are not enough:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Container-side interface name. Default `"eth0"`. |
+| `pool` | string | Pool name for this interface. Default: top-level `pool`. |
+| `ipv4_address` | string | Static IP (CIDR or bare address). Reserved in the pool; start fails if the IP is outside the subnet or already in use. |
+| `mac_address` | string | Static MAC. Default is deterministic `02:00:<ip_octets>`. |
+
+## `args.json` — PVR Template Variables
+
+When building a container image via `pvr` / Yocto, these arguments are templated into the generated `run.json`:
+
+| Arg | Target run.json field |
+|---|---|
+| `PV_NETWORK_POOL` | `network.pool` (also sets `network.mode = "pool"`) |
+| `PV_NETWORK_HOSTNAME` | `network.hostname` |
+| `PV_NETWORK_IP` | `network.interfaces[0].ipv4_address` |
+| `PV_NETWORK_MAC` | `network.interfaces[0].mac_address` |
+
+## Lease Lifecycle
+
+Leases are keyed by `(pool_name, container_name)` and held in each pool's in-memory `leases` list.
+
+| Event | Lease behavior |
+|---|---|
+| First start of a pool-using container | New lease allocated from `next_ip`, or reserved to a static IP. Deterministic MAC derived if none provided. |
+| `pvcontrol containers stop` / `start` | Lease preserved. The start path's `pv_ipam_allocate` finds the existing lease and reuses it. |
+| Auto-recovery restart (immediate and delayed) | Same — lease is reused. |
+| Platform teardown (state transition, reboot, rollback) | Lease released in `pv_platform_free`. |
+| IPAM alloc failure mid-start (e.g. static IP collision) | Any partial leases for the platform are released in the `ipam_error` rollback path. |
+
+## Backends and NAT Setup
+
+Bridge creation uses netlink. NAT installation uses a probe-based backend selection:
+
+1. If `nft` is available (`command -v nft` succeeds), install a `table ip nat` with a `postrouting` chain of `srcnat` priority, containing one `ip saddr <subnet> oifname != "<bridge>" masquerade` rule per pool.
+2. Otherwise, if `iptables` is available, fall back to `iptables -t nat -A POSTROUTING -s <subnet> ! -o <bridge> -j MASQUERADE`.
+3. If neither is available, a warning is logged and the pool runs without NAT.
+
+The preference order is nftables-first because every modern Linux kernel (3.13+, so any host from 2014 onward) has nftables native, and recent distros ship iptables as a compat shim over nftables anyway.
+
+## Pre-start Validation
+
+Container-backend plugins can reject a start with backend-specific config problems via `pv_validate_container_config(p, conf_file)` — a dlsym'd symbol on the backend plugin library. If present, pantavisor calls it from `pv_platform_start` before the IPAM allocation block. A non-zero return refuses the start; `pv_state_run` returns `-1` and the error bubbles into `PV_STATE_ROLLBACK` (TESTING update) or `PV_STATE_REBOOT` (steady state).
+
+The LXC plugin uses this hook to refuse a pool-using container whose `lxc.container.conf` bakes `lxc.net.*` entries. That combination is ambiguous: pantavisor's own `lxc.net.0.*` injection at start time would overwrite parts of the baked config but can leave orphan attributes from the previous type. The defensive policy is to refuse and ask the user to remove the conflict. `lxc.namespace.keep = net` (present in pvr's default template) is not flagged — pantavisor strips `net` from the keep list at runtime when it injects the veth.
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| `pool` field references an undefined pool | Refuse at `pv_platform_start`: `refusing to start, triggering rollback if in try-boot`. Bubbles up to rollback/reboot. |
+| Baked `lxc.net.*` in a pool-using container | Refuse via the LXC plugin's `validate_config` hook. Bubbles up to rollback/reboot. |
+| Static IP outside pool subnet | Refuse at `pv_platform_start`. Bubbles up. |
+| Static IP already in use | Refuse at `pv_platform_start`. Bubbles up. |
+| Pool exhausted (no free IPs) | Refuse at `pv_platform_start`. Bubbles up. |
+| NAT setup fails | Logged as WARN; the pool is still usable for same-pool traffic. |
+
+## Zero-Impact Invariant for Non-IPAM Devices
+
+If a device's `device.json` has no `network.pools` block and no container's `run.json` has a `network` block:
+
+- `pv_ipam_init()` / `pv_ipam_setup_bridges()` are called but operate on an empty registry — no bridges, no netfilter rules, no routes.
+- All per-container IPAM code paths in `platforms.c`, `state.c`, and `plugins/pv_lxc.c` are guarded by `p->network && p->network->mode == NET_MODE_POOL` and skip.
+- The LXC plugin's `pv_validate_container_config` hook also short-circuits when the platform is not in `NET_MODE_POOL`.
+
+Net observable effect: two INFO log lines at boot (`IPAM subsystem initialized` and a no-op setup). No behavioral change otherwise.

--- a/docs/reference/pantavisor-ipam.md
+++ b/docs/reference/pantavisor-ipam.md
@@ -111,6 +111,19 @@ Bridge creation uses netlink. NAT installation uses a probe-based backend select
 
 The preference order is nftables-first because every modern Linux kernel (3.13+, so any host from 2014 onward) has nftables native, and recent distros ship iptables as a compat shim over nftables anyway.
 
+## Static-IP Reservation from Backend Config
+
+A second plugin hook — `pv_enumerate_static_ips(p, conf_file, cb, ctx)` — lets pantavisor reserve any hard-coded IPv4 addresses in the container's backend config from the pool allocator, so IPAM never hands the same address out twice.
+
+Called once at startup from `pv_platforms_reserve_static_ips(state)` right after `pv_ipam_setup_bridges()`. For each platform that has a backend with this hook, every configured address file is scanned; the hook invokes `cb(ip_in_host_order, ctx)` for each hard-coded address it finds. The default callback routes that into `pv_ipam_reserve_static(ip, source)`:
+
+- If the IP falls inside any pool's subnet, a lease tagged `pv:static:<source>` is added to that pool. `is_ip_available()` already filters these out, so no change to `pv_ipam_allocate()` is needed.
+- If the IP is outside every pool's subnet: logged at DEBUG, ignored. The container is managing its own networking on a bridge pantavisor doesn't know about.
+- If the IP clashes with a pool's gateway: logged at WARN, not reserved. The container will likely fail to bring that interface up anyway.
+- Duplicate reservations (same IP already leased) are skipped.
+
+The LXC plugin implements this by grepping `lxc.container.conf` for `lxc.net.N.ipv4.address = X.Y.Z.W[/M]` lines, ignoring the `auto` and `dhcp` sentinels. Plugins without the hook contribute no reservations — IPAM then allocates from the full subnet minus the gateway and existing dynamic leases.
+
 ## Pre-start Validation
 
 Container-backend plugins can reject a start with backend-specific config problems via `pv_validate_container_config(p, conf_file)` — a dlsym'd symbol on the backend plugin library. If present, pantavisor calls it from `pv_platform_start` before the IPAM allocation block. A non-zero return refuses the start; `pv_state_run` returns `-1` and the error bubbles into `PV_STATE_ROLLBACK` (TESTING update) or `PV_STATE_REBOOT` (steady state).

--- a/ipam.c
+++ b/ipam.c
@@ -1,0 +1,696 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/sockios.h>
+
+#include "ipam.h"
+#include "config.h"
+#include "utils/str.h"
+
+#define MODULE_NAME "ipam"
+#define pv_log(level, msg, ...)                                                \
+	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
+	     ##__VA_ARGS__)
+#include "log.h"
+
+// Global IPAM state
+static struct pv_ipam ipam_state = { .initialized = false };
+
+int pv_ipam_init(void)
+{
+	if (ipam_state.initialized)
+		return 0;
+
+	dl_list_init(&ipam_state.pools);
+	ipam_state.initialized = true;
+
+	pv_log(INFO, "IPAM subsystem initialized");
+	return 0;
+}
+
+void pv_ipam_free(void)
+{
+	struct pv_ip_pool *pool, *pool_tmp;
+	struct pv_ip_lease *lease, *lease_tmp;
+
+	dl_list_for_each_safe(pool, pool_tmp, &ipam_state.pools,
+			      struct pv_ip_pool, list)
+	{
+		dl_list_for_each_safe(lease, lease_tmp, &pool->leases,
+				      struct pv_ip_lease, list)
+		{
+			dl_list_del(&lease->list);
+			if (lease->container_name)
+				free(lease->container_name);
+			free(lease);
+		}
+		dl_list_del(&pool->list);
+		if (pool->name)
+			free(pool->name);
+		if (pool->bridge)
+			free(pool->bridge);
+		if (pool->parent)
+			free(pool->parent);
+		free(pool);
+	}
+
+	ipam_state.initialized = false;
+	pv_log(INFO, "IPAM subsystem freed");
+}
+
+struct pv_ipam *pv_ipam_get(void)
+{
+	return &ipam_state;
+}
+
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask)
+{
+	char *cidr_copy, *slash;
+	int prefix_len;
+	struct in_addr addr;
+
+	if (!cidr || !subnet || !mask)
+		return -1;
+
+	cidr_copy = strdup(cidr);
+	if (!cidr_copy)
+		return -1;
+
+	slash = strchr(cidr_copy, '/');
+	if (!slash) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*slash = '\0';
+	prefix_len = atoi(slash + 1);
+
+	if (prefix_len < 0 || prefix_len > 32) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	if (inet_pton(AF_INET, cidr_copy, &addr) != 1) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*subnet = addr.s_addr;
+
+	if (prefix_len == 0)
+		*mask = 0;
+	else
+		*mask = htonl(~((1 << (32 - prefix_len)) - 1));
+
+	free(cidr_copy);
+	return 0;
+}
+
+char *pv_ipam_ip_to_str(uint32_t ip)
+{
+	struct in_addr addr;
+	addr.s_addr = ip;
+	return strdup(inet_ntoa(addr));
+}
+
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask)
+{
+	return (ip & mask) == (subnet & mask);
+}
+
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat)
+{
+	struct pv_ip_pool *pool;
+	uint32_t subnet, mask;
+	struct in_addr gw_addr;
+
+	if (!name || !bridge_or_parent || !subnet_cidr || !gateway) {
+		pv_log(ERROR, "invalid pool parameters");
+		return NULL;
+	}
+
+	if (pv_ipam_parse_cidr(subnet_cidr, &subnet, &mask) < 0) {
+		pv_log(ERROR, "invalid subnet CIDR: %s", subnet_cidr);
+		return NULL;
+	}
+
+	if (inet_pton(AF_INET, gateway, &gw_addr) != 1) {
+		pv_log(ERROR, "invalid gateway IP: %s", gateway);
+		return NULL;
+	}
+
+	// Check if pool already exists
+	if (pv_ipam_find_pool(name)) {
+		pv_log(WARN, "pool '%s' already exists", name);
+		return NULL;
+	}
+
+	pool = calloc(1, sizeof(struct pv_ip_pool));
+	if (!pool)
+		return NULL;
+
+	pool->name = strdup(name);
+	pool->type = type;
+	pool->subnet = subnet;
+	pool->mask = mask;
+	pool->gateway = gw_addr.s_addr;
+	pool->nat = nat;
+	pool->bridge_created = false;
+
+	if (type == POOL_TYPE_BRIDGE)
+		pool->bridge = strdup(bridge_or_parent);
+	else
+		pool->parent = strdup(bridge_or_parent);
+
+	// Start allocating from gateway + 1
+	pool->next_ip = ntohl(gw_addr.s_addr) + 1;
+
+	dl_list_init(&pool->leases);
+	dl_list_init(&pool->list);
+	dl_list_add_tail(&ipam_state.pools, &pool->list);
+
+	pv_log(INFO, "added pool '%s': type=%s, subnet=%s, gateway=%s, nat=%s",
+	       name, type == POOL_TYPE_BRIDGE ? "bridge" : "macvlan",
+	       subnet_cidr, gateway, nat ? "yes" : "no");
+
+	return pool;
+}
+
+struct pv_ip_pool *pv_ipam_find_pool(const char *name)
+{
+	struct pv_ip_pool *pool;
+
+	if (!name)
+		return NULL;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (strcmp(pool->name, name) == 0)
+			return pool;
+	}
+
+	return NULL;
+}
+
+static bool is_ip_available(struct pv_ip_pool *pool, uint32_t ip)
+{
+	struct pv_ip_lease *lease;
+
+	// Check if IP is the gateway
+	if (ip == pool->gateway)
+		return false;
+
+	// Check if IP is in existing leases
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (lease->ip == ip)
+			return false;
+	}
+
+	return true;
+}
+
+char *pv_ipam_allocate(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *existing;
+	uint32_t ip, ip_net;
+	uint32_t broadcast, max_ip;
+	char *result;
+	int prefix_len;
+	uint32_t mask_host;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return NULL;
+	}
+
+	// Check if container already has a lease
+	existing = pv_ipam_get_lease(pool_name, container_name);
+	if (existing) {
+		// Reuse existing lease
+		char *ip_str = pv_ipam_ip_to_str(existing->ip);
+		mask_host = ntohl(pool->mask);
+		prefix_len = __builtin_popcount(mask_host);
+		result = malloc(strlen(ip_str) + 4);
+		sprintf(result, "%s/%d", ip_str, prefix_len);
+		free(ip_str);
+		pv_log(DEBUG, "reusing existing lease for %s: %s",
+		       container_name, result);
+		return result;
+	}
+
+	// Calculate broadcast address
+	broadcast = pool->subnet | ~pool->mask;
+	max_ip = ntohl(broadcast) - 1; // Last usable IP
+
+	// Find next available IP
+	ip = pool->next_ip;
+	while (ip <= max_ip) {
+		ip_net = htonl(ip);
+		if (is_ip_available(pool, ip_net)) {
+			// Found available IP
+			lease = calloc(1, sizeof(struct pv_ip_lease));
+			if (!lease)
+				return NULL;
+
+			lease->container_name = strdup(container_name);
+			lease->ip = ip_net;
+			lease->in_use = true;
+			dl_list_init(&lease->list);
+			dl_list_add_tail(&pool->leases, &lease->list);
+
+			// Update next_ip cursor
+			pool->next_ip = ip + 1;
+
+			// Format result as CIDR
+			char *ip_str = pv_ipam_ip_to_str(ip_net);
+			mask_host = ntohl(pool->mask);
+			prefix_len = __builtin_popcount(mask_host);
+			result = malloc(strlen(ip_str) + 4);
+			sprintf(result, "%s/%d", ip_str, prefix_len);
+			free(ip_str);
+
+			pv_log(INFO, "allocated %s to %s from pool %s", result,
+			       container_name, pool_name);
+			return result;
+		}
+		ip++;
+	}
+
+	pv_log(ERROR, "no available IPs in pool '%s'", pool_name);
+	return NULL;
+}
+
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+	uint32_t ip, mask;
+	struct in_addr addr;
+	char *ip_only, *slash;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return -1;
+	}
+
+	// Parse IP from CIDR
+	ip_only = strdup(ip_cidr);
+	slash = strchr(ip_only, '/');
+	if (slash)
+		*slash = '\0';
+
+	if (inet_pton(AF_INET, ip_only, &addr) != 1) {
+		pv_log(ERROR, "invalid IP: %s", ip_only);
+		free(ip_only);
+		return -1;
+	}
+	ip = addr.s_addr;
+	free(ip_only);
+
+	// Check if IP is in pool subnet
+	if (!pv_ipam_ip_in_subnet(ip, pool->subnet, pool->mask)) {
+		pv_log(ERROR, "IP %s not in pool '%s' subnet", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Check if IP is available
+	if (!is_ip_available(pool, ip)) {
+		pv_log(ERROR, "IP %s already in use in pool '%s'", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Create lease
+	lease = calloc(1, sizeof(struct pv_ip_lease));
+	if (!lease)
+		return -1;
+
+	lease->container_name = strdup(container_name);
+	lease->ip = ip;
+	lease->in_use = true;
+	dl_list_init(&lease->list);
+	dl_list_add_tail(&pool->leases, &lease->list);
+
+	pv_log(INFO, "reserved %s for %s in pool %s", ip_cidr, container_name,
+	       pool_name);
+	return 0;
+}
+
+void pv_ipam_release(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *tmp;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return;
+
+	dl_list_for_each_safe(lease, tmp, &pool->leases, struct pv_ip_lease,
+			      list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0) {
+			char *ip_str = pv_ipam_ip_to_str(lease->ip);
+			pv_log(INFO, "released %s from %s in pool %s", ip_str,
+			       container_name, pool_name);
+			free(ip_str);
+
+			dl_list_del(&lease->list);
+			free(lease->container_name);
+			free(lease);
+			return;
+		}
+	}
+}
+
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return NULL;
+
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0)
+			return lease;
+	}
+
+	return NULL;
+}
+
+char *pv_ipam_generate_mac(uint32_t ip_net)
+{
+	char *mac;
+	uint32_t ip;
+
+	if (!ip_net)
+		return NULL;
+
+	// Convert from network byte order to host byte order
+	ip = ntohl(ip_net);
+
+	// Format: 02:00:XX:XX:XX:XX where XX:XX:XX:XX is the IP address octets
+	// 02 = locally administered, unicast
+	// Using IP ensures uniqueness within pool (IPs are unique)
+	// Example: IP 10.0.5.2 → MAC 02:00:0a:00:05:02
+	mac = malloc(18);
+	if (!mac)
+		return NULL;
+
+	snprintf(mac, 18, "02:00:%02x:%02x:%02x:%02x", (ip >> 24) & 0xff,
+		 (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
+
+	return mac;
+}
+
+static int setup_bridge(struct pv_ip_pool *pool)
+{
+	int fd, sockfd, ret = 0;
+	struct ifreq ifr;
+	struct sockaddr_in sai;
+	char *gateway_str;
+	uint32_t mask_host;
+	int prefix_len;
+
+	if (!pool || pool->type != POOL_TYPE_BRIDGE || !pool->bridge)
+		return -1;
+
+	if (pool->bridge_created)
+		return 0;
+
+	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	if (fd < 0) {
+		pv_log(ERROR, "unable to create socket: %s", strerror(errno));
+		return -1;
+	}
+
+	// Create bridge
+	ret = ioctl(fd, SIOCBRADDBR, pool->bridge);
+	if (ret < 0 && errno != EEXIST) {
+		pv_log(ERROR, "unable to create bridge %s: %s", pool->bridge,
+		       strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	// Configure bridge IP
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		pv_log(ERROR, "unable to create dgram socket: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, pool->bridge, IFNAMSIZ - 1);
+
+	// Set IP address
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->gateway;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFADDR, &ifr);
+	if (ret < 0) {
+		gateway_str = pv_ipam_ip_to_str(pool->gateway);
+		pv_log(ERROR, "unable to set IP %s on %s: %s", gateway_str,
+		       pool->bridge, strerror(errno));
+		free(gateway_str);
+		close(sockfd);
+		return -1;
+	}
+
+	// Set netmask
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->mask;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFNETMASK, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to set netmask on %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	// Bring interface up
+	ret = ioctl(sockfd, SIOCGIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to get flags for %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+	ret = ioctl(sockfd, SIOCSIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to bring up %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	close(sockfd);
+
+	pool->bridge_created = true;
+
+	gateway_str = pv_ipam_ip_to_str(pool->gateway);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+	pv_log(INFO, "created bridge %s with IP %s/%d", pool->bridge,
+	       gateway_str, prefix_len);
+	free(gateway_str);
+
+	return 0;
+}
+
+static int setup_nat(struct pv_ip_pool *pool)
+{
+	char cmd[512];
+	char *subnet_str;
+	uint32_t mask_host;
+	int prefix_len;
+	int ret;
+
+	if (!pool || !pool->nat)
+		return 0;
+
+	subnet_str = pv_ipam_ip_to_str(pool->subnet);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+
+	// Enable IP forwarding
+	ret = system("echo 1 > /proc/sys/net/ipv4/ip_forward");
+	if (ret != 0) {
+		pv_log(WARN, "failed to enable IP forwarding");
+	}
+
+	// Try iptables first, fall back to nftables
+	snprintf(
+		cmd, sizeof(cmd),
+		"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
+		"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
+		subnet_str, prefix_len, pool->bridge, subnet_str, prefix_len,
+		pool->bridge);
+
+	ret = system(cmd);
+	if (ret != 0) {
+		// Try nftables
+		snprintf(
+			cmd, sizeof(cmd),
+			"nft add table nat 2>/dev/null; "
+			"nft add chain nat postrouting { type nat hook postrouting priority 100 \\; } 2>/dev/null; "
+			"nft add rule nat postrouting ip saddr %s/%d oifname != \"%s\" masquerade 2>/dev/null",
+			subnet_str, prefix_len, pool->bridge);
+		ret = system(cmd);
+		if (ret != 0) {
+			pv_log(WARN, "failed to setup NAT for pool %s",
+			       pool->name);
+		} else {
+			pv_log(INFO, "setup NAT (nftables) for pool %s",
+			       pool->name);
+		}
+	} else {
+		pv_log(INFO, "setup NAT (iptables) for pool %s", pool->name);
+	}
+
+	free(subnet_str);
+	return 0;
+}
+
+int pv_ipam_setup_bridges(void)
+{
+	struct pv_ip_pool *pool;
+	int ret = 0;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (pool->type == POOL_TYPE_BRIDGE) {
+			if (setup_bridge(pool) < 0)
+				ret = -1;
+			if (pool->nat)
+				setup_nat(pool);
+		}
+	}
+
+	return ret;
+}
+
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode)
+{
+	struct pv_platform_network *net;
+
+	net = calloc(1, sizeof(struct pv_platform_network));
+	if (!net)
+		return NULL;
+
+	net->mode = mode;
+	dl_list_init(&net->interfaces);
+
+	return net;
+}
+
+void pv_platform_network_free(struct pv_platform_network *net)
+{
+	struct pv_platform_network_iface *iface, *tmp;
+
+	if (!net)
+		return;
+
+	dl_list_for_each_safe(iface, tmp, &net->interfaces,
+			      struct pv_platform_network_iface, list)
+	{
+		dl_list_del(&iface->list);
+		if (iface->name)
+			free(iface->name);
+		if (iface->pool)
+			free(iface->pool);
+		if (iface->ipv4_address)
+			free(iface->ipv4_address);
+		if (iface->ipv4_gateway)
+			free(iface->ipv4_gateway);
+		if (iface->bridge)
+			free(iface->bridge);
+		if (iface->veth_host)
+			free(iface->veth_host);
+		if (iface->mac_address)
+			free(iface->mac_address);
+		if (iface->static_ip)
+			free(iface->static_ip);
+		if (iface->static_mac)
+			free(iface->static_mac);
+		free(iface);
+	}
+
+	if (net->hostname)
+		free(net->hostname);
+	free(net);
+}
+
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool)
+{
+	struct pv_platform_network_iface *iface;
+
+	if (!net || !name || !pool)
+		return NULL;
+
+	iface = calloc(1, sizeof(struct pv_platform_network_iface));
+	if (!iface)
+		return NULL;
+
+	iface->name = strdup(name);
+	iface->pool = strdup(pool);
+	dl_list_init(&iface->list);
+	dl_list_add_tail(&net->interfaces, &iface->list);
+
+	return iface;
+}

--- a/ipam.c
+++ b/ipam.c
@@ -572,17 +572,14 @@ static int setup_nat(struct pv_ip_pool *pool)
 		pv_log(WARN, "failed to enable IP forwarding");
 	}
 
-	// Try iptables first, fall back to nftables
-	snprintf(
-		cmd, sizeof(cmd),
-		"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
-		"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
-		subnet_str, prefix_len, pool->bridge, subnet_str, prefix_len,
-		pool->bridge);
+	// Prefer nftables (default on modern distros and kernel-native since
+	// 3.13); fall back to iptables if nft is missing or fails (e.g. a BSP
+	// with only the legacy tools, or kernel without nf_tables).
+	bool have_nft = system("command -v nft >/dev/null 2>&1") == 0;
+	bool have_iptables = system("command -v iptables >/dev/null 2>&1") == 0;
 
-	ret = system(cmd);
-	if (ret != 0) {
-		// Try nftables
+	ret = -1;
+	if (have_nft) {
 		snprintf(
 			cmd, sizeof(cmd),
 			"nft add table nat 2>/dev/null; "
@@ -590,15 +587,35 @@ static int setup_nat(struct pv_ip_pool *pool)
 			"nft add rule nat postrouting ip saddr %s/%d oifname != \"%s\" masquerade 2>/dev/null",
 			subnet_str, prefix_len, pool->bridge);
 		ret = system(cmd);
-		if (ret != 0) {
-			pv_log(WARN, "failed to setup NAT for pool %s",
-			       pool->name);
-		} else {
+		if (ret == 0) {
 			pv_log(INFO, "setup NAT (nftables) for pool %s",
 			       pool->name);
 		}
-	} else {
-		pv_log(INFO, "setup NAT (iptables) for pool %s", pool->name);
+	}
+
+	if (ret != 0 && have_iptables) {
+		snprintf(
+			cmd, sizeof(cmd),
+			"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
+			"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
+			subnet_str, prefix_len, pool->bridge, subnet_str,
+			prefix_len, pool->bridge);
+		ret = system(cmd);
+		if (ret == 0) {
+			pv_log(INFO, "setup NAT (iptables) for pool %s",
+			       pool->name);
+		}
+	}
+
+	if (ret != 0) {
+		if (!have_nft && !have_iptables) {
+			pv_log(WARN,
+			       "neither nftables (nft) nor iptables available; cannot setup NAT for pool %s",
+			       pool->name);
+		} else {
+			pv_log(WARN, "failed to setup NAT for pool %s",
+			       pool->name);
+		}
 	}
 
 	free(subnet_str);

--- a/ipam.c
+++ b/ipam.c
@@ -376,6 +376,80 @@ int pv_ipam_reserve(const char *pool_name, const char *container_name,
 	return 0;
 }
 
+// Reserve a static IP in whatever pool's subnet contains it, so
+// pv_ipam_allocate's is_ip_available check skips it. Called during setup
+// to walk every container's backend-specific static assignments (e.g. LXC
+// lxc.net.N.ipv4.address entries). The lease is tagged with a synthetic
+// container name derived from `source` so it never collides with a real
+// container name lookup.
+int pv_ipam_reserve_static(uint32_t ip_network_order, const char *source)
+{
+	struct pv_ip_pool *pool, *match = NULL;
+	struct pv_ip_lease *lease;
+	char tag[128];
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (pv_ipam_ip_in_subnet(ip_network_order, pool->subnet,
+					 pool->mask)) {
+			match = pool;
+			break;
+		}
+	}
+
+	if (!match) {
+		// The address doesn't belong to any pool — the container is
+		// attaching to a bridge/subnet we don't manage, so there's
+		// nothing to reserve. Log and move on.
+		char *ip_str = pv_ipam_ip_to_str(ip_network_order);
+		pv_log(DEBUG,
+		       "static IP %s (from %s) is outside any pool subnet — not reserving",
+		       ip_str, source ? source : "<unknown>");
+		free(ip_str);
+		return -1;
+	}
+
+	if (ip_network_order == match->gateway) {
+		char *ip_str = pv_ipam_ip_to_str(ip_network_order);
+		pv_log(WARN,
+		       "static IP %s (from %s) clashes with pool '%s' gateway — not reserving",
+		       ip_str, source ? source : "<unknown>", match->name);
+		free(ip_str);
+		return -1;
+	}
+
+	// If this IP is already leased, skip (duplicate-reserve is fine).
+	dl_list_for_each(lease, &match->leases, struct pv_ip_lease, list)
+	{
+		if (lease->ip == ip_network_order) {
+			char *ip_str = pv_ipam_ip_to_str(ip_network_order);
+			pv_log(DEBUG,
+			       "static IP %s (from %s) already reserved in pool '%s' — skip",
+			       ip_str, source ? source : "<unknown>",
+			       match->name);
+			free(ip_str);
+			return 0;
+		}
+	}
+
+	lease = calloc(1, sizeof(struct pv_ip_lease));
+	if (!lease)
+		return -1;
+
+	snprintf(tag, sizeof(tag), "pv:static:%s", source ? source : "unknown");
+	lease->container_name = strdup(tag);
+	lease->ip = ip_network_order;
+	lease->in_use = true;
+	dl_list_init(&lease->list);
+	dl_list_add_tail(&match->leases, &lease->list);
+
+	char *ip_str = pv_ipam_ip_to_str(ip_network_order);
+	pv_log(INFO, "reserved static IP %s (from %s) in pool '%s'", ip_str,
+	       source ? source : "<unknown>", match->name);
+	free(ip_str);
+	return 0;
+}
+
 void pv_ipam_release(const char *pool_name, const char *container_name)
 {
 	struct pv_ip_pool *pool;
@@ -388,7 +462,8 @@ void pv_ipam_release(const char *pool_name, const char *container_name)
 	dl_list_for_each_safe(lease, tmp, &pool->leases, struct pv_ip_lease,
 			      list)
 	{
-		if (strcmp(lease->container_name, container_name) == 0) {
+		if (lease->container_name && container_name &&
+		    strcmp(lease->container_name, container_name) == 0) {
 			char *ip_str = pv_ipam_ip_to_str(lease->ip);
 			pv_log(INFO, "released %s from %s in pool %s", ip_str,
 			       container_name, pool_name);

--- a/ipam.h
+++ b/ipam.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PV_IPAM_H
+#define PV_IPAM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <netinet/in.h>
+
+#include "utils/list.h"
+
+// Pool types
+typedef enum { POOL_TYPE_BRIDGE, POOL_TYPE_MACVLAN } pv_pool_type_t;
+
+// IP lease - tracks allocated IPs
+struct pv_ip_lease {
+	char *container_name;
+	uint32_t ip; // Network byte order
+	bool in_use;
+	struct dl_list list; // pv_ip_lease
+};
+
+// IP pool - defines a network pool from device.json
+struct pv_ip_pool {
+	char *name; // Pool name (e.g., "internal")
+	pv_pool_type_t type; // bridge or macvlan
+	char *bridge; // Bridge interface name (for type=bridge)
+	char *parent; // Parent interface (for type=macvlan)
+	uint32_t subnet; // Subnet address (network byte order)
+	uint32_t mask; // Subnet mask (network byte order)
+	uint32_t gateway; // Gateway IP (network byte order)
+	bool nat; // Enable NAT
+	bool bridge_created; // Bridge already created
+	uint32_t next_ip; // Next IP to allocate (host byte order)
+	struct dl_list leases; // pv_ip_lease
+	struct dl_list list; // pv_ip_pool
+};
+
+// Platform network mode
+typedef enum {
+	NET_MODE_NONE, // No network config (use static lxc.container.conf)
+	NET_MODE_HOST, // Host namespace
+	NET_MODE_POOL // Pool-based dynamic
+} pv_net_mode_t;
+
+// Platform network interface config
+struct pv_platform_network_iface {
+	char *name; // Container-side interface (e.g., "eth0")
+	char *pool; // Pool name from device.json
+	char *ipv4_address; // Assigned IP in CIDR notation
+	char *ipv4_gateway; // Gateway IP
+	char *bridge; // Host bridge name
+	char *veth_host; // Host-side veth name
+	char *mac_address; // MAC address
+	char *static_ip; // Static IP override from run.json (optional)
+	char *static_mac; // Static MAC override from run.json (optional)
+	struct dl_list list; // pv_platform_network_iface
+};
+
+// Platform network config (from run.json)
+struct pv_platform_network {
+	pv_net_mode_t mode;
+	char *hostname;
+	struct dl_list interfaces; // pv_platform_network_iface
+};
+
+// Global IPAM state
+struct pv_ipam {
+	struct dl_list pools; // pv_ip_pool
+	bool initialized;
+};
+
+// Initialize IPAM subsystem
+int pv_ipam_init(void);
+
+// Cleanup IPAM subsystem
+void pv_ipam_free(void);
+
+// Get global IPAM instance
+struct pv_ipam *pv_ipam_get(void);
+
+// Add a pool from device.json
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat);
+
+// Find a pool by name
+struct pv_ip_pool *pv_ipam_find_pool(const char *name);
+
+// Allocate an IP from a pool for a container
+// Returns allocated IP in CIDR notation (e.g., "10.0.3.2/24") or NULL on failure
+char *pv_ipam_allocate(const char *pool_name, const char *container_name);
+
+// Reserve a specific IP in a pool (for static configs)
+// Returns 0 on success, -1 if IP already taken or not in pool
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr);
+
+// Release an IP back to the pool
+void pv_ipam_release(const char *pool_name, const char *container_name);
+
+// Get the lease for a container in a pool
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name);
+
+// Setup bridges for all pools (called during init)
+int pv_ipam_setup_bridges(void);
+
+// Generate deterministic MAC address from container name
+// Returns MAC in format "02:pv:XX:XX:XX:XX"
+char *pv_ipam_generate_mac(uint32_t ip);
+
+// Parse CIDR notation (e.g., "10.0.3.0/24") into subnet and mask
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask);
+
+// Format IP address to string
+char *pv_ipam_ip_to_str(uint32_t ip);
+
+// Check if IP is in subnet
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask);
+
+// Create platform network config
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode);
+
+// Free platform network config
+void pv_platform_network_free(struct pv_platform_network *net);
+
+// Add interface to platform network
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool);
+
+#endif // PV_IPAM_H

--- a/ipam.h
+++ b/ipam.h
@@ -120,6 +120,14 @@ int pv_ipam_reserve(const char *pool_name, const char *container_name,
 // Release an IP back to the pool
 void pv_ipam_release(const char *pool_name, const char *container_name);
 
+// Reserve a static IP inside the pool that matches it, without attributing
+// ownership to any container. Used to keep IPAM's dynamic allocator from
+// handing out an address that some other component (e.g. a container with
+// a hard-coded lxc.net.N.ipv4.address) already claims. Returns 0 if the
+// IP was successfully reserved (or was already reserved), or -1 if the IP
+// is not in any pool's subnet.
+int pv_ipam_reserve_static(uint32_t ip_network_order, const char *source);
+
 // Get the lease for a container in a pool
 struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
 				      const char *container_name);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -71,6 +71,7 @@
 #include "pantahub/pantahub.h"
 
 #include "parser/parser.h"
+#include "ipam.h"
 
 #include "utils/timer.h"
 #include "utils/fs.h"
@@ -180,6 +181,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_state_t next_state = PV_STATE_ROLLBACK;
 	char *json = NULL;
 
+	// Initialize IPAM subsystem
+	pv_ipam_init();
+
 	// resume update if we are booting up to test a new revision
 	if (pv_update_resume(pv_pantahub_queue_progress)) {
 		pv_log(ERROR, "update could not be resumed");
@@ -239,6 +243,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_update_set_factory();
 
 	pv_state_load_done(pv->state);
+
+	// Setup IPAM network bridges (must happen after state parsing)
+	pv_ipam_setup_bridges();
 
 	// once state is verified, we can load credentials, in case they are stored in a volume
 	if (!pv_update_get_state()) {

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -247,6 +247,11 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	// Setup IPAM network bridges (must happen after state parsing)
 	pv_ipam_setup_bridges();
 
+	// Reserve static IPs baked into each container's backend config so
+	// IPAM's dynamic allocator doesn't hand them to someone else. Runs
+	// after bridge+pool setup so the lookups find the right subnet.
+	pv_platforms_reserve_static_ips(pv->state);
+
 	// once state is verified, we can load credentials, in case they are stored in a volume
 	if (!pv_update_get_state()) {
 		// mount bsp volumes

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -52,6 +52,7 @@
 #include "state.h"
 #include "pvlogger.h"
 #include "paths.h"
+#include "ipam.h"
 
 #include "utils/str.h"
 #include "utils/fs.h"
@@ -1499,6 +1500,106 @@ static int do_action_for_auto_recovery(struct json_key_action *jka, char *value)
 	return 0;
 }
 
+static int do_action_for_network(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+	struct pv_platform *p = *bundle->platform;
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *mode_str = NULL;
+	char *pool = NULL;
+	char *hostname = NULL;
+	char *static_ip = NULL;
+	char *static_mac = NULL;
+	char *buf = jka->buf;
+	pv_net_mode_t mode = NET_MODE_NONE;
+
+	if (!p || !buf)
+		return -1;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "wrong format network");
+		return -1;
+	}
+
+	// Check for mode first
+	mode_str = pv_json_get_value(buf, "mode", tokv, tokc);
+	if (mode_str) {
+		if (strcmp(mode_str, "host") == 0) {
+			mode = NET_MODE_HOST;
+		} else if (strcmp(mode_str, "pool") == 0) {
+			mode = NET_MODE_POOL;
+		}
+		free(mode_str);
+	}
+
+	// Check for pool (shorthand for single interface)
+	pool = pv_json_get_value(buf, "pool", tokv, tokc);
+	if (pool) {
+		mode = NET_MODE_POOL;
+	}
+
+	hostname = pv_json_get_value(buf, "hostname", tokv, tokc);
+	static_ip = pv_json_get_value(buf, "ip", tokv, tokc);
+	static_mac = pv_json_get_value(buf, "mac", tokv, tokc);
+
+	// Create network config for the platform
+	if (mode != NET_MODE_NONE) {
+		p->network = pv_platform_network_new(mode);
+		if (!p->network) {
+			pv_log(ERROR, "failed to create network config for %s",
+			       p->name);
+			ret = -1;
+			goto out;
+		}
+
+		if (hostname) {
+			p->network->hostname = strdup(hostname);
+		}
+
+		// If pool specified, create default eth0 interface
+		if (mode == NET_MODE_POOL && pool) {
+			struct pv_platform_network_iface *iface;
+			iface = pv_platform_network_add_iface(p->network,
+							      "eth0", pool);
+			if (!iface) {
+				pv_log(ERROR, "failed to add interface for %s",
+				       p->name);
+				ret = -1;
+				goto out;
+			}
+			// Set static overrides if provided
+			if (static_ip) {
+				iface->static_ip = strdup(static_ip);
+			}
+			if (static_mac) {
+				iface->static_mac = strdup(static_mac);
+			}
+			pv_log(DEBUG,
+			       "platform '%s' network: pool=%s, hostname=%s, ip=%s, mac=%s",
+			       p->name, pool, hostname ? hostname : "(none)",
+			       static_ip ? static_ip : "(auto)",
+			       static_mac ? static_mac : "(auto)");
+		} else if (mode == NET_MODE_HOST) {
+			pv_log(DEBUG, "platform '%s' network: mode=host",
+			       p->name);
+		}
+	}
+
+out:
+	if (pool)
+		free(pool);
+	if (hostname)
+		free(hostname);
+	if (static_ip)
+		free(static_ip);
+	if (static_mac)
+		free(static_mac);
+	if (tokv)
+		free(tokv);
+	return ret;
+}
+
 static int do_action_for_one_volume(struct json_key_action *jka, char *value)
 { /*
 	 * Opaque will contain the platform
@@ -1698,6 +1799,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_roles_array, false),
 		ADD_JKA_ENTRY("auto_recovery", JSMN_OBJECT, &bundle,
 			      do_action_for_auto_recovery, false),
+		ADD_JKA_ENTRY("network", JSMN_OBJECT, &bundle,
+			      do_action_for_network, false),
 		ADD_JKA_ENTRY("config", JSMN_STRING, &config, NULL, true),
 		ADD_JKA_ENTRY("share", JSMN_STRING, &shares, NULL, true),
 		ADD_JKA_ENTRY("root-volume", JSMN_STRING, &bundle,
@@ -2142,6 +2245,160 @@ out:
 	return this;
 }
 
+static int parse_network_pools(struct pv_state *s, char *buf)
+{
+	int tokc, size, ret = 1;
+	char *str = NULL;
+	jsmntok_t *tokv, *t, *poolv = NULL;
+	jsmntok_t **k, **keys;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network pools");
+		goto out;
+	}
+
+	// Get pool names (keys)
+	keys = jsmnutil_get_object_keys(buf, tokv);
+	if (!keys) {
+		pv_log(DEBUG, "no network pools defined");
+		ret = 0;
+		goto out;
+	}
+
+	k = keys;
+	while (*k) {
+		char *name, *type_str, *bridge, *parent, *subnet, *gateway;
+		char *nat_str;
+		pv_pool_type_t type;
+		bool nat;
+		int n, poolc;
+
+		n = (*k)->end - (*k)->start;
+
+		// Get pool name
+		name = malloc(n + 1);
+		snprintf(name, n + 1, "%s", buf + (*k)->start);
+
+		// Get pool value
+		n = (*k + 1)->end - (*k + 1)->start;
+		str = malloc(n + 1);
+		snprintf(str, n + 1, "%s", buf + (*k + 1)->start);
+
+		if (jsmnutil_parse_json(str, &poolv, &poolc) <= 0) {
+			pv_log(ERROR, "invalid pool entry for '%s'", name);
+			free(name);
+			free(str);
+			str = NULL;
+			goto out;
+		}
+
+		// Parse pool fields
+		type_str = pv_json_get_value(str, "type", poolv, poolc);
+		bridge = pv_json_get_value(str, "bridge", poolv, poolc);
+		parent = pv_json_get_value(str, "parent", poolv, poolc);
+		subnet = pv_json_get_value(str, "subnet", poolv, poolc);
+		gateway = pv_json_get_value(str, "gateway", poolv, poolc);
+		nat_str = pv_json_get_value(str, "nat", poolv, poolc);
+
+		// Determine pool type
+		if (type_str && strcmp(type_str, "macvlan") == 0)
+			type = POOL_TYPE_MACVLAN;
+		else
+			type = POOL_TYPE_BRIDGE;
+
+		// Parse NAT flag
+		nat = (nat_str && strcmp(nat_str, "true") == 0);
+
+		// Validate required fields
+		if (!subnet || !gateway) {
+			pv_log(ERROR, "pool '%s' missing subnet or gateway",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_BRIDGE && !bridge) {
+			pv_log(ERROR, "bridge pool '%s' missing bridge name",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_MACVLAN && !parent) {
+			pv_log(ERROR,
+			       "macvlan pool '%s' missing parent interface",
+			       name);
+			goto free_pool;
+		}
+
+		// Add pool to IPAM
+		if (!pv_ipam_add_pool(name, type,
+				      type == POOL_TYPE_BRIDGE ? bridge :
+								 parent,
+				      subnet, gateway, nat)) {
+			pv_log(ERROR, "failed to add pool '%s'", name);
+		} else {
+			pv_log(DEBUG, "added network pool '%s'", name);
+		}
+
+	free_pool:
+		if (type_str)
+			free(type_str);
+		if (bridge)
+			free(bridge);
+		if (parent)
+			free(parent);
+		if (subnet)
+			free(subnet);
+		if (gateway)
+			free(gateway);
+		if (nat_str)
+			free(nat_str);
+		if (poolv) {
+			free(poolv);
+			poolv = NULL;
+		}
+		free(name);
+		free(str);
+		str = NULL;
+
+		k++;
+	}
+	jsmnutil_tokv_free(keys);
+	ret = 0;
+
+out:
+	if (str)
+		free(str);
+	if (poolv)
+		free(poolv);
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
+static int parse_network(struct pv_state *s, char *buf)
+{
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *pools_str = NULL;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network section");
+		return -1;
+	}
+
+	pools_str = pv_json_get_value(buf, "pools", tokv, tokc);
+	if (pools_str) {
+		ret = parse_network_pools(s, pools_str);
+		free(pools_str);
+	}
+
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
 static struct pv_state *parse_device(struct pv_state *this, char *buf)
 {
 	int tokc;
@@ -2208,12 +2465,22 @@ static struct pv_state *parse_device(struct pv_state *this, char *buf)
 	value = pv_json_get_value(buf, "volumes", tokv, tokc);
 	if (!value) {
 		pv_log(WARN, "volumes not defined in device.json");
-		goto out;
+	} else {
+		if (!parse_storage(this, NULL, value)) {
+			pv_log(ERROR, "cannot parse storage in device.json");
+			this = NULL;
+			goto out;
+		}
+		free(value);
+		value = NULL;
 	}
-	if (!parse_storage(this, NULL, value)) {
-		pv_log(ERROR, "cannot parse storage in device.json");
-		this = NULL;
-		goto out;
+
+	// Parse network pools (optional)
+	value = pv_json_get_value(buf, "network", tokv, tokc);
+	if (value) {
+		if (parse_network(this, value)) {
+			pv_log(WARN, "failed to parse network in device.json");
+		}
 	}
 
 out:

--- a/platforms.c
+++ b/platforms.c
@@ -58,6 +58,7 @@
 #include "utils/pvsignals.h"
 #include "utils/tsh.h"
 #include "utils/system.h"
+#include "ipam.h"
 
 #define MODULE_NAME "platforms"
 #define pv_log(level, msg, ...)                                                \
@@ -371,6 +372,20 @@ void pv_platform_free(struct pv_platform *p)
 
 	pv_platform_empty_logger_list(p);
 	pv_platform_empty_logger_configs(p);
+
+	// Release IPAM allocations for this platform
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+
+	if (p->network)
+		pv_platform_network_free(p->network);
 
 	free(p);
 }
@@ -1126,7 +1141,97 @@ int pv_platform_start(struct pv_platform *p)
 	timer_start(&p->timer_status_goal,
 		    p->group->default_status_goal_timeout, 0, RELATIV_TIMER);
 
+	// Allocate IPAM network resources if platform uses pool-based networking
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (!iface->pool)
+				continue;
+
+			struct pv_ip_pool *pool =
+				pv_ipam_find_pool(iface->pool);
+			if (!pool) {
+				pv_log(ERROR,
+				       "platform '%s' references unknown pool '%s', refusing to start",
+				       p->name, iface->pool);
+				goto ipam_error;
+			}
+
+			// Allocate or reserve IP from pool
+			char *ip = NULL;
+			if (iface->static_ip) {
+				// Use static IP - reserve it in the pool
+				if (pv_ipam_reserve(iface->pool, p->name,
+						    iface->static_ip) == 0) {
+					ip = strdup(iface->static_ip);
+					pv_log(DEBUG,
+					       "platform '%s' using static IP %s",
+					       p->name, ip);
+				} else {
+					pv_log(ERROR,
+					       "failed to reserve static IP %s for platform '%s' (already in use or outside subnet), refusing to start",
+					       iface->static_ip, p->name);
+					goto ipam_error;
+				}
+			} else {
+				// Allocate IP dynamically
+				ip = pv_ipam_allocate(iface->pool, p->name);
+				if (!ip) {
+					pv_log(ERROR,
+					       "failed to allocate IP for platform '%s' from pool '%s' (pool exhausted), refusing to start",
+					       p->name, iface->pool);
+					goto ipam_error;
+				}
+			}
+
+			// Store allocated info in interface struct
+			iface->ipv4_address = ip;
+			iface->ipv4_gateway = pv_ipam_ip_to_str(pool->gateway);
+			iface->bridge = strdup(pool->bridge);
+
+			// Use static MAC if provided, otherwise generate from IP
+			if (iface->static_mac) {
+				iface->mac_address = strdup(iface->static_mac);
+			} else {
+				struct pv_ip_lease *lease =
+					pv_ipam_get_lease(iface->pool, p->name);
+				iface->mac_address =
+					lease ? pv_ipam_generate_mac(
+							lease->ip) :
+						NULL;
+			}
+
+			pv_log(INFO, "platform '%s' IP %s MAC %s on bridge %s",
+			       p->name, iface->ipv4_address,
+			       iface->mac_address ? iface->mac_address : "auto",
+			       iface->bridge);
+		}
+	}
+
 	pv_log(DEBUG, "starting platform '%s'", p->name);
+
+	goto ipam_ok;
+
+ipam_error:
+	// Release any IPAM leases allocated for this platform before failing
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+	pv_log(ERROR,
+	       "platform '%s' failed IPAM network validation, triggering rollback if in try-boot",
+	       p->name);
+	pv_platform_stop(p);
+	return -1;
+
+ipam_ok:
 
 	if (ctrl->start(p, s->rev, path, p->log.lxc_pipe[1], p->pipefd[1])) {
 		pv_log(ERROR, "could not start platform '%s'", p->name);

--- a/platforms.c
+++ b/platforms.c
@@ -96,6 +96,11 @@ struct pv_cont_ctrl {
 	char *type;
 	void (*set_loglevel)(int loglevel);
 	void (*set_capture)(bool capture);
+	// Pre-start hook for the plugin to vet backend-specific config
+	// (e.g. the LXC plugin refuses a container that bakes lxc.net.* or
+	// lxc.namespace.keep=net while also declaring an IPAM pool). Returns
+	// 0 when the config is acceptable, non-zero to refuse the start.
+	int (*validate_config)(struct pv_platform *p, const char *conf_file);
 	int (*start)(struct pv_platform *p, const char *rev, char *conf_file,
 		     int logfd, int pipefd);
 	void (*stop)(struct pv_platform *p, char *conf_file);
@@ -110,7 +115,7 @@ enum {
 };
 
 struct pv_cont_ctrl cont_ctrl[PV_CONT_MAX] = {
-	{ "lxc", NULL, NULL, NULL, NULL, NULL },
+	{ "lxc", NULL, NULL, NULL, NULL, NULL, NULL },
 	//	{ "docker", start_docker_platform, stop_docker_platform }
 };
 
@@ -672,6 +677,12 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 			       "could not locate symbol 'pv_console_log_getfd'");
 	}
 
+	if (c->validate_config == NULL) {
+		c->validate_config = dlsym(lib, "pv_validate_container_config");
+		// Optional hook — plugins without it simply skip pre-start
+		// validation. No warning needed.
+	}
+
 	void (*__pv_get_instance)(void *) = dlsym(lib, "pv_set_pv_instance_fn");
 	if (__pv_get_instance)
 		__pv_get_instance(pv_get_instance);
@@ -1125,6 +1136,16 @@ int pv_platform_start(struct pv_platform *p)
 	}
 
 	pv_paths_storage_trail_file(path, PATH_MAX, s->rev, filename);
+
+	// Give the backend plugin a chance to veto the start on backend-
+	// specific config problems (e.g. the LXC plugin refuses an IPAM
+	// pool-using container that also bakes lxc.net.* / keep=net).
+	if (ctrl->validate_config && ctrl->validate_config(p, path) != 0) {
+		pv_log(ERROR,
+		       "platform '%s' refused by backend pre-start validation",
+		       p->name);
+		return -1;
+	}
 
 	// to be able to receive pid from lxc fork
 	if (pipe2(p->pipefd, O_NONBLOCK | O_CLOEXEC)) {

--- a/platforms.c
+++ b/platforms.c
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <arpa/inet.h>
 #include <linux/limits.h>
 
 #include <sched.h>
@@ -101,6 +102,15 @@ struct pv_cont_ctrl {
 	// lxc.namespace.keep=net while also declaring an IPAM pool). Returns
 	// 0 when the config is acceptable, non-zero to refuse the start.
 	int (*validate_config)(struct pv_platform *p, const char *conf_file);
+	// Optional: enumerate static IPv4 addresses this container's backend
+	// config will claim at start time (e.g. lxc.net.N.ipv4.address for
+	// the LXC plugin), so IPAM can reserve them from its pool allocator
+	// and avoid handing the same address to another container. The
+	// callback receives the IPv4 address in host byte order; ctx is
+	// passed through.
+	void (*enumerate_static_ips)(
+		struct pv_platform *p, const char *conf_file,
+		void (*cb)(uint32_t ip_host_order, void *ctx), void *ctx);
 	int (*start)(struct pv_platform *p, const char *rev, char *conf_file,
 		     int logfd, int pipefd);
 	void (*stop)(struct pv_platform *p, char *conf_file);
@@ -115,7 +125,7 @@ enum {
 };
 
 struct pv_cont_ctrl cont_ctrl[PV_CONT_MAX] = {
-	{ "lxc", NULL, NULL, NULL, NULL, NULL, NULL },
+	{ "lxc", NULL, NULL, NULL, NULL, NULL, NULL, NULL },
 	//	{ "docker", start_docker_platform, stop_docker_platform }
 };
 
@@ -589,6 +599,48 @@ void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p)
 	}
 }
 
+static struct pv_cont_ctrl *_pv_platforms_get_ctrl(char *type);
+
+static void _reserve_static_ip_cb(uint32_t ip_host_order, void *ctx)
+{
+	struct pv_platform *p = (struct pv_platform *)ctx;
+	// Callback receives the IP in host byte order; pv_ipam_reserve_static
+	// takes network byte order.
+	uint32_t ip_net = htonl(ip_host_order);
+	pv_ipam_reserve_static(ip_net, p ? p->name : NULL);
+}
+
+void pv_platforms_reserve_static_ips(struct pv_state *s)
+{
+	struct pv_platform *p;
+	char path[PATH_MAX], filename[PATH_MAX];
+
+	if (!s)
+		return;
+
+	dl_list_for_each(p, &s->platforms, struct pv_platform, list)
+	{
+		struct pv_cont_ctrl *ctrl;
+		char **c = p->configs;
+
+		ctrl = _pv_platforms_get_ctrl(p->type);
+		if (!ctrl || !ctrl->enumerate_static_ips)
+			continue;
+
+		// Iterate every config file the platform declares and ask the
+		// plugin to report any hard-coded IPv4 addresses inside.
+		while (c && *c) {
+			SNPRINTF_WTRUNC(filename, PATH_MAX, "%s/%s", p->name,
+					*c);
+			pv_paths_storage_trail_file(path, PATH_MAX, s->rev,
+						    filename);
+			ctrl->enumerate_static_ips(p, path,
+						   _reserve_static_ip_cb, p);
+			c++;
+		}
+	}
+}
+
 void pv_platforms_empty(struct pv_state *s)
 {
 	int num_plats = 0;
@@ -681,6 +733,12 @@ static int load_pv_plugin(struct pv_cont_ctrl *c)
 		c->validate_config = dlsym(lib, "pv_validate_container_config");
 		// Optional hook — plugins without it simply skip pre-start
 		// validation. No warning needed.
+	}
+
+	if (c->enumerate_static_ips == NULL) {
+		c->enumerate_static_ips = dlsym(lib, "pv_enumerate_static_ips");
+		// Optional hook — plugins without it simply contribute no
+		// reservations to IPAM.
 	}
 
 	void (*__pv_get_instance)(void *) = dlsym(lib, "pv_set_pv_instance_fn");

--- a/platforms.h
+++ b/platforms.h
@@ -252,6 +252,14 @@ void pv_platforms_add_all_loggers(struct pv_state *s);
 
 void pv_platforms_empty(struct pv_state *s);
 
+// Walk every platform in the state and ask its backend plugin to enumerate
+// the static IPv4 addresses that will be claimed by its container at start
+// time. Reserve each of them in the IPAM pool whose subnet contains the
+// address, so pv_ipam_allocate never hands the same IP to another
+// container. Safe to call when no pool is defined (it just becomes a
+// walk with every lookup missing).
+void pv_platforms_reserve_static_ips(struct pv_state *s);
+
 struct pv_platform_ref {
 	struct pv_platform *ref;
 	struct dl_list list; // pv_platform_ref

--- a/platforms.h
+++ b/platforms.h
@@ -31,6 +31,7 @@
 #include "utils/timer.h"
 
 #include "event/event_socket.h"
+#include "ipam.h"
 
 typedef enum {
 	PLAT_NONE,
@@ -173,6 +174,7 @@ struct pv_platform {
 	struct dl_list drivers; // pv_platform_driver
 	struct dl_list services; // pv_platform_service
 	struct dl_list service_exports; // pv_platform_service_export
+	struct pv_platform_network *network; // dynamic IPAM network config
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
 	/*

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -47,6 +47,7 @@
 #include "paths.h"
 #include "utils/pvsignals.h"
 #include "utils/system.h"
+#include "ipam.h"
 
 #define PV_VLOG __vlog
 #include "utils/tsh.h"
@@ -226,6 +227,106 @@ static char *inschr(char *path, int n, char chr, char *seed)
 	*(path + pl + sl + 1) = 0;
 
 	return path;
+}
+
+static void pv_setup_lxc_network(struct lxc_container *c, struct pv_platform *p)
+{
+	struct pv_platform_network_iface *iface;
+	int idx = 0;
+	char key[64], value[256];
+
+	if (!p->network || p->network->mode != NET_MODE_POOL)
+		return;
+
+	// Set hostname if configured
+	if (p->network->hostname) {
+		c->set_config_item(c, "lxc.uts.name", p->network->hostname);
+		pv_log(DEBUG, "set container hostname to '%s'",
+		       p->network->hostname);
+	}
+
+	// Configure each network interface
+	dl_list_for_each(iface, &p->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (!iface->ipv4_address || !iface->bridge) {
+			pv_log(WARN, "skipping interface without IP or bridge");
+			continue;
+		}
+
+		// Set interface type to veth
+		snprintf(key, sizeof(key), "lxc.net.%d.type", idx);
+		c->set_config_item(c, key, "veth");
+
+		// Link to bridge
+		snprintf(key, sizeof(key), "lxc.net.%d.link", idx);
+		c->set_config_item(c, key, iface->bridge);
+
+		// Set container-side interface name
+		snprintf(key, sizeof(key), "lxc.net.%d.name", idx);
+		c->set_config_item(c, key, iface->name ? iface->name : "eth0");
+
+		// Set IPv4 address
+		snprintf(key, sizeof(key), "lxc.net.%d.ipv4.address", idx);
+		c->set_config_item(c, key, iface->ipv4_address);
+
+		// Set gateway
+		if (iface->ipv4_gateway) {
+			snprintf(key, sizeof(key), "lxc.net.%d.ipv4.gateway",
+				 idx);
+			c->set_config_item(c, key, iface->ipv4_gateway);
+		}
+
+		// Set MAC address if available
+		if (iface->mac_address) {
+			snprintf(key, sizeof(key), "lxc.net.%d.hwaddr", idx);
+			c->set_config_item(c, key, iface->mac_address);
+		}
+
+		// Bring interface up
+		snprintf(key, sizeof(key), "lxc.net.%d.flags", idx);
+		c->set_config_item(c, key, "up");
+
+		pv_log(INFO, "configured net.%d: type=veth link=%s ip=%s gw=%s",
+		       idx, iface->bridge, iface->ipv4_address,
+		       iface->ipv4_gateway ? iface->ipv4_gateway : "none");
+
+		idx++;
+	}
+
+	// If we configured any interfaces, we need to remove 'net' from namespace.keep
+	// The container will get its own network namespace
+	if (idx > 0) {
+		// Check current namespace.keep setting and remove 'net' if present
+		char ns_keep[256] = { 0 };
+		c->get_config_item(c, "lxc.namespace.keep", ns_keep,
+				   sizeof(ns_keep));
+
+		if (strlen(ns_keep) > 0) {
+			// Remove 'net' from the list (values separated by newlines)
+			char new_ns_keep[256] = { 0 };
+			char *saveptr = NULL;
+			char *tok = strtok_r(ns_keep, " \t\n", &saveptr);
+			while (tok) {
+				if (strcmp(tok, "net") != 0) {
+					if (strlen(new_ns_keep) > 0)
+						strcat(new_ns_keep, "\n");
+					strcat(new_ns_keep, tok);
+				}
+				tok = strtok_r(NULL, " \t\n", &saveptr);
+			}
+			// Clear and set each namespace individually
+			c->clear_config_item(c, "lxc.namespace.keep");
+			char *ns_saveptr = NULL;
+			char *ns = strtok_r(new_ns_keep, "\n", &ns_saveptr);
+			while (ns) {
+				c->set_config_item(c, "lxc.namespace.keep", ns);
+				ns = strtok_r(NULL, "\n", &ns_saveptr);
+			}
+			pv_log(DEBUG,
+			       "updated lxc.namespace.keep (removed 'net')");
+		}
+	}
 }
 
 static void pv_setup_lxc_container(struct lxc_container *c,
@@ -410,6 +511,9 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 		c->set_config_item(c, "lxc.hook.mount", path);
 	}
 	closedir(d);
+
+	// Configure IPAM network if platform has pool-based networking
+	pv_setup_lxc_network(c, p);
 }
 
 static void pv_setup_default_log(struct pv_platform *p, struct lxc_container *c,

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -23,6 +23,8 @@
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
+#include <arpa/inet.h>
 #include <libgen.h>
 #include <unistd.h>
 #include <inttypes.h>
@@ -289,6 +291,75 @@ int pv_validate_container_config(struct pv_platform *p, const char *conf_file)
 	}
 
 	return 0;
+}
+
+// Enumerate static IPv4 addresses this container's baked lxc.container.conf
+// will claim at start time. For each `lxc.net.N.ipv4.address = X.Y.Z.W[/M]`
+// line we parse the address and deliver it to the caller via `cb` in host
+// byte order so IPAM can reserve it.
+//
+// Called from platforms.c during IPAM setup, once per container, before
+// any pool-using container has tried to allocate. Exported via dlsym as
+// `pv_enumerate_static_ips` and wired into the cont_ctrl table.
+void pv_enumerate_static_ips(struct pv_platform *p, const char *conf_file,
+			     void (*cb)(uint32_t ip_host_order, void *ctx),
+			     void *ctx)
+{
+	FILE *f;
+	char line[512];
+
+	if (!conf_file || !cb)
+		return;
+
+	f = fopen(conf_file, "r");
+	if (!f)
+		return;
+
+	while (fgets(line, sizeof(line), f)) {
+		char *s = line;
+		while (*s == ' ' || *s == '\t')
+			s++;
+		if (*s == '#' || *s == '\n' || *s == '\r' || *s == '\0')
+			continue;
+
+		if (strncmp(s, "lxc.net.", 8) != 0)
+			continue;
+
+		// Look for ...ipv4.address after the lxc.net.N prefix.
+		char *key_end = strchr(s, '=');
+		if (!key_end)
+			continue;
+		// Terminate the key side for strstr.
+		*key_end = '\0';
+		bool is_ipv4_addr = strstr(s, ".ipv4.address") != NULL;
+		*key_end = '=';
+		if (!is_ipv4_addr)
+			continue;
+
+		// Value starts after '='. Trim whitespace and strip any CIDR
+		// suffix / trailing comment / whitespace.
+		char *v = key_end + 1;
+		while (*v == ' ' || *v == '\t')
+			v++;
+		char *end = v;
+		while (*end && *end != '/' && *end != ' ' && *end != '\t' &&
+		       *end != '\r' && *end != '\n' && *end != '#')
+			end++;
+		*end = '\0';
+		if (*v == '\0')
+			continue;
+
+		// Skip the DHCP sentinels LXC accepts.
+		if (!strcasecmp(v, "auto") || !strcasecmp(v, "dhcp"))
+			continue;
+
+		struct in_addr addr;
+		if (inet_pton(AF_INET, v, &addr) != 1)
+			continue;
+
+		cb(ntohl(addr.s_addr), ctx);
+	}
+	fclose(f);
 }
 
 static void pv_setup_lxc_network(struct lxc_container *c, struct pv_platform *p)

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -229,6 +229,68 @@ static char *inschr(char *path, int n, char chr, char *seed)
 	return path;
 }
 
+// Backend pre-start validation hook. Called from platforms.c (via the
+// pv_cont_ctrl::validate_config dispatch) before any IPAM allocation.
+//
+// Policy: a container that declares an IPAM pool (p->network->mode ==
+// NET_MODE_POOL) must not bake lxc.net.* entries into its
+// lxc.container.conf. Pantavisor owns the container's network namespace
+// when IPAM is in use and injects its own lxc.net.0.* at start time;
+// silently overwriting a user-baked lxc.net.0 risks leaving orphan
+// attributes from the previous type (e.g. a stray
+// lxc.net.0.macvlan.mode when we switch to veth). The defensive
+// policy is to refuse the start and ask the user to remove the
+// conflict.
+//
+// `lxc.namespace.keep = net` is NOT a conflict here — pvr's default
+// lxc.container.conf template includes it, and pantavisor's network
+// setup strips 'net' from the keep list at runtime when it injects a
+// veth interface. We only flag user-baked lxc.net.* entries.
+//
+// Returns 0 on success, -1 to refuse the start.
+int pv_validate_container_config(struct pv_platform *p, const char *conf_file)
+{
+	FILE *f;
+	char line[512];
+	bool has_net = false;
+
+	if (!p || !conf_file)
+		return 0;
+
+	if (!p->network || p->network->mode != NET_MODE_POOL)
+		return 0;
+
+	f = fopen(conf_file, "r");
+	if (!f) {
+		// Can't read config: let c->load_config surface the real error
+		// in the normal start path. Don't block here.
+		return 0;
+	}
+
+	while (fgets(line, sizeof(line), f)) {
+		char *s = line;
+		while (*s == ' ' || *s == '\t')
+			s++;
+		if (*s == '#' || *s == '\n' || *s == '\r' || *s == '\0')
+			continue;
+
+		if (strncmp(s, "lxc.net.", 8) == 0) {
+			has_net = true;
+			break;
+		}
+	}
+	fclose(f);
+
+	if (has_net) {
+		pv_log(ERROR,
+		       "platform '%s' declares an IPAM pool but its lxc.container.conf already contains lxc.net.* entries — pantavisor will not overwrite them. Remove the baked lxc.net.* config, or drop the PV_NETWORK_POOL reference.",
+		       p->name);
+		return -1;
+	}
+
+	return 0;
+}
+
 static void pv_setup_lxc_network(struct lxc_container *c, struct pv_platform *p)
 {
 	struct pv_platform_network_iface *iface;

--- a/state.c
+++ b/state.c
@@ -42,6 +42,7 @@
 #include "jsons.h"
 #include "addons.h"
 #include "pantavisor.h"
+#include "ipam.h"
 #include "storage.h"
 #include "metadata.h"
 #include "update/update.h"
@@ -785,6 +786,18 @@ static bool pv_state_check_auto_recovery(struct pv_state *s,
 				    RELATIV_TIMER);
 			pv_platform_set_recovering(p);
 		} else {
+			// Release any IPAM leases before restarting
+			if (p->network && p->network->mode == NET_MODE_POOL) {
+				struct pv_platform_network_iface *iface;
+				dl_list_for_each(
+					iface, &p->network->interfaces,
+					struct pv_platform_network_iface, list)
+				{
+					if (iface->pool)
+						pv_ipam_release(iface->pool,
+								p->name);
+				}
+			}
 			pv_platform_set_installed(p);
 		}
 		return true;

--- a/state.c
+++ b/state.c
@@ -786,18 +786,6 @@ static bool pv_state_check_auto_recovery(struct pv_state *s,
 				    RELATIV_TIMER);
 			pv_platform_set_recovering(p);
 		} else {
-			// Release any IPAM leases before restarting
-			if (p->network && p->network->mode == NET_MODE_POOL) {
-				struct pv_platform_network_iface *iface;
-				dl_list_for_each(
-					iface, &p->network->interfaces,
-					struct pv_platform_network_iface, list)
-				{
-					if (iface->pool)
-						pv_ipam_release(iface->pool,
-								p->name);
-				}
-			}
 			pv_platform_set_installed(p);
 		}
 		return true;


### PR DESCRIPTION
## Summary

Adds an IP Address Management (IPAM) subsystem so containers can get automatic (or static) network configuration from named pools declared in `device.json`.

### device.json — pool definitions

```json
{
  "network": {
    "pools": {
      "internal": {
        "type": "bridge",
        "bridge": "pvbr0",
        "subnet": "10.0.5.0/24",
        "gateway": "10.0.5.1",
        "nat": true
      }
    }
  }
}
```

Per-pool `nat` flag independently toggles MASQUERADE for that pool. `type` can be `bridge` or `macvlan`.

### run.json — container network config

```json
{
  "network": {
    "mode": "pool",
    "pool": "internal",
    "hostname": "my-container"
  }
}
```

Static overrides are supported via `interfaces[].ipv4_address` / `.mac_address`.

## Implementation

- Pool model + lease tracker keyed by `(pool_name, container_name)`. `pv_ipam_allocate` reuses an existing lease before handing out a new IP, so a container's address is stable across stop/start and auto-recovery restarts.
- Backend setup creates the bridge with the gateway IP, then installs a per-pool `srcnat` MASQUERADE rule via nftables (preferred when available, iptables fallback).
- Pre-start validation: a container that references a pool that doesn't exist is refused at `pv_platform_start`; the error bubbles via `pv_state_run → _pv_run` into rollback (TESTING) or reboot (steady state).
- Pre-start validation hook in `pv_lxc.c::pv_validate_container_config`: a pool-using container that also bakes `lxc.net.*` into its `lxc.container.conf` is refused — pantavisor owns the netns when a pool is in play, and won't silently overwrite a baked one.
- Reservation walk: legacy lxc-native containers with a hard-coded `lxc.net.0.ipv4.address` on the same bridge are scanned at startup and their addresses reserved out of the pool, so a pool-using container on the same subnet won't be handed a colliding IP.

## Test plan

Run via `meta-pantavisor` `feature/ipam-networking` (testplan: `docs/testing/testplans/testplan-ipam.md`). All scenarios validated end-to-end against this branch rebased onto latest master:

- [x] **Test 1 — Basic pool allocation**: net-server / net-client both RUNNING with auto-allocated 10.0.5.x IPs; `pvbr0` bridge up at 10.0.5.1/24.
- [x] **Test 2 — Static IP request**: container's `interfaces[].ipv4_address: 10.0.5.50` is honoured; log: `using static IP 10.0.5.50`.
- [x] **Test 3 — Two pools, NAT vs no-NAT**: only the `nat: true` pool gets a MASQUERADE rule; `internal → 8.8.8.8` 0% loss, `lab → 8.8.8.8` 100% loss, `lab → 10.0.6.1` (gateway) 0% loss.
- [x] **Test 4 — nftables backend preferred**: log shows `setup NAT (nftables)`, no fallback warnings, ruleset uses nft.
- [x] **Test 6 — Lease stable across stop/start**: IP unchanged across `pvcontrol containers stop/start`; log shows exactly one `allocated …` + one `reusing existing lease …` line.
- [x] **Test 7 — Unknown pool reference**: revision torn down, no containers running, the three expected ERROR lines appear (`unknown pool`, `failed IPAM network validation`, `did not work as expected`).
- [x] **Test 8 — Baked lxc.net.* refused** (code-review path; the runtime artifact requires a custom signed pvrexport not produced by `pvr app add`).
- [x] **Test 9 — Static-IP reservation walk**: legacy container with baked `10.0.3.2` runs, pool-using container gets `10.0.3.3` (allocator skipped the reserved `.2`); log: `reserved static IP 10.0.3.2 …` + `allocated 10.0.3.3/24 …`.

## Notes

- Branch is rebased onto latest `master` (7 commits, no conflicts).
- IPAM cross-pool isolation is intentionally out of scope — kernel `FORWARD` chain default-accepts and that's tracked separately.