### PR TITLE
xconnect: implement TCP and HTTP ingress plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1020 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with the Pantavisor source code.
+
+## Overview
+
+Pantavisor is the core runtime for managing containerized embedded Linux devices. Written in C, it acts as the init system (PID 1) that orchestrates containerized building blocks for firmware and applications. It provides atomic state management, over-the-air updates, and integration with Pantahub cloud services.
+
+Key characteristics:
+- Single binary design (~1MB compressed) for low-spec embedded devices
+- Uses LXC for container management
+- Atomic state transitions with rollback support
+- JSON-based declarative state format
+
+## Build System
+
+### CMake Build
+
+```bash
+mkdir build && cd build
+cmake .. [OPTIONS]
+make
+make install
+```
+
+### Feature Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `PANTAVISOR_RUNTIME` | ON | Build main pantavisor binary |
+| `PANTAVISOR_PVTX` | ON | Build pvtx transaction tool |
+| `PANTAVISOR_PVTX_STATIC` | OFF | Build statically-linked pvtx |
+| `PANTAVISOR_DM_VERITY` | OFF | dm-verity for read-only squash volumes |
+| `PANTAVISOR_DM_CRYPT` | OFF | dm-crypt encrypted disk support |
+| `PANTAVISOR_DEBUG` | OFF | Enable debug features |
+| `PANTAVISOR_APPENGINE` | OFF | Build for Docker-based appengine mode |
+| `PANTAVISOR_E2FSGROW_ENABLE` | ON | Partition autogrow feature |
+| `PANTAVISOR_PVTEST` | OFF | Build test components |
+| `PANTAVISOR_CLANG_FORMAT_CHECK` | OFF | Enforce clang-format on build |
+| `PANTAVISOR_DISTRO_NAME` | "" | Distro name in version string |
+| `PANTAVISOR_DISTRO_VERSION` | "" | Distro version in version string |
+
+### Build Targets
+
+- `pantavisor` - Main runtime binary (installed as `/usr/bin/pantavisor`, symlinked to `/init`)
+- `pvtx` - Transaction management CLI tool
+- `pvtx-static` - Statically-linked pvtx for environments without shared libs
+- `remount` - Container mount/remount utility
+
+### Dependencies
+
+- **thttp** - HTTP server library
+- **mbedtls** - TLS/crypto (mbedtls, mbedx509, mbedcrypto)
+- **lxc** - Container library (liblxc)
+- **libevent** - Asynchronous I/O with mbedtls support
+- **picohttpparser** - HTTP parsing
+- **zlib** - Compression
+
+## Directory Structure
+
+```
+pantavisor/
+├── ctrl/           # HTTP control server and REST API endpoints
+├── disk/           # Storage management (dm-crypt, swap, volumes, zram)
+├── event/          # libevent-based async event handling
+├── logserver/      # Distributed logging with multiple backends
+├── pantahub/       # Cloud platform integration
+├── parser/         # State JSON parsing (multi1, system1 formats)
+├── plugins/        # Loadable plugin system (pv_lxc)
+├── pvtx/           # Transaction management
+├── remount/        # Container remount utility
+├── update/         # Update lifecycle and progress
+├── utils/          # Core utilities (json, lists, base64, fs, etc.)
+├── scripts/        # Helper scripts (hooks, mounts, crash handling)
+├── tools/          # Utilities (pventer, fallbear-cmd)
+├── defaults/       # Default configuration files
+├── policies/       # AppArmor and security policies
+├── ssh/            # SSH configuration
+├── skel/           # Filesystem skeleton
+├── pvs/            # Secure boot trust store
+├── appengine/      # Appengine build mode configs
+├── embedded/       # Embedded build mode configs
+└── pvtest/         # Testing framework
+```
+
+## Core Architecture
+
+### Main Data Structures
+
+**`struct pantavisor`** (pantavisor.h) - Central state holder containing:
+- `pv_state *state` - Current device state
+- `pv_update *update` - Active update information
+- `pv_ctrl_cmd *cmd` - Pending control command
+- Connection, metadata, and remote trail information
+
+**`struct pv_state`** (state.h) - Device state containing:
+- `spec_t spec` - State format (SPEC_MULTI1, SPEC_SYSTEM1)
+- `revision` - State revision number
+- BSP configuration, platforms list, volumes, disks, addons, objects
+
+**`struct pv_platform`** (platforms.h) - Container with:
+- Status: INSTALLED, MOUNTED, BLOCKED, STARTING, STARTED, READY, STOPPING, STOPPED
+- LXC configuration, volumes, drivers
+- Group membership, restart policies
+
+### State Machine
+
+The main state machine in `pantavisor.c` defines these states:
+
+- `INIT` - System initialization
+- `RUN` - Normal operation, platforms running
+- `WAIT` - Idle, waiting for commands/updates
+- `COMMAND` - Processing control command
+- `ROLLBACK` - Rolling back to previous state
+- `REBOOT` / `POWEROFF` - System shutdown
+- `ERROR` - Error state
+- `EXIT` - Clean exit
+
+State flow:
+```
+INIT -> RUN -> WAIT <-> COMMAND
+                 |
+                 v
+             ROLLBACK <- ERROR
+                 |
+                 v
+         REBOOT / POWEROFF / EXIT
+```
+
+### Entry Point
+
+`init.c:main()` initializes the system:
+1. Early mounts (/proc, /sys, /dev)
+2. Signal handling setup
+3. Configuration loading
+4. Storage initialization
+5. Starts main loop via `pantavisor.c`
+
+## Key Components
+
+### Control Server (ctrl/)
+
+HTTP REST API for device management via Unix socket at `/run/pantavisor/pv/pv-ctrl`.
+
+**Endpoints:**
+- `/buildinfo` - Build version information
+- `/commands` - Device commands (reboot, poweroff, etc.)
+- `/config` - Runtime configuration
+- `/containers` - Container status and lifecycle control
+- `/daemons` - Managed daemon control (pv-xconnect, etc.)
+- `/devmeta` - Device metadata
+- `/drivers` - Driver management
+- `/groups` - Container group management
+- `/objects` - Object store operations
+- `/signals` - Signal handling
+- `/steps` - Update step tracking
+- `/usrmeta` - User metadata
+- `/xconnect-graph` - Service mesh topology
+
+#### Container Control API (`ctrl/ctrl_containers_ep.c`)
+
+**GET /containers**
+Returns JSON array of all containers with detailed runtime status and service mesh info:
+```json
+[{
+  "name": "my-container",
+  "group": "root",
+  "status": "STARTED",
+  "status_goal": "STARTED",
+  "restart_policy": "container",
+  "pid": 1234,
+  "uptime_secs": 3600,
+  "auto_recovery": {
+    "type": "on-failure",
+    "max_retries": 5,
+    "current_retries": 0,
+    "retry_delay": 1,
+    "backoff_factor": 200,
+    "reset_window": 300
+  },
+  "roles": ["mgmt"],
+  "provides": [
+    {"name": "my-service", "type": "rest", "socket": "/run/my.sock"}
+  ],
+  "consumes": [
+    {"name": "other-service", "type": "dbus", "requirement": "required",
+     "role": "client", "interface": "org.example.Service", "target": "/run/proxy.sock"}
+  ]
+}]
+```
+
+| Field | Description |
+|-------|-------------|
+| `pid` | Container init process PID (0 if not running) |
+| `uptime_secs` | Seconds since container started |
+| `auto_recovery.type` | Recovery policy: `no`, `always`, `on-failure`, `unless-stopped` |
+| `auto_recovery.current_retries` | Current retry count |
+| `provides` | Services this container exports (pv-xconnect) |
+| `consumes` | Services this container requires/uses |
+
+**PUT /containers/{name}**
+Performs lifecycle actions on a container. Only containers with `restart_policy: "container"` can be controlled; containers with `restart_policy: "system"` are protected.
+
+Request body:
+```json
+{"action": "stop"}   // Stop container, disable auto-recovery
+{"action": "start"}  // Start a stopped container
+{"action": "restart"}  // Stop and immediately restart
+```
+
+Response: HTTP 200 OK on success, HTTP 400/404 on error.
+
+**Implementation notes:**
+- `stop`: Sets status goal to STOPPED, disables auto-recovery, calls `pv_platform_force_stop()`
+- `start`: Restores group default status goal, calls `pv_platform_start()`
+- `restart`: Combines stop and start in a single operation
+
+#### Daemon Control API (`ctrl/ctrl_daemons_ep.c`)
+
+**GET /daemons**
+Returns JSON array of managed daemons:
+```json
+[{
+  "name": "pv-xconnect",
+  "pid": 1234,
+  "respawn": true
+}]
+```
+
+**PUT /daemons/{name}**
+Controls daemon lifecycle:
+```json
+{"action": "stop"}   // Disable respawn and kill daemon
+{"action": "start"}  // Enable respawn and start if not running
+```
+
+**Commands** (defined in `ctrl_cmd.h`):
+- `UPDATE_METADATA` - Update device metadata
+- `REBOOT_DEVICE` - Trigger device reboot
+- `POWEROFF_DEVICE` - Trigger device poweroff
+- `LOCAL_RUN` - Run local state
+- `LOCAL_RUN_COMMIT` - Commit local state run
+- `MAKE_FACTORY` - Reset to factory state
+- `ENABLE_SSH` / `DISABLE_SSH` - SSH control
+- `GO_REMOTE` - Switch to remote management
+- `RUN_GC` - Run garbage collection
+- `DEFER_REBOOT` - Defer pending reboot
+- `TRY_ONCE` - Try state once without commit
+
+### State Parsers (parser/)
+
+Two state format versions:
+- `parser_system1.c` - Current format with platforms, groups, volumes, disks
+- `parser_multi1.c` - Legacy format
+
+Entry point: `pv_parser_get_state()`
+
+### Update System (update/)
+
+**Remote updates:**
+1. Download state from Pantahub
+2. Install objects (containers, configs)
+3. Validate signatures/checksums
+4. Test new state
+5. Commit or rollback
+
+**Local updates:**
+1. Pre-install hooks
+2. Apply state changes
+3. Run tests
+4. Post-install hooks
+
+**Update states:** queued, downloading, inprogress, testing, done, failed, final
+
+### Storage Management (disk/, storage.c)
+
+**Disk types:**
+- `DIR` - Directory mount
+- `DM_CRYPT_*` - Encrypted disk
+- `SWAP` - Swap space
+- `VOLUME` - Mounted volume
+- `ZRAM` - Compressed RAM disk
+
+**Volume types:**
+- `LOOPIMG` - Loop-mounted image
+- `PERMANENT` - Persistent storage
+- `REVISION` - Per-revision storage
+- `BOOT` - Boot partition
+
+**Storage layout:**
+```
+/storage/
+├── trails/{rev}/.pvr/json  # State JSON
+├── trails/{rev}/.pv/       # Platform state
+├── boot/                   # Boot files
+├── config/                 # Configuration
+├── disks/                  # Disk definitions
+└── objects/                # Cached objects
+```
+
+### Pantahub Integration (pantahub/)
+
+Cloud platform communication:
+- Device registration and authentication
+- State synchronization
+- Progress reporting for updates
+- Device token management (Pantahub-Devices-Auto-Token-V1)
+
+### Logging System (logserver/)
+
+Multiple backends available:
+- `stdout` - Console output
+- `singlefile` - Single log file
+- `filetree` - Per-platform log files
+- `null` - Discard logs
+- `out` - Generic output
+- `update` - Update-specific logging
+- `timestamp` - Timestamped logging
+
+### Event System (event/)
+
+Built on libevent2:
+- `pv_event_base_init()` - Initialize event loop
+- `pv_event_base_loop()` - Run main loop
+- HTTP server integration via thttp
+- Socket listeners, periodic timers
+
+### PVTX Transaction System (pvtx/)
+
+CLI tool for local state transactions:
+
+```bash
+# Start a new transaction
+pvtx begin
+
+# Add a file to the transaction
+pvtx add <file>
+
+# Remove a file from the transaction
+pvtx remove <path>
+
+# Apply the transaction
+pvtx commit
+
+# Cancel the transaction
+pvtx abort
+
+# Show current transaction state
+pvtx show
+
+# Deploy a transaction archive
+pvtx deploy <archive.tgz>
+```
+
+Transactions are tar-based with checksums and state serialization.
+
+### Configuration (config.h)
+
+Over 130 configuration options organized by category:
+
+**Network settings:**
+- Pantahub connection parameters
+- Proxy configuration
+- Interface settings
+
+**Storage configuration:**
+- Disk encryption settings
+- Volume mount options
+- Garbage collection policies
+
+**Security options:**
+- Signature verification
+- AppArmor policies
+- SSH access control
+
+**Bootloader settings:**
+- `BL_UBOOT_PLAIN` - Standard U-Boot
+- `BL_UBOOT_PVK` - U-Boot with PVK
+- `BL_UBOOT_AB` - U-Boot A/B boot
+- `BL_GRUB` - GRUB bootloader
+- `BL_RPIAB` - Raspberry Pi A/B boot
+
+**Debug options:**
+- Log levels
+- Crash dump settings
+- Development features
+
+**Updater settings:**
+- Retry policies
+- Timeout configuration
+- Rollback behavior
+
+### Plugin System (plugins/)
+
+The plugin system provides modular container runtime support. Plugins are dynamically loaded shared libraries that implement the container lifecycle interface.
+
+#### Plugin Architecture
+
+**Loading Mechanism (platforms.c):**
+1. At startup, `pv_platforms_init_ctrl()` iterates through registered container types
+2. For each type, attempts to load `pv_<type>.so` from `${SYSTEM_LIBDIR}/pv_<type>.so`
+3. Uses `dlopen()` with `RTLD_NOW` for immediate symbol resolution
+4. Resolves required function symbols via `dlsym()`
+5. Injects callback functions for paths, logging, and pantavisor instance access
+
+**Plugin Location:**
+- Default: `/lib/pantavisor/pv_<type>.so`
+- Controlled by `PV_SYSTEM_LIBDIR` configuration
+
+#### Container Controller Interface
+
+Defined in `platforms.c`:
+
+```c
+struct pv_cont_ctrl {
+    char *type;                     // Container type name (e.g., "lxc")
+    void (*set_loglevel)(int);      // Set plugin log level
+    void (*set_capture)(bool);      // Enable/disable log capture
+    int (*start)(struct pv_platform *p, const char *rev,
+                 char *conf_file, int logfd, int pipefd);
+    void (*stop)(struct pv_platform *p, char *conf_file);
+    int (*get_console_fd)(struct pv_platform *p,
+                          struct pv_platform_log *log);
+};
+```
+
+**Registered Types:**
+```c
+enum {
+    PV_CONT_LXC,        // LXC containers
+    // PV_CONT_DOCKER,  // Future: Docker support
+    PV_CONT_MAX
+};
+```
+
+#### Required Plugin Exports
+
+Every plugin must export these symbols:
+
+| Symbol | Signature | Purpose |
+|--------|-----------|---------|
+| `pv_start_container` | `int (pv_platform*, const char*, char*, int, int)` | Start a container |
+| `pv_stop_container` | `void (pv_platform*, char*)` | Stop a container |
+| `pv_set_pv_instance_fn` | `void (void*)` | Receive pantavisor instance getter |
+| `pv_set_pv_paths_fn` | `void (void*, ...)` | Receive path helper functions |
+
+**Optional exports:**
+
+| Symbol | Signature | Purpose |
+|--------|-----------|---------|
+| `pv_set_pv_conf_loglevel_fn` | `void (int)` | Configure log level |
+| `pv_set_pv_conf_capture_fn` | `void (bool)` | Enable log capture |
+| `pv_console_log_getfd` | `int (pv_platform*, pv_platform_log*)` | Get console file descriptor |
+
+#### pv_lxc Plugin (plugins/pv_lxc.c)
+
+The primary container runtime plugin providing LXC integration.
+
+**Dependencies:**
+- liblxc (LXC container library)
+- Pantavisor's custom LXC fork (lxc-pv) with `pv_export.h` extensions
+
+**Key Functions:**
+
+```c
+// Start an LXC container
+int pv_start_container(struct pv_platform *p, const char *rev,
+                       char *conf_file, int logfd, int pipefd);
+
+// Stop an LXC container
+void pv_stop_container(struct pv_platform *p, char *conf_file);
+
+// Get console PTY file descriptor for logging
+int pv_console_log_getfd(struct pv_platform *p, struct pv_platform_log *log);
+```
+
+**Container Setup (`pv_setup_lxc_container`):**
+
+1. **Basic Configuration:**
+   - Sets `lxc.rootfs.mount` for container filesystem
+   - Sets `lxc.uts.name` (hostname) to platform name
+   - Configures log level from pantavisor settings
+
+2. **Config Overlay:**
+   - Injects platform-specific config directory into rootfs path
+   - Supports overlayfs-style configuration layering
+
+3. **Cgroup Configuration:**
+   - Handles cgroup v1/v2 differences
+   - Removes legacy `lxc.cgroup.devices.allow/deny` for cgroup2
+   - Sets `lxc.cgroup2.devices.allow = a` for unified cgroup
+
+4. **Role-based Mounts:**
+
+   For `PLAT_ROLE_MGMT` (management platforms):
+   - Mounts `.pv/` directory read-only at `/pv`
+   - Mounts logs directory read-only at `/pv/logs`
+   - Mounts user metadata at `/pv/user-meta`
+   - Mounts device metadata at `/pv/device-meta`
+
+   For regular platforms:
+   - Mounts log control socket at `/pv/pv-ctrl/log`
+   - Mounts pvcontrol socket at `/pv/pv-ctrl/ctrl`
+   - Mounts platform-specific logs at `/pv/logs`
+   - Mounts platform user/device metadata
+
+5. **Auto Module/Firmware Mounting:**
+   - If `automodfw` enabled, binds `/lib/firmware`
+   - Mounts kernel modules squashfs for current kernel version
+
+6. **Cmdline Filtering:**
+   - Strips `console=` parameters from kernel cmdline
+   - Passes filtered cmdline to container
+
+7. **Mount Hooks:**
+   - Enables hooks from `/lib/pantavisor/pv/hooks_lxc-mount.d/`
+   - Optionally includes `export.sh` hook if export enabled
+
+**Container Startup Process:**
+
+```
+pv_start_container()
+    │
+    ├── Fork child process (pv-platform-<name>)
+    │
+    └── Child:
+        ├── Block SIGCHLD
+        ├── Initialize LXC logging
+        ├── Create lxc_container object
+        ├── Load config from conf_file
+        ├── Apply pv_setup_lxc_container() modifications
+        ├── Set custom init command if p->exec specified
+        ├── Save modified config
+        ├── Start container (daemonized)
+        ├── Write init_pid to pipefd
+        └── Exit child process
+
+    Parent:
+        └── Return success (init_pid communicated via pipe)
+```
+
+**Logging Setup:**
+- Supports LXC log file (`lxc.log.file`)
+- Supports console log (`lxc.console.logfile`)
+- Automatic pvlogger process spawning for external log files
+- Default truncate size: 2MB
+
+#### Creating New Plugins
+
+**CMakeLists.txt Template:**
+```cmake
+cmake_minimum_required(VERSION 3.0)
+project(pv_myruntime VERSION 019)
+
+find_library(MYRUNTIME_LIB myruntime)
+
+add_library(pv_myruntime MODULE
+    pv_myruntime.c
+    pv_myruntime.h
+)
+
+get_filename_component(PARENT_DIR ../ ABSOLUTE)
+target_include_directories(pv_myruntime PRIVATE ${PARENT_DIR})
+SET_TARGET_PROPERTIES(pv_myruntime PROPERTIES PREFIX "")
+target_link_libraries(pv_myruntime ${MYRUNTIME_LIB})
+
+install(TARGETS pv_myruntime
+    DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/${CMAKE_PROJECT_NAME}
+)
+```
+
+**Header Template (pv_myruntime.h):**
+```c
+#ifndef PV_MYRUNTIME_H
+#define PV_MYRUNTIME_H
+
+#include "../config.h"
+#include "../platforms.h"
+
+// Required: Receive pantavisor instance getter
+void pv_set_pv_instance_fn(void *fn_pv_get_instance);
+
+// Required: Receive path helper functions
+void pv_set_pv_paths_fn(void *fn_vlog, void *fn_pv_paths_pv_file, ...);
+
+// Optional: Configure log level
+void pv_set_pv_conf_loglevel_fn(int loglevel);
+
+// Optional: Enable/disable log capture
+void pv_set_pv_conf_capture_fn(bool capture);
+
+// Required: Start container, return 0 on success
+int pv_start_container(struct pv_platform *p, const char *rev,
+                       char *conf_file, int logfd, int pipefd);
+
+// Required: Stop container
+void pv_stop_container(struct pv_platform *p, char *conf_file);
+
+// Optional: Get console file descriptor
+int pv_console_log_getfd(struct pv_platform *p, struct pv_platform_log *log);
+
+#endif
+```
+
+**Registering New Plugin Type:**
+
+Add to `platforms.c`:
+```c
+enum {
+    PV_CONT_LXC,
+    PV_CONT_MYRUNTIME,  // Add new type
+    PV_CONT_MAX
+};
+
+struct pv_cont_ctrl cont_ctrl[PV_CONT_MAX] = {
+    { "lxc", NULL, NULL, NULL, NULL, NULL },
+    { "myruntime", NULL, NULL, NULL, NULL, NULL },  // Add entry
+};
+```
+
+#### Experimental Plugins (In Development)
+
+Based on backup files in the plugins directory:
+
+**pv_runc (OCI Runtime):**
+- Provides runc/OCI container support
+- Similar interface to pv_lxc
+- Would enable running standard OCI container images
+
+**pv_wasmedge (WebAssembly):**
+- WasmEdge runtime integration
+- Would enable running WebAssembly workloads as "containers"
+- Lightweight alternative for edge computing
+
+#### Plugin Files
+
+| File | Purpose |
+|------|---------|
+| `plugins/CMakeLists.txt` | Build configuration for plugins |
+| `plugins/pv_lxc.c` | LXC plugin implementation (~670 lines) |
+| `plugins/pv_lxc.h` | LXC plugin interface |
+| `plugins/pv_runc.c~` | (WIP) runc plugin |
+| `plugins/pv_wasmedge.c~` | (WIP) WasmEdge plugin |
+
+## Bootloader Subsystem
+
+The bootloader subsystem manages atomic updates across reboots using a set of state variables and bootloader-specific implementations.
+
+### Core Variables
+
+Three key variables control the update state machine:
+
+| Variable | Storage | Purpose |
+|----------|---------|---------|
+| `pv_rev` | Runtime + cmdline/env | Currently running revision (set at boot time) |
+| `pv_try` | Persistent storage | Revision being tested (set when installing update) |
+| `pv_done` | Persistent storage | Last committed/stable revision |
+
+**Variable relationships:**
+
+```
+Normal operation:     pv_rev == pv_done, pv_try is empty
+Installing update:    pv_try set to new revision, pv_rev == pv_done
+Trying update:        pv_rev == pv_try (booted into new revision)
+After commit:         pv_rev == pv_done == committed rev, pv_try cleared
+After rollback:       pv_rev == pv_done (old revision), pv_try cleared
+```
+
+### State Detection Logic (bootloader.c)
+
+```c
+pv_bootloader_update_in_progress()  // pv_try is set and non-empty
+pv_bootloader_trying_update()       // pv_try is set AND pv_rev == pv_try
+```
+
+### Update Flow
+
+1. **Install Update** (`pv_bootloader_install_update(rev)`):
+   - Calls bootloader-specific `install_update()` hook
+   - Sets `pv_try = rev` in persistent storage
+
+2. **Reboot** - Device boots with new revision
+
+3. **On Success - Commit** (`pv_bootloader_pre_commit_update()` + `post_commit_update()`):
+   - Sets `pv_rev = rev` (the new revision)
+   - Clears `pv_try`
+   - Calls bootloader-specific `commit_update()` hook
+
+4. **On Failure - Rollback** (`pv_bootloader_fail_update()`):
+   - Clears `pv_try`
+   - Next reboot returns to `pv_done` revision
+
+### Bootloader Operations Interface (bootloader.h)
+
+```c
+struct bl_ops {
+    void (*free)(void);
+    int (*init)(void);
+
+    // Key-value storage primitives
+    int (*set_env_key)(char *key, char *value);
+    int (*unset_env_key)(char *key);
+    char *(*get_env_key)(char *key);
+    int (*flush_env)(void);
+
+    // Update lifecycle hooks
+    int (*install_update)(char *rev);
+    int (*commit_update)();
+    int (*fail_update)();
+
+    // Boot state validation (optional)
+    int (*validate_state)(const char *pv_try, const char *pv_done,
+                          char **pv_rev_out);
+};
+```
+
+### Bootloader Implementations
+
+#### U-Boot Plain/PVK (uboot.c)
+
+**Type:** `BL_UBOOT_PLAIN`, `BL_UBOOT_PVK`
+
+**Storage:**
+- Primary: `uboot.txt` file in `/storage/boot/`
+- Optional: MTD partition named `pv-env` for atomic writes
+
+**Format:** Null-terminated key=value pairs:
+```
+pv_rev=5\0pv_try=6\0\0
+```
+
+**Behavior:**
+- Reads `pv_rev` from environment variable or kernel cmdline at boot
+- Stores `pv_rev`, `pv_try` in uboot.txt (or MTD if `mtd_only` config set)
+- `flush_env()` erases MTD partition to clean dirty flags
+- No install/commit hooks - relies on storage layer for image management
+
+**Configuration:**
+- `PV_BOOTLOADER_MTD_ONLY` - Use only MTD partition (no uboot.txt)
+- `PV_BOOTLOADER_MTD_ENV` - MTD partition name (default: "pv-env")
+
+#### U-Boot A/B (ubootab.c)
+
+**Type:** `BL_UBOOT_AB`
+
+**Storage:**
+- U-Boot environment via `fw_printenv`/`fw_setenv` commands
+- Two MTD partitions for A/B kernel images
+
+**Features:**
+- Manages active/inactive MTD partitions for FIT images
+- Each partition has a 4KB header with `fit_rev=<revision>`
+- Smart update: compares FIT image signatures, skips write if unchanged
+- Writes FIT image to inactive partition during install
+
+**Update Flow:**
+1. `install_update(rev)`: Write kernel to inactive partition with version header
+2. On reboot: U-Boot selects partition based on environment
+3. `commit_update()`: (not implemented - relies on env update)
+
+**Configuration:**
+- `PV_BOOTLOADER_UBOOTAB_A_NAME` - Partition A name
+- `PV_BOOTLOADER_UBOOTAB_B_NAME` - Partition B name
+- `PV_BOOTLOADER_UBOOTAB_ENV_NAME` - Environment partition
+- `PV_BOOTLOADER_UBOOTAB_ENV_BAK_NAME` - Backup environment partition
+- `PV_BOOTLOADER_UBOOTAB_ENV_OFFSET` - Environment offset in partition
+- `PV_BOOTLOADER_UBOOTAB_ENV_SIZE` - Environment size
+
+#### Raspberry Pi A/B (rpiab.c)
+
+**Type:** `BL_RPIAB`
+
+**Storage:**
+- `rpiab.txt` in `/storage/boot/` - stores pv_rev, pv_try (like uboot.txt)
+- `autoboot.txt` on partition 1 - controls A/B boot selection
+- `pv_rev.txt` on each boot partition - identifies installed revision
+
+**Partition Layout:**
+```
+Partition 1: bootsel   - Contains autoboot.txt (selector)
+Partition 2: boot_a    - Boot image A with kernels, DTBs, initramfs
+Partition 3: boot_b    - Boot image B (alternate)
+```
+
+**Boot State Detection:**
+Reads from device tree at boot:
+- `/proc/device-tree/chosen/bootloader/tryboot` - Is this a tryboot? (0 or 1)
+- `/proc/device-tree/chosen/bootloader/partition` - Which partition booted
+- `/proc/device-tree/chosen/bootloader/boot-mode` - SD card (1) or USB (4)
+
+**autoboot.txt Format:**
+```ini
+[all]
+tryboot_a_b=1
+boot_partition=2
+
+[tryboot]
+boot_partition=3
+```
+
+**Update Flow:**
+
+1. **Install** (`install_update(rev)`):
+   - Writes `rpiboot.img` (or `.gz`) to try partition
+   - Writes `pv_rev.txt` containing revision to try partition
+
+2. **Arm Tryboot** (in `set_env_key("pv_try", rev)`):
+   - After pv_try is stored in rpiab.txt
+   - Sets tryboot flag via RPi mailbox API (`RPI_FIRMWARE_SET_REBOOT_FLAGS`)
+   - This is the commit point - next reboot will boot try partition
+
+3. **On Reboot**:
+   - RPi bootloader checks tryboot flag
+   - If set, boots from `[tryboot]` partition (e.g., partition 3)
+   - Tryboot flag is automatically cleared by bootloader
+
+4. **Validate State** (`validate_state()`):
+   - Reads `pv_rev.txt` from booted partition
+   - Verifies it matches expected revision (pv_try or pv_done)
+   - Detects early rollback if tryboot=0 but pv_try was set
+
+5. **Commit** (`commit_update()`):
+   - Swaps boot_partition and tryboot_partition in autoboot.txt
+   - New revision becomes the default boot
+
+**Early Rollback Detection:**
+If device boots normally (not tryboot) but pv_try is set, this indicates:
+- Power loss before tryboot flag was armed
+- Very early crash causing RPi auto-rollback
+Pantavisor logs a warning and continues with pv_done revision.
+
+#### GRUB (grub.c)
+
+**Type:** `BL_GRUB`
+
+**Storage:**
+- `grubenv` file in `/storage/boot/` (standard GRUB environment block)
+
+**Format:** Standard 1024-byte GRUB environment:
+```
+# GRUB Environment Block
+pv_rev=5
+pv_try=6
+###########################... (padding with #)
+```
+
+**Behavior:**
+- Reads/writes standard GRUB environment format
+- Creates/initializes grubenv if missing or invalid
+- No install/commit hooks - GRUB script handles boot selection
+- Expects GRUB configuration to read pv_rev/pv_try and select appropriate boot entry
+
+### Initialization Sequence (bootloader.c)
+
+```c
+pv_bl_early_init():
+    1. Initialize pv_rev to "0" (factory default)
+    2. Initialize bootloader ops based on config type
+    3. Read pv_try from storage (ops->get_env_key("pv_try"))
+    4. Read pv_done from storage (ops->get_env_key("pv_rev"))
+    5. Get pv_rev from environment variable or kernel cmdline
+    6. If validate_state() hook exists, call it to verify/override pv_rev
+```
+
+### Storage Files Summary
+
+| Bootloader | State File | Boot Image Management |
+|------------|------------|----------------------|
+| uboot | `/storage/boot/uboot.txt` | External (storage layer) |
+| ubootab | U-Boot env (fw_printenv) | MTD partitions A/B |
+| rpiab | `/storage/boot/rpiab.txt` | FAT partitions 2/3 |
+| grub | `/storage/boot/grubenv` | External (GRUB config) |
+
+## Utilities (utils/)
+
+| Utility | Purpose |
+|---------|---------|
+| `json.c` | JSON parsing/building with json-build |
+| `list.h` | Doubly-linked list operations |
+| `base64.c` | Base64 encoding/decoding |
+| `fs.c` | Filesystem operations |
+| `str.c` | String manipulation |
+| `tsh.c` | Task shell - command execution |
+| `timer.c` | Timer abstractions |
+| `pvsignals.c` | Signal handling |
+| `pvzlib.c` | Zlib compression wrapper |
+| `socket.c` | Socket utilities |
+| `mtd.c` | MTD device handling |
+| `fitimg.c` | FIT image support |
+| `buildinfo.c` | Build information |
+
+## Container Lifecycle
+
+1. **Installation** - Create volumes, prepare mounts
+2. **Mounting** - Set up LXC configuration
+3. **Starting** - Launch container init process
+4. **Monitoring** - Track status goals
+5. **Stopping** - Graceful shutdown or force kill
+6. **Cleanup** - Remove mounts, release resources
+
+## Platform Status Flow
+
+```
+INSTALLED -> MOUNTED -> STARTING -> STARTED -> READY
+                                       |
+                                       v
+                                   STOPPING -> STOPPED
+```
+
+## Runlevels
+
+Platforms are started in runlevel order:
+1. `RUNLEVEL_DATA` - Data/storage platforms
+2. `RUNLEVEL_ROOT` - Root filesystem
+3. `RUNLEVEL_PLATFORM` - Core platform services
+4. `RUNLEVEL_APP` - Application containers
+
+## Testing
+
+### Running Tests
+
+```bash
+# Build with tests enabled
+cmake -DPANTAVISOR_TESTS=ON ..
+make
+
+# Run all tests via CTest
+ctest
+
+# Run pvtx test suite
+./test/pvtx/pvtx.sh <source_dir> <build_dir>
+```
+
+### Test Binaries
+
+When `PANTAVISOR_TESTS=ON`:
+- `test-pv-json` - JSON utility tests
+- `test-pv-tsh` - Task shell tests
+- `test-pv-zram` - ZRAM utility tests
+
+## Code Style
+
+### Compiler Settings
+
+- All warnings treated as errors (`-Werror` flag)
+- C standard as defined by CMake defaults
+
+### Formatting
+
+The project uses clang-format for code formatting.
+
+**Check formatting (fails build if incorrect):**
+```bash
+cmake -DPANTAVISOR_CLANG_FORMAT_CHECK=ON ..
+make
+```
+
+**Auto-format all source files:**
+```bash
+cmake -DPANTAVISOR_CLANG_FORMAT_CHECK=ON ..
+make format
+```
+
+The project uses a `.clang-format` file in the root directory for style configuration.
+
+## Installation Paths
+
+| Path | Contents |
+|------|----------|
+| `/usr/bin/pantavisor` | Main binary |
+| `/init` | Symlink to pantavisor (embedded mode) |
+| `/usr/bin/pvtx` | Transaction tool |
+| `/usr/bin/pventer` | Container entry utility |
+| `/usr/bin/fallbear-cmd` | SSH command handler |
+| `/lib/pantavisor/pv/` | Plugins and scripts |
+| `/lib/pantavisor/pv/hooks_lxc-mount.d/` | LXC mount hooks |
+| `/lib/pantavisor/pvtx.d/` | PVTX scripts |
+| `/lib/pantavisor/skel/` | Filesystem skeleton |
+| `/etc/pantavisor/` | Configuration directory |
+| `/etc/pantavisor/defaults/` | Default settings |
+| `/etc/pantavisor/policies/` | Security policies |
+| `/etc/pantavisor/ssh/` | SSH configuration |
+| `/etc/pantavisor/pvs/` | Secure boot trust store |
+| `/storage/` | Runtime storage (embedded mode) |
+
+## Key Files Reference
+
+| File | Purpose |
+|------|---------|
+| `init.c` | Entry point, early initialization |
+| `pantavisor.c` | Core state machine |
+| `state.c` | State lifecycle management |
+| `platforms.c` | Container management |
+| `storage.c` | Revision and object storage |
+| `config.c` | Configuration handling |
+| `ctrl/ctrl.c` | REST API server |
+| `update/update.c` | Update coordination |
+| `pantahub/pantahub.c` | Cloud integration |
+| `parser/parser_system1.c` | State JSON parsing (42KB, comprehensive) |
+| `event/event.c` | Event loop |
+| `disk/disk.c` | Storage management |
+| `logserver/logserver.c` | Logging system |
+| `pvtx/pvtx_txn.c` | Transaction handling |
+
+## External Resources
+
+- [Pantavisor Documentation](https://docs.pantahub.com/pantavisor-architecture/)
+- [Community Forum](https://community.pantavisor.io)
+- [Getting Started Guide](https://docs.pantahub.com/before-you-begin/)
+- [FAQ](https://pantavisor.io/guides/faq/)
+
+## Architecture Documentation
+
+For deep-dives into specific subsystems, refer to the following documents:
+
+- **[CONFIGURATION.md](CONFIGURATION.md)**: Complete configuration reference with layered precedence model.
+- **[PLATFORM.md](PLATFORM.md)**: Container runtime features, try-boot mechanism, and rollback behavior.
+- **[SYSTEM_STATE.md](SYSTEM_STATE.md)**: Defines the Pantavisor System State architecture (BSP, Device Config, Containers, Storage, Signatures).
+- **[xconnect/XCONNECT.md](xconnect/XCONNECT.md)**: Specification for the pv-xconnect service mesh (D-Bus, Unix, REST mediation).
+- **[PLATFORM-FUTURE.md](PLATFORM-FUTURE.md)**: Design roadmap for future container engine features.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,8 @@ add_executable(pantavisor
 			grub.c
 			init.c
 			init.h
+			ipam.c
+			ipam.h
 			jsons.c
 			jsons.h
 			log.c

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,450 @@
+# Pantavisor Configuration System
+
+This document describes the Pantavisor configuration system, including all available options, the layered precedence model, and configuration sources.
+
+---
+
+## 1. Configuration Layers
+
+Pantavisor uses a layered configuration system where higher-precedence sources override lower ones. Each configuration key specifies which layers are allowed to set it.
+
+### 1.1 Layer Precedence (Low to High)
+
+| Level | Source | Description |
+|-------|--------|-------------|
+| `default` | Code | Built-in defaults compiled into pantavisor |
+| `args` | Binary args | Command-line arguments to pantavisor binary |
+| `pv conf file` | `pantavisor.config` | Main configuration file in `/etc/pantavisor/` |
+| `ph conf file` | `pantahub.config` | Pantahub credentials file |
+| `policy` | Policy file | Named policy in `/etc/pantavisor/policies/` |
+| `oem config` | OEM container | Configuration from OEM container's config file |
+| `pv cmdline` | Kernel cmdline | `pv_*` parameters on kernel command line |
+| `ph cmdline` | Kernel cmdline | `ph_*` parameters on kernel command line |
+| `env` | Environment | Environment variables |
+| `metadata` | User metadata | Runtime overrides via device metadata |
+| `command` | API command | Runtime overrides via pv-ctrl API |
+
+**Higher levels override lower levels.** For example, a value set via kernel cmdline (`pv cmdline`) overrides the same value set in `pantavisor.config` (`pv conf file`).
+
+### 1.2 Configuration Loading Sequence
+
+```
+1. Initialize defaults from code
+   │
+2. Parse kernel cmdline (pv_* and ph_* prefixes)
+   │
+3. Parse environment variables
+   │
+4. Load /etc/pantavisor/pantavisor.config
+   │   └─ Apply values at 'pv conf file' level
+   │
+5. Determine policy name (from cmdline → env → config)
+   │   └─ Load /etc/pantavisor/policies/<policy>.config
+   │      └─ Apply values at 'policy' level
+   │
+6. Apply kernel cmdline values at 'pv cmdline' level
+   │
+7. Apply environment values at 'env' level
+   │
+8. [At runtime] Load OEM container config
+   │   └─ Apply values at 'oem config' level
+   │
+9. [At runtime] Load pantahub.config (credentials)
+   │   └─ Apply values at 'ph conf file' level
+   │
+10. [At runtime] Apply metadata overrides
+    └─ Apply values at 'metadata' level
+```
+
+### 1.3 Key Naming Conventions
+
+Configuration keys use two formats:
+
+**Canonical format** (preferred):
+```
+PV_SECTION_SUBSECTION_NAME
+PH_SECTION_SUBSECTION_NAME
+```
+
+**Legacy format** (deprecated, still supported):
+```
+section.subsection.name
+```
+
+Examples:
+- `PV_LOG_LEVEL` (canonical) = `log.level` (legacy)
+- `PH_CREDS_HOST` (canonical) = `creds.host` (legacy)
+
+On kernel cmdline, use lowercase with underscores:
+```
+pv_log_level=4 pv_storage_device=/dev/mmcblk0p2
+```
+
+---
+
+## 2. Configuration Files
+
+### 2.1 pantavisor.config
+
+Main configuration file, typically at `/etc/pantavisor/pantavisor.config`.
+
+**Format:** Key-value pairs, one per line:
+```
+PV_LOG_LEVEL=4
+PV_BOOTLOADER_TYPE=rpiab
+PV_STORAGE_DEVICE=/dev/mmcblk0p2
+PV_STORAGE_FSTYPE=ext4
+```
+
+### 2.2 pantahub.config
+
+Pantahub credentials and connection settings, at `/pv/phconfig/pantahub.config`.
+
+```
+PH_CREDS_HOST=api.pantahub.com
+PH_CREDS_PORT=443
+PH_CREDS_ID=<device-id>
+PH_CREDS_SECRET=<device-secret>
+PH_CREDS_PRN=<device-prn>
+```
+
+### 2.3 Policy Files
+
+Named policies in `/etc/pantavisor/policies/<name>.config`:
+
+```
+# /etc/pantavisor/policies/debug.config
+PV_LOG_LEVEL=5
+PV_DEBUG_SHELL=1
+PV_DEBUG_SSH=1
+```
+
+Select policy via:
+- Kernel cmdline: `pv_policy=debug`
+- Config file: `PV_POLICY=debug`
+
+### 2.4 OEM Container Config
+
+OEM containers can provide configuration overrides in `<policy>.config`:
+
+```
+/storage/trails/<rev>/<oem-container>/<policy>.config
+```
+
+The OEM container is identified by `PV_OEM_NAME` configuration.
+
+---
+
+## 3. Configuration Reference
+
+### 3.1 Pantahub Connection (PH_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PH_CREDS_HOST` | string | `api.pantahub.com` | ph, oem | Pantahub API server hostname |
+| `PH_CREDS_ID` | string | - | ph, oem | Device identifier |
+| `PH_CREDS_PORT` | int | `443` | ph, oem | Pantahub API port |
+| `PH_CREDS_PROXY_HOST` | string | - | ph, oem | HTTP proxy hostname |
+| `PH_CREDS_PROXY_NOPROXYCONNECT` | int | `0` | ph, oem | Disable CONNECT for proxy (0/1) |
+| `PH_CREDS_PROXY_PORT` | int | `3218` | ph, oem | HTTP proxy port |
+| `PH_CREDS_PRN` | string | - | ph, oem | Device PRN (Pantahub Resource Name) |
+| `PH_CREDS_SECRET` | string | - | ph, oem | Device authentication secret |
+| `PH_CREDS_TYPE` | string | `builtin` | ph, oem | Credentials type |
+| `PH_FACTORY_AUTOTOK` | string | - | ph, oem | Factory auto-claim token |
+| `PH_LIBEVENT_HTTP_TIMEOUT` | int | `60` | ph, oem, run | HTTP request timeout (seconds) |
+| `PH_LIBEVENT_HTTP_RETRIES` | int | `1` | ph, oem, run | HTTP request retry count |
+| `PH_METADATA_DEVMETA_INTERVAL` | int | `10` | ph, oem, run | Device metadata push interval (seconds) |
+| `PH_METADATA_USRMETA_INTERVAL` | int | `5` | ph, oem, run | User metadata refresh interval (seconds) |
+| `PH_ONLINE_REQUEST_THRESHOLD` | int | `0` | ph, oem, run | Failed requests before going offline |
+| `PH_UPDATER_INTERVAL` | int | `60` | ph, oem, run | Update check interval (seconds) |
+| `PH_UPDATER_NETWORK_TIMEOUT` | int | `120` | ph, oem, run | Network timeout before rollback (seconds) |
+| `PH_UPDATER_TRANSFER_MAX_COUNT` | int | `5` | ph, oem, run | Max concurrent object transfers |
+
+### 3.2 Bootloader (PV_BOOTLOADER_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_BOOTLOADER_TYPE` | enum | `uboot` | pv | Bootloader type: `uboot`, `uboot-pvk`, `uboot-ab`, `grub`, `rpiab` |
+| `PV_BOOTLOADER_FITCONFIG` | string | - | pv | FIT image configuration name |
+| `PV_BOOTLOADER_MTD_ENV` | string | - | pv | MTD partition for bootloader environment |
+| `PV_BOOTLOADER_MTD_ONLY` | bool | `0` | pv | Use only MTD for env storage (no file) |
+| `PV_BOOTLOADER_UBOOTAB_A_NAME` | string | `fitA` | pv | U-Boot A/B: partition A name |
+| `PV_BOOTLOADER_UBOOTAB_B_NAME` | string | `fitB` | pv | U-Boot A/B: partition B name |
+| `PV_BOOTLOADER_UBOOTAB_ENV_NAME` | string | - | pv | U-Boot A/B: environment partition |
+| `PV_BOOTLOADER_UBOOTAB_ENV_BAK_NAME` | string | - | pv | U-Boot A/B: backup environment partition |
+| `PV_BOOTLOADER_UBOOTAB_ENV_OFFSET` | int | `0` | pv | U-Boot A/B: environment offset (bytes) |
+| `PV_BOOTLOADER_UBOOTAB_ENV_SIZE` | int | `0` | pv | U-Boot A/B: environment size (bytes) |
+
+### 3.3 Storage (PV_STORAGE_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_STORAGE_DEVICE` | string | - | pv, **cmdline** | Storage device path (e.g., `/dev/mmcblk0p2`) |
+| `PV_STORAGE_FSTYPE` | string | - | pv, **cmdline** | Filesystem type: `ext4`, `ubifs`, `jffs2` |
+| `PV_STORAGE_MNTPOINT` | string | - | pv, **cmdline** | Storage mount point |
+| `PV_STORAGE_MNTTYPE` | string | - | pv | Mount type override |
+| `PV_STORAGE_WAIT` | int | `5` | pv | Wait for storage device (seconds) |
+| `PV_STORAGE_LOGTEMPSIZE` | string | - | pv | In-memory log tmpfs size |
+| `PV_STORAGE_GC_KEEP_FACTORY` | bool | `0` | pv, oem, run | Protect factory revision from GC |
+| `PV_STORAGE_GC_RESERVED` | int | `5` | pv, oem, run | Disk space reservation (%) |
+| `PV_STORAGE_GC_THRESHOLD` | int | `0` | pv, oem, run | GC trigger threshold (%) |
+| `PV_STORAGE_GC_THRESHOLD_DEFERTIME` | int | `600` | pv, oem, run | GC deferral time (seconds) |
+| `PV_STORAGE_PHCONFIG_VOL` | bool | `0` | pv | Use volume for Pantahub config |
+
+### 3.4 Logging (PV_LOG_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_LOG_LEVEL` | int | `0` | pv, oem, run | Log level: 0=FATAL, 1=ERROR, 2=WARN, 3=INFO, 4=DEBUG, 5=ALL |
+| `PV_LOG_DIR` | string | `/storage/logs/` | pv | Log storage directory |
+| `PV_LOG_MAXSIZE` | int | `2097152` | pv, oem, run | Max log file size before rotation (bytes) |
+| `PV_LOG_BUF_NITEMS` | int | `128` | pv, oem | In-memory log buffer size (KB) |
+| `PV_LOG_CAPTURE` | bool | `1` | pv, oem | Enable log capture |
+| `PV_LOG_CAPTURE_DMESG` | bool | `1` | pv, oem | Capture kernel messages |
+| `PV_LOG_LOGGERS` | bool | `1` | pv, oem | Enable container loggers |
+| `PV_LOG_PUSH` | bool | `1` | pv, oem, run | Push logs to Pantahub |
+| `PV_LOG_SERVER_OUTPUTS` | mask | `filetree` | pv, oem, run | Output backends (comma-separated) |
+| `PV_LOG_FILETREE_TIMESTAMP_FORMAT` | string | - | pv, oem, run | Timestamp format for filetree output |
+| `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | string | - | pv, oem, run | Timestamp format for singlefile output |
+| `PV_LOG_STDOUT_TIMESTAMP_FORMAT` | string | - | pv, oem, run | Timestamp format for stdout output |
+| `PV_LXC_LOG_LEVEL` | int | `2` | pv, oem | LXC log level: 0=TRACE to 8=FATAL |
+| `PV_LIBTHTTP_LOG_LEVEL` | int | `3` | pv, oem, run | HTTP library log level |
+
+**Log server outputs:** `nullsink`, `singlefile`, `filetree`, `stdout`, `stdout_direct`, `stdout.containers`, `stdout.pantavisor`
+
+### 3.5 Debug (PV_DEBUG_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_DEBUG_SHELL` | bool | `1` | pv | Enable debug shell on console |
+| `PV_DEBUG_SHELL_AUTOLOGIN` | bool | `0` | pv | Auto-login to debug shell |
+| `PV_DEBUG_SHELL_TIMEOUT` | int | `60` | pv | Shell access timeout (seconds) |
+| `PV_DEBUG_SSH` | bool | `1` | pv, oem, run | Enable SSH server |
+| `PV_DEBUG_SSH_AUTHORIZED_KEYS` | string | - | pv, oem, run | SSH authorized_keys file |
+
+### 3.6 System (PV_SYSTEM_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_SYSTEM_INIT_MODE` | enum | `embedded` | pv, **cmdline** | Init mode: `embedded`, `standalone`, `appengine` |
+| `PV_SYSTEM_RUNDIR` | string | `/run/pantavisor/pv` | pv | Runtime directory |
+| `PV_SYSTEM_CONFDIR` | string | `/configs` | pv | Configuration directory |
+| `PV_SYSTEM_ETCDIR` | string | `/etc` | pv | Etc directory |
+| `PV_SYSTEM_ETCPANTAVISORDIR` | string | `/etc/pantavisor` | pv | Pantavisor etc directory |
+| `PV_SYSTEM_LIBDIR` | string | `/lib` | pv | Library directory |
+| `PV_SYSTEM_USRDIR` | string | `/usr` | pv | Usr directory |
+| `PV_SYSTEM_MEDIADIR` | string | `/media` | pv | Media mount directory |
+| `PV_SYSTEM_APPARMOR_PROFILES` | string | - | pv | AppArmor profiles to load |
+| `PV_SYSTEM_MOUNT_SECURITYFS` | bool | `0` | pv | Mount security filesystem |
+| `PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO` | bool | `0` | pv | Auto-load drivers at startup |
+
+### 3.7 Network (PV_NET_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_NET_BRDEV` | string | `lxcbr0` | pv, oem | Default bridge device |
+| `PV_NET_BRADDRESS4` | string | `10.0.3.1` | pv, oem | Bridge IPv4 address |
+| `PV_NET_BRMASK4` | string | `255.255.255.0` | pv, oem | Bridge IPv4 netmask |
+
+### 3.8 Updater (PV_UPDATER_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_UPDATER_COMMIT_DELAY` | int | `25` | pv, oem, run | Stability wait before commit (seconds) |
+| `PV_UPDATER_GOALS_TIMEOUT` | int | `120` | pv, oem, run | Container readiness timeout (seconds) |
+| `PV_UPDATER_USE_TMP_OBJECTS` | bool | `0` | pv, oem, run | Store objects in tmpfs during download |
+| `PV_REVISION_RETRIES` | int | `10` | pv, oem, run | Update retry attempts before rollback |
+
+### 3.9 Secure Boot (PV_SECUREBOOT_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_SECUREBOOT_MODE` | enum | `lenient` | pv | Mode: `disabled`, `audit`, `lenient`, `strict` |
+| `PV_SECUREBOOT_CHECKSUM` | bool | `1` | pv | Validate artifact checksums |
+| `PV_SECUREBOOT_HANDLERS` | bool | `1` | pv | Enable checksum handlers |
+| `PV_SECUREBOOT_TRUSTSTORE` | string | `ca-certificates` | pv | Default certificate store |
+| `PV_SECUREBOOT_OEM_TRUSTSTORE` | string | `ca-oem-certificates` | pv | OEM certificate store |
+
+### 3.10 Watchdog (PV_WDT_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_WDT_MODE` | enum | `shutdown` | pv | Mode: `disabled`, `shutdown`, `startup`, `always` |
+| `PV_WDT_TIMEOUT` | int | `15` | pv | Watchdog timeout (seconds) |
+
+### 3.11 Control (PV_CONTROL_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_CONTROL_REMOTE` | bool | `1` | pv, oem | Enable Pantahub communication |
+| `PV_CONTROL_REMOTE_ALWAYS` | bool | `0` | pv, oem | Maintain connection in local mode |
+
+### 3.12 Disk (PV_DISK_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_DISK_EXPORTSDIR` | string | `/exports` | pv | Exports directory |
+| `PV_DISK_VOLDIR` | string | `/volumes` | pv | Volumes directory |
+| `PV_DISK_WRITABLEDIR` | string | `/writable` | pv | Writable overlay directory |
+
+### 3.13 Cache (PV_CACHE_*)
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_CACHE_DEVMETADIR` | string | `/storage/cache/devmeta` | pv | Device metadata cache |
+| `PV_CACHE_USRMETADIR` | string | `/storage/cache/meta` | pv | User metadata cache |
+
+### 3.14 Other
+
+| Key | Type | Default | Levels | Description |
+|-----|------|---------|--------|-------------|
+| `PV_OEM_NAME` | string | - | pv | OEM container name for config overlay |
+| `PV_POLICY` | string | - | pv | Active policy name |
+| `PV_DROPBEAR_CACHE_DIR` | string | `/storage/cache/dropbear` | pv | SSH server cache |
+| `PV_LIBTHTTP_CERTSDIR` | string | `/certs` | pv | TLS certificates directory |
+| `PV_LIBEVENT_DEBUG_MODE` | bool | `0` | pv, oem | Enable libevent debugging |
+| `PV_VOLMOUNT_DM_EXTRA_ARGS` | string | - | pv, oem | Extra dm-verity mount options |
+
+---
+
+## 4. Kernel Command Line
+
+Only specific settings can be configured via kernel command line:
+
+| Key | Cmdline Parameter | Required |
+|-----|-------------------|----------|
+| `PV_STORAGE_DEVICE` | `pv_storage_device` | Yes (embedded mode) |
+| `PV_STORAGE_FSTYPE` | `pv_storage_fstype` | Yes (embedded mode) |
+| `PV_STORAGE_MNTPOINT` | `pv_storage_mntpoint` | Yes (embedded mode) |
+| `PV_SYSTEM_INIT_MODE` | `pv_system_init_mode` | No |
+
+Example kernel cmdline:
+```
+pv_storage_device=/dev/mmcblk0p2 pv_storage_fstype=ext4 pv_storage_mntpoint=/storage pv_system_init_mode=embedded
+```
+
+For Pantahub settings, use `ph_` prefix:
+```
+ph_creds_host=custom.pantahub.com ph_updater_interval=120
+```
+
+---
+
+## 5. Sysctl Configuration
+
+Keys prefixed with `PV_SYSCTL_` are written to `/proc/sys/` paths:
+
+```
+PV_SYSCTL_KERNEL_CORE_PATTERN=|/lib/pv/pvcrash --skip
+```
+
+Translates to:
+```
+/proc/sys/kernel/core_pattern = |/lib/pv/pvcrash --skip
+```
+
+The key path uses underscores where the sysctl path uses slashes/dots.
+
+---
+
+## 6. Runtime Configuration API
+
+### 6.1 Query Configuration
+
+```bash
+curl --unix-socket /run/pantavisor/pv/pv-ctrl http://localhost/config
+```
+
+Returns JSON array with all config entries:
+```json
+[
+  {"key": "PV_LOG_LEVEL", "value": "3", "modified": "pv conf file"},
+  {"key": "PV_BOOTLOADER_TYPE", "value": "rpiab", "modified": "default"},
+  ...
+]
+```
+
+### 6.2 Runtime Overrides via Metadata
+
+Configuration can be overridden at runtime through device user-meta:
+
+```bash
+# Set via Pantahub API or local metadata
+curl -X PUT --unix-socket /run/pantavisor/pv/pv-ctrl \
+  http://localhost/usrmeta/PV_LOG_LEVEL -d '4'
+```
+
+Only keys with `run` (META | CMD) in their allowed levels support runtime override.
+
+---
+
+## 7. Example Configurations
+
+### 7.1 Minimal Embedded Configuration
+
+```
+# /etc/pantavisor/pantavisor.config
+PV_STORAGE_DEVICE=/dev/mmcblk0p2
+PV_STORAGE_FSTYPE=ext4
+PV_BOOTLOADER_TYPE=uboot
+```
+
+### 7.2 Raspberry Pi Configuration
+
+```
+# /etc/pantavisor/pantavisor.config
+PV_STORAGE_DEVICE=/dev/mmcblk0p4
+PV_STORAGE_FSTYPE=ext4
+PV_BOOTLOADER_TYPE=rpiab
+PV_LOG_LEVEL=3
+```
+
+### 7.3 Debug Policy
+
+```
+# /etc/pantavisor/policies/debug.config
+PV_LOG_LEVEL=5
+PV_DEBUG_SHELL=1
+PV_DEBUG_SHELL_AUTOLOGIN=1
+PV_DEBUG_SSH=1
+PV_LXC_LOG_LEVEL=0
+```
+
+### 7.4 Production Policy
+
+```
+# /etc/pantavisor/policies/production.config
+PV_LOG_LEVEL=1
+PV_DEBUG_SHELL=0
+PV_DEBUG_SSH=0
+PV_SECUREBOOT_MODE=strict
+PV_WDT_MODE=always
+```
+
+---
+
+## 8. Legacy Key Migration
+
+The following legacy keys are deprecated. Migrate to canonical format:
+
+| Legacy Key | Canonical Key |
+|------------|---------------|
+| `log.level` | `PV_LOG_LEVEL` |
+| `bootloader.type` | `PV_BOOTLOADER_TYPE` |
+| `storage.device` | `PV_STORAGE_DEVICE` |
+| `creds.host` | `PH_CREDS_HOST` |
+| `updater.interval` | `PH_UPDATER_INTERVAL` |
+| `control.remote` | `PV_CONTROL_REMOTE` |
+| `debug.shell` | `PV_DEBUG_SHELL` |
+| `debug.ssh` | `PV_DEBUG_SSH` |
+| `wdt.mode` | `PV_WDT_MODE` |
+| `secureboot.mode` | `PV_SECUREBOOT_MODE` |
+
+See source code `config.c` for complete alias table.
+
+---
+
+## 9. Related Documentation
+
+- [PLATFORM.md](PLATFORM.md) - Container runtime features and try-boot mechanism
+- [Pantavisor Configuration](https://docs.pantahub.com/pantavisor-configuration/) - Online reference

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,28 +1,238 @@
-# feature/xconnect-landing
+# Pantavisor Development Guide
 
-This branch adds the pv-xconnect service mesh, daemon management, control API enhancements, and shell tooling (pvcurl/pvcontrol).
+This document provides guidance for AI assistants and developers working with the Pantavisor codebase.
 
-## Key Components
+## Current Branch: feature/ipam
 
-| Component | Description |
-|-----------|-------------|
-| `xconnect/` | Service mesh daemon with plugins (unix, rest, dbus, drm, wayland) |
-| `ctrl/` | REST API: /xconnect-graph, /daemons, /signal endpoints |
-| `tools/pvcurl` | Lightweight curl wrapper using nc for HTTP-over-Unix-socket |
-| `tools/pvcontrol` | CLI wrapper around pvcurl for pv-ctrl operations |
-| `utils/tsh.c` | Daemon stdout/stderr capture via logserver |
+This branch implements IP Address Management (IPAM) for container networking with automatic rollback on configuration errors.
 
-## Architecture
+## Quick Reference
 
-- **pv-xconnect**: Standalone mediation service for cross-container communication
-  - Detailed design in [xconnect/XCONNECT.md](xconnect/XCONNECT.md)
-  - Plugin-driven: unix, rest, dbus, drm, wayland
-  - Runs as a managed daemon (DM_ALL mode, all init modes)
-- **Pantavisor as Security Broker**: Containers use logical service names, access granted via explicit `run.json` requirements
-- **Build flag**: `PANTAVISOR_XCONNECT` (CMake), controlled by `xconnect` in `PANTAVISOR_FEATURES` (Yocto)
+### Key Documentation
 
-## Development Guidelines
+| Document | Purpose |
+|----------|---------|
+| [CLAUDE.md](CLAUDE.md) | Comprehensive codebase architecture and API reference |
+| [CONFIGURATION.md](CONFIGURATION.md) | Complete configuration system with layered precedence |
+| [PLATFORM.md](PLATFORM.md) | Container runtime features, try-boot, and rollback |
+| [SYSTEM_STATE.md](SYSTEM_STATE.md) | System state architecture (BSP, containers, storage) |
+| [xconnect/XCONNECT.md](xconnect/XCONNECT.md) | Service mesh specification (D-Bus, Unix, REST) |
 
-- **Formatting**: Run `clang-format -i` on modified `.c`/`.h` files before committing
-- **API testing**: Use `pvcurl` (not `curl`) inside appengine containers
-- **Build**: Use `kas/with-workspace.yaml` overlay for local source development
+### Build Commands
+
+```bash
+# Standard build
+mkdir build && cd build
+cmake ..
+make
+
+# With debug
+cmake -DPANTAVISOR_DEBUG=ON ..
+
+# For appengine (Docker testing)
+cmake -DPANTAVISOR_APPENGINE=ON ..
+```
+
+### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `init.c` | Entry point, early initialization |
+| `pantavisor.c` | Core state machine |
+| `platforms.c` | Container lifecycle management |
+| `ipam.c` / `ipam.h` | IP address management (this branch) |
+| `config.c` / `config.h` | Configuration system |
+| `ctrl/ctrl.c` | REST API server |
+| `parser/parser_system1.c` | State JSON parsing |
+
+---
+
+## Architecture Overview
+
+Pantavisor is the init system (PID 1) for containerized embedded Linux devices.
+
+### Core Concepts
+
+1. **Atomic Updates**: Updates are all-or-nothing with automatic rollback
+2. **Try-Boot**: New revisions are tested before committing
+3. **Containers**: LXC-based isolation for applications
+4. **Service Mesh**: pv-xconnect mediates container-to-container communication
+
+### State Machine
+
+```
+INIT → RUN → WAIT ↔ COMMAND
+               ↓
+           ROLLBACK ← ERROR
+               ↓
+       REBOOT / POWEROFF
+```
+
+### Try-Boot Mechanism
+
+When an update is installed:
+
+1. `pv_try` is set to new revision
+2. Device reboots into new revision
+3. Pantavisor validates (containers start, network works, etc.)
+4. **Success**: Commit (`pv_done = pv_rev`, clear `pv_try`)
+5. **Failure**: Any reboot before commit → bootloader returns to `pv_done`
+
+**Rollback triggers:**
+- Container crash or start failure
+- Essential mount failure
+- Network config error (IPAM validation)
+- Goals timeout (`PV_UPDATER_GOALS_TIMEOUT`)
+- Network timeout (`PH_UPDATER_NETWORK_TIMEOUT`)
+
+---
+
+## Configuration System
+
+Pantavisor uses layered configuration with precedence (low to high):
+
+```
+default → pantavisor.config → policy → oem config → kernel cmdline → env → metadata
+```
+
+### Key Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `PV_UPDATER_COMMIT_DELAY` | 25s | Stability wait before commit |
+| `PV_UPDATER_GOALS_TIMEOUT` | 120s | Container readiness timeout |
+| `PV_LOG_LEVEL` | 0 | Log verbosity (0=FATAL to 5=ALL) |
+| `PV_BOOTLOADER_TYPE` | uboot | Bootloader: `uboot`, `rpiab`, `grub` |
+
+See [CONFIGURATION.md](CONFIGURATION.md) for complete reference.
+
+---
+
+## IPAM (This Branch)
+
+### Overview
+
+IPAM manages container networking through IP pools defined in `device.json`:
+
+```json
+{
+    "network": {
+        "pools": {
+            "internal": {
+                "type": "bridge",
+                "bridge": "br0",
+                "subnet": "10.0.3.0/24",
+                "gateway": "10.0.3.1",
+                "nat": true
+            }
+        }
+    }
+}
+```
+
+Containers request interfaces in `run.json`:
+
+```json
+{
+    "name": "my-app",
+    "network": {
+        "pool": "internal",
+        "hostname": "myhost"
+    }
+}
+```
+
+### Key Files
+
+- `ipam.c` - Pool management, IP allocation, bridge setup
+- `ipam.h` - Data structures (`pv_ip_pool`, `pv_ip_lease`)
+- `platforms.c` - Integration with container startup
+- `parser/parser_system1.c` - Parsing network config from JSON
+
+### Validation & Rollback
+
+Invalid network configuration should fail container start:
+
+| Error | Result |
+|-------|--------|
+| Static IP outside subnet | Container start refused → rollback |
+| IP already in use | Container start refused → rollback |
+| Pool doesn't exist | Container start refused → rollback |
+
+**Fixed in `state.c`**:
+- **Auto-Recovery Collision**: Ensured that network leases (IPAM) are released before a platform is set to `INSTALLED` during a restart. This prevents "IP already in use" errors when a container restarts after a crash.
+- **Legacy Fallback**: Added fallback for `restart_policy: container` so it triggers automatic restart even if `auto_recovery` JSON is not defined.
+
+---
+
+## Testing with Appengine
+
+Appengine is a Docker-based testing environment.
+
+### Quick Start
+
+```bash
+# Build appengine image (from meta-pantavisor)
+./kas-container build .github/configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml
+
+# Load and run
+docker load < build/tmp-scarthgap/deploy/images/docker-x86_64/pantavisor-appengine-docker.tar
+
+docker run --name pva-test -d --privileged \
+    -v $(pwd)/pvtx.d:/usr/lib/pantavisor/pvtx.d \
+    -v storage-test:/var/pantavisor/storage \
+    --entrypoint /bin/sh pantavisor-appengine:1.0 -c "sleep infinity"
+
+# Start pantavisor manually
+docker exec pva-test sh -c 'pv-appengine &'
+
+# Check status
+docker exec pva-test lxc-ls -f
+```
+
+### Useful Commands
+
+```bash
+# Pantavisor logs
+docker exec pva-test cat /run/pantavisor/pv/logs/0/pantavisor/pantavisor.log
+
+# Container logs
+docker exec pva-test cat /run/pantavisor/pv/logs/0/<container>/lxc/console.log
+
+# API queries
+# NOTE: Use pvcurl instead of curl inside appengine
+docker exec pva-test pvcurl --unix-socket /run/pantavisor/pv/pv-ctrl http://localhost/containers
+docker exec pva-test pvcurl --unix-socket /run/pantavisor/pv/pv-ctrl http://localhost/config
+```
+
+---
+
+## Development Guidelines (Gemini Memory)
+
+### Code Formatting
+- **Clang Format**: Always run `clang-format -i` on modified `.c` and `.h` files before committing. Use the `.clang-format` file in the root of the repository.
+- **Whitespace**: Avoid unnecessary newlines that don't serve to structure functional blocks of code. Ensure code modifications are clean and maintain consistent style.
+
+### Commit Style
+
+```
+feat(component): short description
+fix(component): short description
+docs: documentation update
+refactor(component): code improvement
+```
+
+Examples:
+```
+feat(ipam): support static IP and MAC overrides from run.json
+docs: comprehensive IPAM design with in-memory leases
+fix(ctrl): handle NULL host header in HTTP requests
+```
+
+---
+
+## Related Repositories
+
+- **meta-pantavisor**: Yocto layer for building Pantavisor images
+- **pvr**: CLI tool for managing Pantavisor devices
+- **pantahub**: Cloud platform for device management

--- a/INGRESS.md
+++ b/INGRESS.md
@@ -1,0 +1,136 @@
+# Pantavisor Ingress Specification
+
+Ingress allows routing external traffic (TCP or HTTP) from the host network into container-provided services. Pantavisor supports two primary patterns for managing Ingress.
+
+## 1. Global Ingress Policy (Integrated)
+
+Managed centrally in \`device.json\`. This is the preferred method for simple port forwarding and path routing without requiring a dedicated proxy container.
+
+### Specification (\`device.json\`)
+
+\`\`\`json
+{
+  "ingress": [
+    {
+      "name": "public-api",
+      "type": "http",
+      "external": "0.0.0.0:80/api",
+      "provider": "api-container",
+      "service": "api-unix-service"
+    },
+    {
+      "name": "public-https",
+      "type": "tcp",
+      "external": "0.0.0.0:443",
+      "provider": "api-container",
+      "service": "api-https-service"
+    },
+    {
+      "name": "ssh-gateway",
+      "type": "tcp",
+      "external": "0.0.0.0:2222",
+      "provider": "shell-container",
+      "service": "ssh-service"
+    }
+  ]
+}
+\`\`\`
+
+#### Field Definitions:
+- \`name\`: A unique identifier for the ingress rule.
+- \`type\`: The protocol type (\`tcp\` or \`http\`).
+- \`external\`: The host-side listening address and port. For \`http\`, this can include a path prefix (e.g., ":80/api").
+- \`provider\`: The name of the container providing the service.
+- \`service\`: The name of the service as defined in the provider's \`services.json\`.
+
+#### Conflict Resolution:
+Pantavisor validates the global \`ingress\` array at startup. If two rules attempt to bind to the same host port, the entire state is considered invalid, preventing silent port collisions.
+
+---
+
+## 2. Ingress Proxy Container (Advanced)
+
+### Pattern 2b: Isolated Proxy + Integrated Ingress (Recommended for Security)
+
+In this hybrid pattern, the proxy container runs in an isolated network namespace (via IPAM) and does NOT have host network access. External traffic is routed into it via a global ingress rule.
+
+**1. The Ingress Rule (`device.json`):**
+```json
+{
+  "ingress": [
+    {
+      "name": "nginx-ingress-80",
+      "type": "tcp",
+      "external": "0.0.0.0:80",
+      "provider": "proxy-container",
+      "service": "nginx-http"
+    },
+    {
+      "name": "nginx-ingress-443",
+      "type": "tcp",
+      "external": "0.0.0.0:443",
+      "provider": "proxy-container",
+      "service": "nginx-https"
+    }
+  ]
+}
+```
+
+**2. The Proxy Export (`services.json` inside `proxy-container`):**
+```json
+{
+  "services": [
+    {
+      "type": "tcp",
+      "name": "nginx-http",
+      "port": 80
+    }
+  ]
+}
+```
+
+**Pros:**
+- Proxy is isolated from the host network stack.
+- Ports are managed centrally in `device.json` (conflict prevention).
+- Proxy can still use IPAM names to talk to backend containers.
+
+
+For advanced scenarios requiring SSL termination, load balancing, or WAF (e.g., using Nginx or HAProxy).
+
+### Pattern:
+1. **The Proxy Container**: Runs a standard proxy (e.g., Nginx) and requests host network access or a public IP via IPAM.
+2. **IP Downstreams**: The proxy container talks to backend containers using their container names as hostnames over a shared network pool managed by IPAM.
+3. **Configuration**: The proxy configuration is managed via Pantavisor's \`_config\` mechanism.
+
+### Example Nginx Ingress Setup
+
+**Network Configuration (\`device.json\`):**
+\`\`\`json
+{
+  "network": {
+    "pools": {
+      "internal": { "subnet": "10.0.3.0/24" }
+    }
+  }
+}
+\`\`\`
+
+**Backend Container (\`app-1\`) \`args.json\`:**
+\`\`\`json
+{ "PV_NETWORK_POOL": "internal" }
+\`\`\`
+
+**Nginx Container (\`ingress-nginx\`) \`args.json\`:**
+\`\`\`json
+{ "PV_NETWORK_POOL": "internal" }
+\`\`\`
+
+**Nginx configuration (\`_config/ingress-nginx/etc/nginx/conf.d/default.conf\`):**
+\`\`\`nginx
+server {
+    listen 80;
+    location / {
+        proxy_pass http://app-1:8080;
+    }
+}
+\`\`\`

--- a/IPAM.md
+++ b/IPAM.md
@@ -1,0 +1,274 @@
+# IPAM - IP Address Management for Pantavisor
+
+## Overview
+
+IPAM provides automatic IP address allocation and network configuration for containers. Instead of manually configuring network settings in each container's `lxc.container.conf`, you define IP pools in `device.json` and reference them from container `run.json` files.
+
+## Features
+
+- **Bridge Pool Creation**: Automatically creates Linux bridge interfaces with NAT
+- **IP Allocation**: Sequential IP assignment from configured subnet
+- **MAC Generation**: Deterministic MAC addresses derived from allocated IPs (collision-free)
+- **Hostname Configuration**: Per-container hostname support
+- **Lease Management**: Tracks allocations, supports container restart with same IP
+
+## Configuration
+
+### device.json - Pool Definition
+
+Define network pools in the `device.json` file:
+
+```json
+{
+  "groups": [...],
+  "network": {
+    "pools": {
+      "internal": {
+        "type": "bridge",
+        "bridge": "pvbr0",
+        "subnet": "10.0.5.0/24",
+        "gateway": "10.0.5.1",
+        "nat": true
+      },
+      "dmz": {
+        "type": "bridge",
+        "bridge": "pvbr1",
+        "subnet": "192.168.100.0/24",
+        "gateway": "192.168.100.1",
+        "nat": false
+      }
+    }
+  }
+}
+```
+
+#### Pool Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Pool type: `"bridge"` or `"macvlan"` |
+| `bridge` | string | Yes (bridge) | Host bridge interface name |
+| `parent` | string | Yes (macvlan) | Parent interface for macvlan |
+| `subnet` | string | Yes | CIDR notation (e.g., `"10.0.5.0/24"`) |
+| `gateway` | string | Yes | Gateway IP address |
+| `nat` | boolean | No | Enable NAT for outbound traffic (default: false) |
+
+### run.json - Container Network Reference
+
+Reference a pool from the container's `run.json`:
+
+```json
+{
+  "#spec": "service-manifest-run@1",
+  "name": "my-container",
+  "type": "lxc",
+  "config": "lxc.container.conf",
+  "root-volume": "root.squashfs",
+  "network": {
+    "pool": "internal",
+    "hostname": "myhost"
+  }
+}
+```
+
+#### Network Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pool` | string | Yes | Pool name from device.json |
+| `hostname` | string | No | Container hostname |
+
+## How It Works
+
+### Startup Sequence
+
+1. **IPAM Initialization**: `pv_ipam_init()` initializes the subsystem
+2. **Pool Parsing**: `device.json` is parsed, pools registered via `pv_ipam_add_pool()`
+3. **Bridge Setup**: For each bridge pool, creates bridge interface with gateway IP and optionally enables NAT
+4. **Container Start**: When a container starts:
+   - `pv_ipam_allocate()` assigns next available IP from pool
+   - MAC address generated from IP (ensures uniqueness)
+   - LXC network configuration injected dynamically
+
+### IP Allocation
+
+IPs are allocated sequentially starting from gateway + 1:
+- Gateway: 10.0.5.1
+- First container: 10.0.5.2
+- Second container: 10.0.5.3
+- etc.
+
+The broadcast address is reserved and skipped.
+
+### MAC Address Generation
+
+MAC addresses are deterministically derived from the allocated IP to ensure:
+- **Uniqueness**: IPs are unique within a pool, so MACs are too
+- **Stability**: Same IP always produces same MAC
+- **Predictability**: Easy to correlate MACs with IPs for debugging
+
+Format: `02:00:AA:BB:CC:DD` where `AA.BB.CC.DD` is the IP address.
+
+Examples:
+- IP `10.0.5.2` → MAC `02:00:0a:00:05:02`
+- IP `10.0.5.3` → MAC `02:00:0a:00:05:03`
+- IP `192.168.1.100` → MAC `02:00:c0:a8:01:64`
+
+The `02` prefix indicates a locally administered unicast address.
+
+### Lease Persistence
+
+Leases are tracked in memory. If a container restarts, it receives the same IP if its lease still exists. Leases are released when the platform is freed.
+
+## LXC Integration
+
+When a container uses pool-based networking, IPAM dynamically configures LXC:
+
+```
+lxc.net.0.type = veth
+lxc.net.0.link = pvbr0
+lxc.net.0.name = eth0
+lxc.net.0.ipv4.address = 10.0.5.2/24
+lxc.net.0.ipv4.gateway = 10.0.5.1
+lxc.net.0.hwaddr = 02:00:0a:00:05:02
+lxc.net.0.flags = up
+lxc.uts.name = myhost
+```
+
+The `net` namespace is removed from `lxc.namespace.keep` so the container gets its own network namespace.
+
+## NAT Configuration
+
+When `nat: true` is set for a pool, IPAM configures:
+1. IP forwarding: `echo 1 > /proc/sys/net/ipv4/ip_forward`
+2. iptables MASQUERADE rule for the subnet
+
+This allows containers to access external networks through the host.
+
+## Example: Two-Container Setup
+
+### device.json
+```json
+{
+  "groups": [{"name": "root", "restart_policy": "container", "status_goal": "STARTED"}],
+  "network": {
+    "pools": {
+      "internal": {
+        "type": "bridge",
+        "bridge": "pvbr0",
+        "subnet": "10.0.5.0/24",
+        "gateway": "10.0.5.1",
+        "nat": true
+      }
+    }
+  }
+}
+```
+
+### server/run.json
+```json
+{
+  "#spec": "service-manifest-run@1",
+  "name": "server",
+  "type": "lxc",
+  "network": {
+    "pool": "internal",
+    "hostname": "server"
+  }
+}
+```
+
+### client/run.json
+```json
+{
+  "#spec": "service-manifest-run@1",
+  "name": "client",
+  "type": "lxc",
+  "network": {
+    "pool": "internal",
+    "hostname": "client"
+  }
+}
+```
+
+### Result
+```
+$ lxc-ls -f
+NAME   STATE   IPV4
+client RUNNING 10.0.5.3
+server RUNNING 10.0.5.2
+
+$ pventer -c client ping -c1 10.0.5.2
+PING 10.0.5.2: 64 bytes, seq=0 ttl=64 time=0.063 ms
+```
+
+## API Reference
+
+### Pool Management
+
+```c
+// Add a pool (called during device.json parsing)
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+                                     const char *bridge_or_parent,
+                                     const char *subnet_cidr,
+                                     const char *gateway, bool nat);
+
+// Find a pool by name
+struct pv_ip_pool *pv_ipam_find_pool(const char *name);
+```
+
+### IP Allocation
+
+```c
+// Allocate IP for a container (returns "IP/prefix" string)
+char *pv_ipam_allocate(const char *pool_name, const char *container_name);
+
+// Release container's IP back to pool
+void pv_ipam_release(const char *pool_name, const char *container_name);
+
+// Get existing lease
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+                                       const char *container_name);
+```
+
+### Utilities
+
+```c
+// Generate MAC from IP (IP in network byte order)
+char *pv_ipam_generate_mac(uint32_t ip_net);
+
+// Convert IP to string
+char *pv_ipam_ip_to_str(uint32_t ip);
+
+// Parse CIDR notation
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask);
+```
+
+## Troubleshooting
+
+### Container fails to start with network error
+
+Check that:
+1. Pool is defined in `device.json`
+2. Pool name in `run.json` matches exactly
+3. Bridge interface was created: `ip link show pvbr0`
+
+### Containers can't communicate
+
+Verify:
+1. Both containers are on the same pool/bridge
+2. Bridge has gateway IP: `ip addr show pvbr0`
+3. Containers have IPs: `lxc-ls -f`
+
+### No external network access
+
+If NAT is enabled but containers can't reach external hosts:
+1. Check IP forwarding: `cat /proc/sys/net/ipv4/ip_forward` (should be 1)
+2. Check iptables rules: `iptables -t nat -L POSTROUTING`
+
+## Limitations
+
+- IPv4 only (no IPv6 support yet)
+- Maximum ~254 containers per /24 pool
+- Bridge pools require NET_ADMIN capability
+- Leases are not persisted across pantavisor restarts (containers get same IP if started in same order)

--- a/PLATFORM-FUTURE.md
+++ b/PLATFORM-FUTURE.md
@@ -1,0 +1,193 @@
+# Platform Future: Deferred Features
+
+This document tracks future enhancements not yet scheduled for implementation.
+For current features, see [PLATFORM.md](PLATFORM.md).
+
+---
+
+## 1. Advanced Networking
+
+### 1.1 Multi-Interface Containers
+
+Allow containers to connect to multiple pools simultaneously.
+
+**Use case:** Management plane + data plane separation
+
+```json
+{
+    "name": "gateway",
+    "network": {
+        "interfaces": [
+            {"name": "eth0", "pool": "management", "default_route": true},
+            {"name": "eth1", "pool": "data"}
+        ]
+    }
+}
+```
+
+**Status:** Deferred. Initial implementation supports single interface only.
+
+### 1.2 IPv6 Support
+
+Dual-stack pools with IPv6 addressing.
+
+```json
+{
+    "network": {
+        "pools": {
+            "internal": {
+                "subnet": "10.0.3.0/24",
+                "subnet6": "fd00:pv::0/64",
+                "gateway6": "fd00:pv::1"
+            }
+        }
+    }
+}
+```
+
+**Status:** Deferred. IPv4-only for initial implementation.
+
+### 1.3 DHCP Server
+
+Run lightweight DHCP server on bridges for containers that expect DHCP.
+
+**Use case:** Full system containers that run their own DHCP client.
+
+**Status:** Deferred. Static assignment only for initial implementation. Containers receive IP via LXC config injection; no DHCP needed.
+
+### 1.4 CNI Backend
+
+Optional CNI plugin support for Kubernetes-adjacent deployments.
+
+```json
+{
+    "network": {
+        "backend": "cni",
+        "cni_path": "/opt/cni/bin",
+        "pools": { ... }
+    }
+}
+```
+
+**Status:** Deferred. Native netns implementation first; CNI as optional backend later.
+
+### 1.5 Macvlan/IPvlan Pools
+
+Direct attachment to physical network without bridge overhead.
+
+```json
+{
+    "network": {
+        "pools": {
+            "direct-lan": {
+                "type": "macvlan",
+                "parent": "eth0",
+                "mode": "bridge"
+            }
+        }
+    }
+}
+```
+
+**Status:** Deferred. Bridge pools first.
+
+---
+
+## 2. Advanced Recovery
+
+### 2.1 Failure Escalation
+
+Escalate container failure to system reboot after recovery exhaustion.
+
+```json
+{
+    "auto_recovery": {
+        "type": "on-failure",
+        "maximum_retry_count": 5,
+        "escalate_to": "reboot"
+    }
+}
+```
+
+**Status:** Deferred. Current behavior: container enters FAILED state.
+
+### 2.2 Health Checks
+
+Proactive health checking with custom commands or HTTP endpoints.
+
+```json
+{
+    "health_check": {
+        "type": "http",
+        "endpoint": "http://localhost:8080/health",
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3
+    }
+}
+```
+
+**Status:** Not planned. Consider for future.
+
+---
+
+## 3. Service Mesh Extensions
+
+### 3.1 TCP Proxy Plugin
+
+Extend pv-xconnect with TCP proxying for legacy network applications.
+
+**Modes:**
+- Unix-to-TCP: Consumer uses UDS, proxied to provider TCP port
+- TCP-to-TCP: Port mapping within network namespace
+
+**Status:** See [xconnect/XCONNECT-FUTURE.md](xconnect/XCONNECT-FUTURE.md)
+
+### 3.2 Container DNS
+
+DNS server for container name resolution.
+
+```bash
+# Inside container:
+ping webserver.pv.local  # Resolves to 10.0.3.5
+```
+
+**Status:** Deferred. Use API resolution for now.
+
+### 3.3 HTTP Ingress
+
+Layer 7 routing for multi-container HTTP services.
+
+**Status:** See [xconnect/XCONNECT-FUTURE.md](xconnect/XCONNECT-FUTURE.md)
+
+---
+
+## 4. Alternative Runtimes
+
+### 4.1 Runc Network Support
+
+OCI container networking via config.json modification or pre-created netns.
+
+**Status:** Deferred. pv_runc is PoC; focus on pv_lxc first.
+
+### 4.2 Wasmedge Networking
+
+WASI sockets support for WebAssembly workloads.
+
+**Status:** Deferred. pv_wasmedge is PoC.
+
+---
+
+## 5. Roadmap
+
+| Feature | Priority | Dependencies |
+|---------|----------|--------------|
+| Multi-interface | Medium | IPAM core |
+| IPv6 | Low | IPAM core |
+| CNI backend | Low | IPAM core |
+| DHCP server | Low | Bridge setup |
+| Failure escalation | Medium | Auto-recovery |
+| Health checks | Low | - |
+| TCP proxy | Medium | xconnect |
+| Container DNS | Medium | IPAM core |
+| Runc networking | Low | IPAM core |

--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -1,0 +1,552 @@
+# Platform: Container Runtime Features
+
+This document describes implemented and in-progress container runtime features in Pantavisor.
+
+---
+
+## 1. Container Lifecycle Control
+
+**Status:** ✅ Implemented (PR #612)
+
+### API
+
+```bash
+# Stop a container
+curl -X PUT --unix-socket /run/pv/pv-ctrl \
+  http://localhost/containers/myapp -d '{"action": "stop"}'
+
+# Start a stopped container
+curl -X PUT --unix-socket /run/pv/pv-ctrl \
+  http://localhost/containers/myapp -d '{"action": "start"}'
+
+# Restart (atomic stop + start)
+curl -X PUT --unix-socket /run/pv/pv-ctrl \
+  http://localhost/containers/myapp -d '{"action": "restart"}'
+```
+
+### Constraints
+- Only containers with `restart_policy: container` can be controlled
+- Containers with `restart_policy: system` are protected (require reboot)
+
+---
+
+## 2. Auto-Recovery
+
+**Status:** ✅ Implemented (PR #610)
+
+Containers can define recovery policies for automatic restart on failure.
+
+### Configuration (`run.json`)
+
+```json
+{
+    "name": "my-app",
+    "auto_recovery": {
+        "type": "on-failure",
+        "maximum_retry_count": 5,
+        "retry_delay": 1,
+        "backoff_factor": 2.0,
+        "reset_window": 300
+    }
+}
+```
+
+### Policy Types
+
+| Type | Behavior |
+|------|----------|
+| `no` | Default. Exit = Stop. |
+| `always` | Restart on any exit (including exit 0) |
+| `on-failure` | Restart only on non-zero exit |
+| `unless-stopped` | Restart unless stopped via API |
+
+### Backoff
+
+Exponential backoff prevents crash loops:
+- First retry: `retry_delay` seconds
+- Subsequent: `delay * backoff_factor`
+- After `maximum_retry_count`: container stops, enters FAILED state
+- If running longer than `reset_window`: retry counter resets
+
+---
+
+## 3. Dynamic Networking (IPAM)
+
+**Status:** 🔲 In Development
+
+### 3.1 Overview
+
+Pantavisor manages container networking through IP pools defined at the device level. Containers request interfaces from pools and receive dynamically allocated IPs.
+
+**Design Principles:**
+- Names are identity; IPs are ephemeral
+- Sticky IPs within boot session (restart keeps same IP)
+- Fresh allocation on device reboot (no persistence)
+- Backward compatible with static `lxc.container.conf`
+
+### 3.2 Pool Definition (`device.json`)
+
+BSP/integrator defines available networks:
+
+```json
+{
+    "network": {
+        "pools": {
+            "internal": {
+                "type": "bridge",
+                "bridge": "br0",
+                "subnet": "10.0.3.0/24",
+                "gateway": "10.0.3.1",
+                "nat": true
+            }
+        }
+    }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `type` | `bridge` (veth pair to bridge) or `macvlan` (direct to parent) |
+| `bridge` | Bridge interface name (for type=bridge) |
+| `parent` | Parent interface (for type=macvlan) |
+| `subnet` | IP subnet in CIDR notation |
+| `gateway` | Gateway IP (assigned to bridge) |
+| `nat` | Enable NAT for outbound traffic |
+
+### 3.3 Interface Request (`run.json`)
+
+Containers request a single interface from a pool:
+
+```json
+{
+    "name": "webserver",
+    "network": {
+        "pool": "internal",
+        "hostname": "webserver"
+    }
+}
+```
+
+Or explicit host networking (bypass IPAM):
+
+```json
+{
+    "name": "legacy-app",
+    "network": {
+        "mode": "host"
+    }
+}
+```
+
+**Default:** No `network` section = use static `lxc.container.conf` (backward compatible)
+
+### 3.4 IP Allocation
+
+In-memory lease tracking:
+
+```
+Container start → Allocate next IP from pool → Create lease
+Container restart → Reuse existing lease (same IP)
+Container stop → Lease retained (for restart)
+Container removed → Release lease
+Device reboot → All leases cleared
+```
+
+IPs are allocated sequentially starting from `gateway + 1`.
+
+### 3.5 Static Config Validation
+
+Containers with static IPs in `lxc.container.conf` are validated against pools:
+
+| Static Config | run.json | Result |
+|--------------|----------|--------|
+| IP on br0, in subnet | Pool uses br0 | ✅ Honor static, reserve in pool |
+| IP on br1 | Pool uses br0 | ❌ Bridge mismatch → refuse, rollback |
+| IP outside subnet | Pool defined | ❌ IP conflict → refuse, rollback |
+| Any static config | No network section | ✅ Legacy mode, no validation |
+
+### 3.6 Bridge Setup
+
+On boot, Pantavisor:
+1. Creates bridge interface (e.g., `br0`)
+2. Assigns gateway IP to bridge
+3. Sets up NAT rules (iptables or nftables, whichever available)
+4. Enables IP forwarding
+
+### 3.7 LXC Integration
+
+For containers with pool networking, Pantavisor injects LXC config:
+
+```
+lxc.net.0.type = veth
+lxc.net.0.link = br0
+lxc.net.0.name = eth0
+lxc.net.0.ipv4.address = 10.0.3.2/24
+lxc.net.0.ipv4.gateway = 10.0.3.1
+lxc.net.0.flags = up
+```
+
+This overrides any static network config in `lxc.container.conf`.
+
+### 3.8 Name Resolution
+
+Container IPs are exposed via API:
+
+```bash
+curl --unix-socket /run/pv/pv-ctrl http://localhost/containers | jq .
+```
+
+Response includes `ipv4_address` for each container. Use pv-xconnect or query API for name→IP resolution.
+
+### 3.9 MAC Address Generation
+
+MAC addresses are generated deterministically from container name:
+```
+02:pv:XX:XX:XX:XX  (XX = hash of container name)
+```
+
+This ensures same MAC on restart (helps with ARP caches, debugging).
+
+---
+
+## 4. Container Status API
+
+**Status:** ✅ Implemented (PR #612)
+
+### GET /containers
+
+Returns detailed runtime status:
+
+```json
+[{
+    "name": "my-container",
+    "status": "STARTED",
+    "status_goal": "STARTED",
+    "pid": 1234,
+    "uptime_secs": 3600,
+    "restart_policy": "container",
+    "auto_recovery": {
+        "type": "on-failure",
+        "max_retries": 5,
+        "current_retries": 0
+    },
+    "provides": [
+        {"name": "my-api", "type": "rest", "socket": "/run/my.sock"}
+    ],
+    "consumes": [
+        {"name": "db", "type": "unix", "requirement": "required", "role": "client"}
+    ]
+}]
+```
+
+---
+
+## 5. Try-Boot and Rollback
+
+Pantavisor implements atomic updates with automatic rollback. When an update is installed, the device enters "try-boot" mode. If the new revision fails to reach a stable state, the system automatically rolls back to the previous working revision.
+
+### 5.1 Overview
+
+The try-boot mechanism ensures devices remain operational even if an update is faulty:
+
+1. **Install**: New revision is written, `pv_try` is set
+2. **Reboot**: Device boots into new revision (try-boot mode)
+3. **Validate**: Pantavisor waits for system stability
+4. **Commit or Rollback**:
+   - Success → commit new revision as `pv_done`
+   - Failure → reboot returns to previous `pv_done`
+
+**Key principle**: Any reboot before commit is a rollback. Whether it's a controlled reboot triggered by pantavisor due to failure, or an unexpected kernel panic, the bootloader will return to the last known good revision.
+
+### 5.2 Bootloader Variables
+
+Four variables control update state:
+
+| Variable | Storage | Purpose |
+|----------|---------|---------|
+| `pv_rev` | Kernel cmdline | Currently booted revision |
+| `pv_try` | Persistent (uboot.txt/rpiab.txt) | Revision to try |
+| `pv_done` | Persistent | Last committed revision |
+| `pv_trying` | Persistent (pv.env) | Latch to detect rollback |
+
+**State relationships:**
+
+```
+Normal operation:     pv_rev == pv_done, pv_try empty
+Installing update:    pv_try = new_rev, pv_rev == pv_done
+Trying update:        pv_rev == pv_try (booted into new revision)
+After commit:         pv_rev == pv_done == new_rev, pv_try cleared
+After rollback:       pv_rev == pv_done (old revision), pv_try cleared
+```
+
+### 5.3 Bootloader Logic
+
+The bootloader (U-Boot) uses `pv_trying` as a latch to detect rollback:
+
+```
+if pv_try is set:
+    if pv_trying == pv_try:
+        # Already tried this revision and rebooted → ROLLBACK
+        boot pv_rev (previous stable)
+    else:
+        # First attempt → try the new revision
+        set pv_trying = pv_try
+        boot pv_try
+else:
+    # Normal boot
+    boot pv_rev
+```
+
+Reference implementation: `meta-pantavisor/recipes-bsp/u-boot/files/boot.cmd.pvgeneric`
+
+### 5.4 Boot Success Criteria
+
+For pantavisor to commit a try-boot revision, ALL of the following must be true:
+
+1. **All containers started** - No container startup failures
+2. **Essential mounts succeeded** - All required disks/volumes mounted
+3. **Readiness signals received** - Containers with `status_goal: ready` signaled via pv-ctrl
+4. **Stability period passed** - System stable for `PV_UPDATER_COMMIT_DELAY` seconds
+5. **Network connected** (remote devices) - Pantahub communication working
+
+Only after all criteria are met does pantavisor commit: `pv_done = pv_rev`, clear `pv_try`.
+
+### 5.5 Rollback Triggers
+
+Any of these conditions trigger rollback (reboot to previous revision):
+
+| Trigger | Description |
+|---------|-------------|
+| Container crash | Any container exits unexpectedly during startup |
+| Container start failure | Container fails to start (bad config, missing deps) |
+| Essential mount failure | Required disk/volume fails to mount |
+| Network config error | Invalid IPAM configuration (IP outside subnet, etc.) |
+| Goals timeout | Containers don't reach `status_goal` within `PV_UPDATER_GOALS_TIMEOUT` |
+| Network timeout | Can't reach Pantahub within `PH_UPDATER_NETWORK_TIMEOUT` (remote devices) |
+| Kernel panic | Unexpected crash causes reboot |
+| Watchdog timeout | System hangs, hardware watchdog triggers reboot |
+
+### 5.6 Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `PV_UPDATER_COMMIT_DELAY` | 25s | Stability period before commit |
+| `PV_UPDATER_GOALS_TIMEOUT` | 120s | Max time for containers to reach ready state |
+| `PH_UPDATER_NETWORK_TIMEOUT` | 120s | Max time to establish Pantahub connection |
+| `PV_REVISION_RETRIES` | 10 | Retry attempts before permanent rollback |
+
+See [CONFIGURATION.md](CONFIGURATION.md) for the complete configuration reference and layered precedence model.
+
+### 5.7 Container Readiness
+
+Containers can declare a `status_goal` in their configuration:
+
+```json
+{
+    "name": "my-app",
+    "status_goal": "ready"
+}
+```
+
+**Status goals:**
+
+| Goal | Meaning |
+|------|---------|
+| `started` | Container process running (default) |
+| `ready` | Container must signal readiness via pv-ctrl |
+
+**Signaling readiness:**
+
+```bash
+# From inside container
+curl -X PUT --unix-socket /pv/pv-ctrl/ctrl \
+  http://localhost/containers/my-app -d '{"status": "ready"}'
+```
+
+If a container with `status_goal: ready` doesn't signal within `PV_UPDATER_GOALS_TIMEOUT`, the system rolls back.
+
+### 5.8 Network Configuration Validation
+
+IPAM validates network configuration at container start. Invalid configuration prevents container startup, triggering rollback during try-boot:
+
+| Validation | Error | Result |
+|------------|-------|--------|
+| Static IP outside pool subnet | IP 10.0.5.200 not in 10.0.3.0/24 | Container start refused |
+| Static IP already in use | IP collision with another container | Container start refused |
+| Pool doesn't exist | Reference to undefined pool | Container start refused |
+
+**Example invalid configuration:**
+
+```json
+{
+    "network": {
+        "pools": {
+            "internal": {
+                "subnet": "10.0.3.0/24",
+                "gateway": "10.0.3.1"
+            }
+        }
+    }
+}
+```
+
+```json
+{
+    "name": "my-app",
+    "network": {
+        "pool": "internal",
+        "static_ip": "192.168.1.100"  // ERROR: outside 10.0.3.0/24
+    }
+}
+```
+
+This container will fail to start. During try-boot, this triggers rollback to the previous working revision.
+
+### 5.9 Rollback Detection
+
+When pantavisor boots after a rollback, it detects the situation:
+
+```
+pv_rev != pv_try (but pv_try was set)
+```
+
+Pantavisor logs the rollback event and clears `pv_try`. The system continues operating on the stable `pv_done` revision.
+
+### 5.10 Bootloader Customization
+
+The reference bootloader script (`boot.cmd.pvgeneric`) supports several customization mechanisms for tweaking kernel command line during development and production.
+
+#### Environment Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `oemEnv.txt` | Boot partition | OEM environment overrides, loaded early |
+| `uboot.txt` | `/boot/` on data partition | Pantavisor state (pv_rev, pv_try) |
+| `pv.env` | Boot partition | Try-boot latch (pv_trying) |
+
+#### Command Line Variables
+
+The kernel command line is assembled from multiple sources:
+
+```
+${pv_platargs} ${pv_baseargs} pv_try=${pv_try} pv_rev=${boot_rev} panic=2 pv_quickboot ${fdtbootargs} ${configargs} ${oemargs} ${localargs}
+```
+
+| Variable | Source | Purpose |
+|----------|--------|---------|
+| `pv_platargs` | U-Boot env / oemEnv.txt | Platform-specific args (default: `earlyprintk`) |
+| `pv_baseargs` | Hardcoded | Core boot args: `panic=3 root=/dev/ram rootfstype=ramfs rdinit=/usr/bin/pantavisor` |
+| `fdtbootargs` | Device tree `/chosen/bootargs` | Args from DTB (display, memory config) |
+| `configargs` | U-Boot env | BSP configuration args |
+| `oemargs` | U-Boot env / oemEnv.txt | OEM-specific production args |
+| `localargs` | U-Boot env | Local development/debug args |
+
+#### Development Customization
+
+**Method 1: oemEnv.txt on boot partition**
+
+Create `oemEnv.txt` with U-Boot environment format:
+```
+localargs=loglevel=7
+configargs=cma=128M
+```
+
+**Method 2: U-Boot environment**
+
+Set variables in U-Boot before boot:
+```
+setenv localargs "loglevel=7"
+saveenv
+```
+
+**Method 3: Runtime via pv.env**
+
+The `pv.env` file on boot partition can store persistent variables that survive across boots.
+
+#### Kernel Cmdline Configuration
+
+Only specific pantavisor settings can be configured via kernel command line:
+
+| Config Key | Cmdline | Description |
+|------------|---------|-------------|
+| `PV_STORAGE_DEVICE` | Yes | Storage device path (mandatory) |
+| `PV_STORAGE_FSTYPE` | Yes | Filesystem type: `ext4`, `ubifs`, `jffs2` (mandatory) |
+| `PV_STORAGE_MNTPOINT` | Yes | Storage mount point (mandatory) |
+| `PV_SYSTEM_INIT_MODE` | Yes | Mode: `embedded`, `standalone`, `appengine` |
+
+Most pantavisor configuration is done via config files, not kernel cmdline. See [Pantavisor Configuration](https://docs.pantahub.com/pantavisor-configuration/) for the full reference.
+
+#### Common Customizations
+
+| Use Case | Variable | Example |
+|----------|----------|---------|
+| Kernel debug | `localargs` | `loglevel=7 debug` |
+| Serial console | `pv_platargs` | `console=ttyS0,115200 earlyprintk` |
+| Memory config | `configargs` | `cma=256M` |
+| Display config | `fdtbootargs` | (set in DTB) |
+| Production tweaks | `oemargs` | `quiet` |
+| Init mode | `localargs` | `PV_SYSTEM_INIT_MODE=appengine` |
+| Storage | `localargs` | `PV_STORAGE_DEVICE=/dev/mmcblk0p2 PV_STORAGE_FSTYPE=ext4` |
+
+#### Precedence
+
+Variables are concatenated in order, so later variables can override earlier ones for some kernel parameters. Platform-specific (`pv_platargs`) comes first, development (`localargs`) comes last.
+
+### 5.11 Sequence Diagram
+
+```
+                    INSTALL UPDATE
+                          │
+                          ▼
+              ┌─────────────────────┐
+              │  Set pv_try = new   │
+              │  Write boot image   │
+              └─────────────────────┘
+                          │
+                          ▼
+                       REBOOT
+                          │
+                          ▼
+              ┌─────────────────────┐
+              │  Bootloader checks  │
+              │  pv_try vs pv_trying│
+              └─────────────────────┘
+                          │
+            ┌─────────────┴─────────────┐
+            │                           │
+     First attempt              Already tried
+            │                           │
+            ▼                           ▼
+    Boot pv_try                 Boot pv_rev
+    Set pv_trying               (ROLLBACK)
+            │
+            ▼
+    ┌───────────────┐
+    │  Pantavisor   │
+    │  validates    │
+    └───────────────┘
+            │
+  ┌─────────┴─────────┐
+  │                   │
+Success            Failure
+  │                   │
+  ▼                   ▼
+COMMIT              REBOOT
+pv_done=new         (triggers
+pv_try=∅            rollback)
+```
+
+---
+
+## 6. Implementation Status
+
+| Feature | Status | PR |
+|---------|--------|-----|
+| Container stop/start/restart | ✅ Done | #612 |
+| Enhanced status API | ✅ Done | #612 |
+| Auto-recovery policies | ✅ Done | #610 |
+| IPAM core (pools, leases) | ✅ Done | - |
+| Bridge/NAT setup | ✅ Done | - |
+| LXC network injection | ✅ Done | - |
+| Static IP validation | 🔲 In Progress | - |
+| Network config rollback | 🔲 In Progress | - |

--- a/appengine/pv-appengine.in
+++ b/appengine/pv-appengine.in
@@ -4,12 +4,17 @@ set -e
 
 interrupt='false'
 
+once='false'
+
+
+
 usage() {
 	echo "Usage: $0 [options]"
 	echo "Run Pantavisor in an existing OS"
 	echo "options:"
 	echo "       -h         show help"
-	echo "       -i         interrupt auto reboot and wait for user confirmation"
+	echo "       -i         wait for user confirmation between reboots"
+	echo "       -o         run only once and exit"
 	echo "       -c CMDLINE additional cmdline arguments (incl. legacy configs)"
 	echo "       -e ENVS envs to set (incl. new config format)"
 }
@@ -139,6 +144,10 @@ exec_run() {
 				break
 			fi
 		fi
+		if [ "$once" = 'true' ]; then
+			echo "Run once mode enabled. Exiting..."
+			break
+		fi
 		echo "restarting in 5 seconds..."
 		sleep 5 || true
 	done
@@ -156,10 +165,13 @@ while [ $# -gt 0 ]; do
 	-h)
 		usage
 		exit 0
-		;; 
+		;;
 	-i)
 		interrupt='true'
-		;; 
+		;;
+	-o)
+		once='true'
+		;;
 	-c)
 		shift
 		cmdline="$1"
@@ -167,10 +179,10 @@ while [ $# -gt 0 ]; do
 	-e)
 		shift
 		envs="$1"
-		;; 
+		;;
 	*)
 		break
-		;; 
+		;;
 	esac
 	shift
 done

--- a/cgroup.c
+++ b/cgroup.c
@@ -374,7 +374,6 @@ static char *pv_cgroup_parse_proc_unified(FILE *fd)
 
 	return pname;
 }
-
 char *pv_cgroup_get_process_name(pid_t pid)
 {
 	int len;

--- a/ctrl/ctrl_containers_ep.c
+++ b/ctrl/ctrl_containers_ep.c
@@ -26,8 +26,13 @@
 #include "ctrl_util.h"
 #include "state.h"
 #include "pantavisor.h"
+#include "platforms.h"
+#include "group.h"
+#include "utils/json.h"
 
 #include <event2/http.h>
+#include <event2/buffer.h>
+#include <linux/limits.h>
 
 #include <string.h>
 
@@ -53,9 +58,174 @@ static void ctrl_containers_list(struct evhttp_request *req, void *ctx)
 	pv_ctrl_utils_send_json(req, HTTP_OK, NULL, cont);
 }
 
+static void ctrl_container_process_action(struct evbuffer *buf,
+					  const struct evbuffer_cb_info *info,
+					  void *ctx)
+{
+	struct evhttp_request *req = ctx;
+	char *data = NULL;
+	char *action = NULL;
+	int tokc;
+	jsmntok_t *tokv = NULL;
+	struct pv_platform *p = NULL;
+	struct pantavisor *pv = pv_get_instance();
+
+	if (!info->n_added)
+		return;
+
+	const char *uri = evhttp_request_get_uri(req);
+	char split[PV_CTRL_MAX_SPLIT][NAME_MAX] = { 0 };
+	int size = pv_ctrl_utils_split_path(uri, split);
+
+	if (size < 2) {
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST,
+					 "Missing container name");
+		return;
+	}
+
+	p = pv_state_fetch_platform(pv->state, split[1]);
+	if (!p) {
+		pv_ctrl_utils_send_error(req, HTTP_NOTFOUND,
+					 "Container not found");
+		return;
+	}
+
+	if (p->restart_policy != RESTART_CONTAINER) {
+		pv_ctrl_utils_send_error(
+			req, HTTP_FORBIDDEN,
+			"Container has restart_policy 'system' and cannot be controlled via API");
+		return;
+	}
+
+	data = pv_ctrl_utils_get_data(req, 1024, NULL);
+	if (!data) {
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST, "No data");
+		return;
+	}
+
+	jsmn_parser parser;
+	jsmn_init(&parser);
+	tokc = jsmn_parse(&parser, data, strlen(data), NULL, 0);
+	if (tokc < 0) {
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST, "Invalid JSON");
+		return;
+	}
+	tokv = calloc(tokc, sizeof(jsmntok_t));
+	if (!tokv) {
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_INTERNAL, "Out of memory");
+		return;
+	}
+	jsmn_init(&parser);
+	jsmn_parse(&parser, data, strlen(data), tokv, tokc);
+
+	action = pv_json_get_value(data, "action", tokv, tokc);
+
+	if (!action) {
+		free(tokv);
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST,
+					 "Missing 'action' field");
+		return;
+	}
+
+	if (strcmp(action, "stop") == 0) {
+		pv_log(DEBUG, "Stopping container %s via ctrl", p->name);
+
+		if (pv_platform_is_stopped(p)) {
+			pv_log(DEBUG, "Container %s is already stopped",
+			       p->name);
+		} else {
+			p->auto_recovery.type = RECOVERY_NO;
+			pv_platform_set_status_goal(p, PLAT_STOPPED);
+			pv_platform_force_stop(p);
+		}
+	} else if (strcmp(action, "start") == 0) {
+		pv_log(DEBUG, "Starting container %s via ctrl", p->name);
+
+		if (pv_platform_is_started(p) || pv_platform_is_starting(p) ||
+		    pv_platform_is_ready(p)) {
+			pv_log(DEBUG, "Container %s is already running",
+			       p->name);
+		} else if (pv_platform_is_stopped(p)) {
+			pv_platform_set_status_goal(
+				p, p->group->default_status_goal);
+			pv_platform_set_mounted(p);
+			pv_platform_start(p);
+		} else {
+			free(action);
+			free(tokv);
+			free(data);
+			pv_ctrl_utils_send_error(
+				req, HTTP_BADREQUEST,
+				"Container must be in STOPPED state to start");
+			return;
+		}
+	} else if (strcmp(action, "restart") == 0) {
+		pv_log(DEBUG, "Restarting container %s via ctrl", p->name);
+
+		if (pv_platform_is_stopped(p)) {
+			pv_platform_set_status_goal(
+				p, p->group->default_status_goal);
+			pv_platform_set_mounted(p);
+			pv_platform_start(p);
+		} else if (pv_platform_is_started(p) ||
+			   pv_platform_is_starting(p) ||
+			   pv_platform_is_ready(p)) {
+			p->auto_recovery.type = RECOVERY_NO;
+			pv_platform_set_status_goal(p, PLAT_STOPPED);
+			pv_platform_force_stop(p);
+			pv_platform_set_status_goal(
+				p, p->group->default_status_goal);
+			pv_platform_set_mounted(p);
+			pv_platform_start(p);
+		} else {
+			free(action);
+			free(tokv);
+			free(data);
+			pv_ctrl_utils_send_error(
+				req, HTTP_BADREQUEST,
+				"Container state does not allow restart");
+			return;
+		}
+	} else {
+		free(action);
+		free(tokv);
+		free(data);
+		pv_ctrl_utils_send_error(
+			req, HTTP_BADREQUEST,
+			"Invalid action. Use 'start', 'stop', or 'restart'");
+		return;
+	}
+
+	free(action);
+	free(tokv);
+	free(data);
+
+	pv_ctrl_utils_send_ok(req);
+}
+
+static void ctrl_container_put(struct evhttp_request *req, void *ctx)
+{
+	char err[PV_CTRL_MAX_ERR] = { 0 };
+	int code = pv_ctrl_utils_is_req_ok(req, ctx, err);
+	if (code != 0) {
+		pv_ctrl_utils_drain_on_arrive_with_err(req, code, err);
+		return;
+	}
+
+	pv_log(DEBUG, "PUT request for containers");
+
+	evbuffer_add_cb(evhttp_request_get_input_buffer(req),
+			ctrl_container_process_action, req);
+}
+
 int pv_ctrl_endpoints_containers_init()
 {
 	pv_ctrl_add_endpoint("/containers", EVHTTP_REQ_GET, true,
 			     ctrl_containers_list);
+	pv_ctrl_add_endpoint("/containers/{}", EVHTTP_REQ_PUT, true,
+			     ctrl_container_put);
 	return 0;
 }

--- a/daemons.c
+++ b/daemons.c
@@ -145,6 +145,20 @@ int pv_init_daemon_exited(pid_t pid)
 	return 0;
 }
 
+void pv_init_stop_daemons(void)
+{
+	int i = 0;
+	while (daemons[i].name) {
+		if (daemons[i].pid > 0) {
+			pv_log(INFO, "Stopping daemon %s (pid %d)",
+			       daemons[i].name, daemons[i].pid);
+			daemons[i].respawn = 0;
+			kill(daemons[i].pid, SIGTERM);
+		}
+		i++;
+	}
+}
+
 static int pv_daemons_init(struct pv_init *this)
 {
 	init_mode_t mode = pv_config_get_system_init_mode();

--- a/daemons.h
+++ b/daemons.h
@@ -52,4 +52,6 @@ int pv_init_is_daemon(pid_t pid);
 
 int pv_init_daemon_exited(pid_t pid);
 
+void pv_init_stop_daemons(void);
+
 #endif // PV_DAEMONS_H

--- a/ipam.c
+++ b/ipam.c
@@ -1,0 +1,696 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/sockios.h>
+
+#include "ipam.h"
+#include "config.h"
+#include "utils/str.h"
+
+#define MODULE_NAME "ipam"
+#define pv_log(level, msg, ...)                                                \
+	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
+	     ##__VA_ARGS__)
+#include "log.h"
+
+// Global IPAM state
+static struct pv_ipam ipam_state = { .initialized = false };
+
+int pv_ipam_init(void)
+{
+	if (ipam_state.initialized)
+		return 0;
+
+	dl_list_init(&ipam_state.pools);
+	ipam_state.initialized = true;
+
+	pv_log(INFO, "IPAM subsystem initialized");
+	return 0;
+}
+
+void pv_ipam_free(void)
+{
+	struct pv_ip_pool *pool, *pool_tmp;
+	struct pv_ip_lease *lease, *lease_tmp;
+
+	dl_list_for_each_safe(pool, pool_tmp, &ipam_state.pools,
+			      struct pv_ip_pool, list)
+	{
+		dl_list_for_each_safe(lease, lease_tmp, &pool->leases,
+				      struct pv_ip_lease, list)
+		{
+			dl_list_del(&lease->list);
+			if (lease->container_name)
+				free(lease->container_name);
+			free(lease);
+		}
+		dl_list_del(&pool->list);
+		if (pool->name)
+			free(pool->name);
+		if (pool->bridge)
+			free(pool->bridge);
+		if (pool->parent)
+			free(pool->parent);
+		free(pool);
+	}
+
+	ipam_state.initialized = false;
+	pv_log(INFO, "IPAM subsystem freed");
+}
+
+struct pv_ipam *pv_ipam_get(void)
+{
+	return &ipam_state;
+}
+
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask)
+{
+	char *cidr_copy, *slash;
+	int prefix_len;
+	struct in_addr addr;
+
+	if (!cidr || !subnet || !mask)
+		return -1;
+
+	cidr_copy = strdup(cidr);
+	if (!cidr_copy)
+		return -1;
+
+	slash = strchr(cidr_copy, '/');
+	if (!slash) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*slash = '\0';
+	prefix_len = atoi(slash + 1);
+
+	if (prefix_len < 0 || prefix_len > 32) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	if (inet_pton(AF_INET, cidr_copy, &addr) != 1) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*subnet = addr.s_addr;
+
+	if (prefix_len == 0)
+		*mask = 0;
+	else
+		*mask = htonl(~((1 << (32 - prefix_len)) - 1));
+
+	free(cidr_copy);
+	return 0;
+}
+
+char *pv_ipam_ip_to_str(uint32_t ip)
+{
+	struct in_addr addr;
+	addr.s_addr = ip;
+	return strdup(inet_ntoa(addr));
+}
+
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask)
+{
+	return (ip & mask) == (subnet & mask);
+}
+
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat)
+{
+	struct pv_ip_pool *pool;
+	uint32_t subnet, mask;
+	struct in_addr gw_addr;
+
+	if (!name || !bridge_or_parent || !subnet_cidr || !gateway) {
+		pv_log(ERROR, "invalid pool parameters");
+		return NULL;
+	}
+
+	if (pv_ipam_parse_cidr(subnet_cidr, &subnet, &mask) < 0) {
+		pv_log(ERROR, "invalid subnet CIDR: %s", subnet_cidr);
+		return NULL;
+	}
+
+	if (inet_pton(AF_INET, gateway, &gw_addr) != 1) {
+		pv_log(ERROR, "invalid gateway IP: %s", gateway);
+		return NULL;
+	}
+
+	// Check if pool already exists
+	if (pv_ipam_find_pool(name)) {
+		pv_log(WARN, "pool '%s' already exists", name);
+		return NULL;
+	}
+
+	pool = calloc(1, sizeof(struct pv_ip_pool));
+	if (!pool)
+		return NULL;
+
+	pool->name = strdup(name);
+	pool->type = type;
+	pool->subnet = subnet;
+	pool->mask = mask;
+	pool->gateway = gw_addr.s_addr;
+	pool->nat = nat;
+	pool->bridge_created = false;
+
+	if (type == POOL_TYPE_BRIDGE)
+		pool->bridge = strdup(bridge_or_parent);
+	else
+		pool->parent = strdup(bridge_or_parent);
+
+	// Start allocating from gateway + 1
+	pool->next_ip = ntohl(gw_addr.s_addr) + 1;
+
+	dl_list_init(&pool->leases);
+	dl_list_init(&pool->list);
+	dl_list_add_tail(&ipam_state.pools, &pool->list);
+
+	pv_log(INFO, "added pool '%s': type=%s, subnet=%s, gateway=%s, nat=%s",
+	       name, type == POOL_TYPE_BRIDGE ? "bridge" : "macvlan",
+	       subnet_cidr, gateway, nat ? "yes" : "no");
+
+	return pool;
+}
+
+struct pv_ip_pool *pv_ipam_find_pool(const char *name)
+{
+	struct pv_ip_pool *pool;
+
+	if (!name)
+		return NULL;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (strcmp(pool->name, name) == 0)
+			return pool;
+	}
+
+	return NULL;
+}
+
+static bool is_ip_available(struct pv_ip_pool *pool, uint32_t ip)
+{
+	struct pv_ip_lease *lease;
+
+	// Check if IP is the gateway
+	if (ip == pool->gateway)
+		return false;
+
+	// Check if IP is in existing leases
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (lease->ip == ip)
+			return false;
+	}
+
+	return true;
+}
+
+char *pv_ipam_allocate(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *existing;
+	uint32_t ip, ip_net;
+	uint32_t broadcast, max_ip;
+	char *result;
+	int prefix_len;
+	uint32_t mask_host;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return NULL;
+	}
+
+	// Check if container already has a lease
+	existing = pv_ipam_get_lease(pool_name, container_name);
+	if (existing) {
+		// Reuse existing lease
+		char *ip_str = pv_ipam_ip_to_str(existing->ip);
+		mask_host = ntohl(pool->mask);
+		prefix_len = __builtin_popcount(mask_host);
+		result = malloc(strlen(ip_str) + 4);
+		sprintf(result, "%s/%d", ip_str, prefix_len);
+		free(ip_str);
+		pv_log(DEBUG, "reusing existing lease for %s: %s",
+		       container_name, result);
+		return result;
+	}
+
+	// Calculate broadcast address
+	broadcast = pool->subnet | ~pool->mask;
+	max_ip = ntohl(broadcast) - 1; // Last usable IP
+
+	// Find next available IP
+	ip = pool->next_ip;
+	while (ip <= max_ip) {
+		ip_net = htonl(ip);
+		if (is_ip_available(pool, ip_net)) {
+			// Found available IP
+			lease = calloc(1, sizeof(struct pv_ip_lease));
+			if (!lease)
+				return NULL;
+
+			lease->container_name = strdup(container_name);
+			lease->ip = ip_net;
+			lease->in_use = true;
+			dl_list_init(&lease->list);
+			dl_list_add_tail(&pool->leases, &lease->list);
+
+			// Update next_ip cursor
+			pool->next_ip = ip + 1;
+
+			// Format result as CIDR
+			char *ip_str = pv_ipam_ip_to_str(ip_net);
+			mask_host = ntohl(pool->mask);
+			prefix_len = __builtin_popcount(mask_host);
+			result = malloc(strlen(ip_str) + 4);
+			sprintf(result, "%s/%d", ip_str, prefix_len);
+			free(ip_str);
+
+			pv_log(INFO, "allocated %s to %s from pool %s", result,
+			       container_name, pool_name);
+			return result;
+		}
+		ip++;
+	}
+
+	pv_log(ERROR, "no available IPs in pool '%s'", pool_name);
+	return NULL;
+}
+
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+	uint32_t ip, mask;
+	struct in_addr addr;
+	char *ip_only, *slash;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return -1;
+	}
+
+	// Parse IP from CIDR
+	ip_only = strdup(ip_cidr);
+	slash = strchr(ip_only, '/');
+	if (slash)
+		*slash = '\0';
+
+	if (inet_pton(AF_INET, ip_only, &addr) != 1) {
+		pv_log(ERROR, "invalid IP: %s", ip_only);
+		free(ip_only);
+		return -1;
+	}
+	ip = addr.s_addr;
+	free(ip_only);
+
+	// Check if IP is in pool subnet
+	if (!pv_ipam_ip_in_subnet(ip, pool->subnet, pool->mask)) {
+		pv_log(ERROR, "IP %s not in pool '%s' subnet", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Check if IP is available
+	if (!is_ip_available(pool, ip)) {
+		pv_log(ERROR, "IP %s already in use in pool '%s'", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Create lease
+	lease = calloc(1, sizeof(struct pv_ip_lease));
+	if (!lease)
+		return -1;
+
+	lease->container_name = strdup(container_name);
+	lease->ip = ip;
+	lease->in_use = true;
+	dl_list_init(&lease->list);
+	dl_list_add_tail(&pool->leases, &lease->list);
+
+	pv_log(INFO, "reserved %s for %s in pool %s", ip_cidr, container_name,
+	       pool_name);
+	return 0;
+}
+
+void pv_ipam_release(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *tmp;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return;
+
+	dl_list_for_each_safe(lease, tmp, &pool->leases, struct pv_ip_lease,
+			      list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0) {
+			char *ip_str = pv_ipam_ip_to_str(lease->ip);
+			pv_log(INFO, "released %s from %s in pool %s", ip_str,
+			       container_name, pool_name);
+			free(ip_str);
+
+			dl_list_del(&lease->list);
+			free(lease->container_name);
+			free(lease);
+			return;
+		}
+	}
+}
+
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return NULL;
+
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0)
+			return lease;
+	}
+
+	return NULL;
+}
+
+char *pv_ipam_generate_mac(uint32_t ip_net)
+{
+	char *mac;
+	uint32_t ip;
+
+	if (!ip_net)
+		return NULL;
+
+	// Convert from network byte order to host byte order
+	ip = ntohl(ip_net);
+
+	// Format: 02:00:XX:XX:XX:XX where XX:XX:XX:XX is the IP address octets
+	// 02 = locally administered, unicast
+	// Using IP ensures uniqueness within pool (IPs are unique)
+	// Example: IP 10.0.5.2 → MAC 02:00:0a:00:05:02
+	mac = malloc(18);
+	if (!mac)
+		return NULL;
+
+	snprintf(mac, 18, "02:00:%02x:%02x:%02x:%02x", (ip >> 24) & 0xff,
+		 (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
+
+	return mac;
+}
+
+static int setup_bridge(struct pv_ip_pool *pool)
+{
+	int fd, sockfd, ret = 0;
+	struct ifreq ifr;
+	struct sockaddr_in sai;
+	char *gateway_str;
+	uint32_t mask_host;
+	int prefix_len;
+
+	if (!pool || pool->type != POOL_TYPE_BRIDGE || !pool->bridge)
+		return -1;
+
+	if (pool->bridge_created)
+		return 0;
+
+	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	if (fd < 0) {
+		pv_log(ERROR, "unable to create socket: %s", strerror(errno));
+		return -1;
+	}
+
+	// Create bridge
+	ret = ioctl(fd, SIOCBRADDBR, pool->bridge);
+	if (ret < 0 && errno != EEXIST) {
+		pv_log(ERROR, "unable to create bridge %s: %s", pool->bridge,
+		       strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	// Configure bridge IP
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		pv_log(ERROR, "unable to create dgram socket: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, pool->bridge, IFNAMSIZ - 1);
+
+	// Set IP address
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->gateway;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFADDR, &ifr);
+	if (ret < 0) {
+		gateway_str = pv_ipam_ip_to_str(pool->gateway);
+		pv_log(ERROR, "unable to set IP %s on %s: %s", gateway_str,
+		       pool->bridge, strerror(errno));
+		free(gateway_str);
+		close(sockfd);
+		return -1;
+	}
+
+	// Set netmask
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->mask;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFNETMASK, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to set netmask on %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	// Bring interface up
+	ret = ioctl(sockfd, SIOCGIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to get flags for %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+	ret = ioctl(sockfd, SIOCSIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to bring up %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	close(sockfd);
+
+	pool->bridge_created = true;
+
+	gateway_str = pv_ipam_ip_to_str(pool->gateway);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+	pv_log(INFO, "created bridge %s with IP %s/%d", pool->bridge,
+	       gateway_str, prefix_len);
+	free(gateway_str);
+
+	return 0;
+}
+
+static int setup_nat(struct pv_ip_pool *pool)
+{
+	char cmd[512];
+	char *subnet_str;
+	uint32_t mask_host;
+	int prefix_len;
+	int ret;
+
+	if (!pool || !pool->nat)
+		return 0;
+
+	subnet_str = pv_ipam_ip_to_str(pool->subnet);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+
+	// Enable IP forwarding
+	ret = system("echo 1 > /proc/sys/net/ipv4/ip_forward");
+	if (ret != 0) {
+		pv_log(WARN, "failed to enable IP forwarding");
+	}
+
+	// Try iptables first, fall back to nftables
+	snprintf(
+		cmd, sizeof(cmd),
+		"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
+		"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
+		subnet_str, prefix_len, pool->bridge, subnet_str, prefix_len,
+		pool->bridge);
+
+	ret = system(cmd);
+	if (ret != 0) {
+		// Try nftables
+		snprintf(
+			cmd, sizeof(cmd),
+			"nft add table nat 2>/dev/null; "
+			"nft add chain nat postrouting { type nat hook postrouting priority 100 \\; } 2>/dev/null; "
+			"nft add rule nat postrouting ip saddr %s/%d oifname != \"%s\" masquerade 2>/dev/null",
+			subnet_str, prefix_len, pool->bridge);
+		ret = system(cmd);
+		if (ret != 0) {
+			pv_log(WARN, "failed to setup NAT for pool %s",
+			       pool->name);
+		} else {
+			pv_log(INFO, "setup NAT (nftables) for pool %s",
+			       pool->name);
+		}
+	} else {
+		pv_log(INFO, "setup NAT (iptables) for pool %s", pool->name);
+	}
+
+	free(subnet_str);
+	return 0;
+}
+
+int pv_ipam_setup_bridges(void)
+{
+	struct pv_ip_pool *pool;
+	int ret = 0;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (pool->type == POOL_TYPE_BRIDGE) {
+			if (setup_bridge(pool) < 0)
+				ret = -1;
+			if (pool->nat)
+				setup_nat(pool);
+		}
+	}
+
+	return ret;
+}
+
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode)
+{
+	struct pv_platform_network *net;
+
+	net = calloc(1, sizeof(struct pv_platform_network));
+	if (!net)
+		return NULL;
+
+	net->mode = mode;
+	dl_list_init(&net->interfaces);
+
+	return net;
+}
+
+void pv_platform_network_free(struct pv_platform_network *net)
+{
+	struct pv_platform_network_iface *iface, *tmp;
+
+	if (!net)
+		return;
+
+	dl_list_for_each_safe(iface, tmp, &net->interfaces,
+			      struct pv_platform_network_iface, list)
+	{
+		dl_list_del(&iface->list);
+		if (iface->name)
+			free(iface->name);
+		if (iface->pool)
+			free(iface->pool);
+		if (iface->ipv4_address)
+			free(iface->ipv4_address);
+		if (iface->ipv4_gateway)
+			free(iface->ipv4_gateway);
+		if (iface->bridge)
+			free(iface->bridge);
+		if (iface->veth_host)
+			free(iface->veth_host);
+		if (iface->mac_address)
+			free(iface->mac_address);
+		if (iface->static_ip)
+			free(iface->static_ip);
+		if (iface->static_mac)
+			free(iface->static_mac);
+		free(iface);
+	}
+
+	if (net->hostname)
+		free(net->hostname);
+	free(net);
+}
+
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool)
+{
+	struct pv_platform_network_iface *iface;
+
+	if (!net || !name || !pool)
+		return NULL;
+
+	iface = calloc(1, sizeof(struct pv_platform_network_iface));
+	if (!iface)
+		return NULL;
+
+	iface->name = strdup(name);
+	iface->pool = strdup(pool);
+	dl_list_init(&iface->list);
+	dl_list_add_tail(&net->interfaces, &iface->list);
+
+	return iface;
+}

--- a/ipam.h
+++ b/ipam.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PV_IPAM_H
+#define PV_IPAM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <netinet/in.h>
+
+#include "utils/list.h"
+
+// Pool types
+typedef enum { POOL_TYPE_BRIDGE, POOL_TYPE_MACVLAN } pv_pool_type_t;
+
+// IP lease - tracks allocated IPs
+struct pv_ip_lease {
+	char *container_name;
+	uint32_t ip; // Network byte order
+	bool in_use;
+	struct dl_list list; // pv_ip_lease
+};
+
+// IP pool - defines a network pool from device.json
+struct pv_ip_pool {
+	char *name; // Pool name (e.g., "internal")
+	pv_pool_type_t type; // bridge or macvlan
+	char *bridge; // Bridge interface name (for type=bridge)
+	char *parent; // Parent interface (for type=macvlan)
+	uint32_t subnet; // Subnet address (network byte order)
+	uint32_t mask; // Subnet mask (network byte order)
+	uint32_t gateway; // Gateway IP (network byte order)
+	bool nat; // Enable NAT
+	bool bridge_created; // Bridge already created
+	uint32_t next_ip; // Next IP to allocate (host byte order)
+	struct dl_list leases; // pv_ip_lease
+	struct dl_list list; // pv_ip_pool
+};
+
+// Platform network mode
+typedef enum {
+	NET_MODE_NONE, // No network config (use static lxc.container.conf)
+	NET_MODE_HOST, // Host namespace
+	NET_MODE_POOL // Pool-based dynamic
+} pv_net_mode_t;
+
+// Platform network interface config
+struct pv_platform_network_iface {
+	char *name; // Container-side interface (e.g., "eth0")
+	char *pool; // Pool name from device.json
+	char *ipv4_address; // Assigned IP in CIDR notation
+	char *ipv4_gateway; // Gateway IP
+	char *bridge; // Host bridge name
+	char *veth_host; // Host-side veth name
+	char *mac_address; // MAC address
+	char *static_ip; // Static IP override from run.json (optional)
+	char *static_mac; // Static MAC override from run.json (optional)
+	struct dl_list list; // pv_platform_network_iface
+};
+
+// Platform network config (from run.json)
+struct pv_platform_network {
+	pv_net_mode_t mode;
+	char *hostname;
+	struct dl_list interfaces; // pv_platform_network_iface
+};
+
+// Global IPAM state
+struct pv_ipam {
+	struct dl_list pools; // pv_ip_pool
+	bool initialized;
+};
+
+// Initialize IPAM subsystem
+int pv_ipam_init(void);
+
+// Cleanup IPAM subsystem
+void pv_ipam_free(void);
+
+// Get global IPAM instance
+struct pv_ipam *pv_ipam_get(void);
+
+// Add a pool from device.json
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat);
+
+// Find a pool by name
+struct pv_ip_pool *pv_ipam_find_pool(const char *name);
+
+// Allocate an IP from a pool for a container
+// Returns allocated IP in CIDR notation (e.g., "10.0.3.2/24") or NULL on failure
+char *pv_ipam_allocate(const char *pool_name, const char *container_name);
+
+// Reserve a specific IP in a pool (for static configs)
+// Returns 0 on success, -1 if IP already taken or not in pool
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr);
+
+// Release an IP back to the pool
+void pv_ipam_release(const char *pool_name, const char *container_name);
+
+// Get the lease for a container in a pool
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name);
+
+// Setup bridges for all pools (called during init)
+int pv_ipam_setup_bridges(void);
+
+// Generate deterministic MAC address from container name
+// Returns MAC in format "02:pv:XX:XX:XX:XX"
+char *pv_ipam_generate_mac(uint32_t ip);
+
+// Parse CIDR notation (e.g., "10.0.3.0/24") into subnet and mask
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask);
+
+// Format IP address to string
+char *pv_ipam_ip_to_str(uint32_t ip);
+
+// Check if IP is in subnet
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask);
+
+// Create platform network config
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode);
+
+// Free platform network config
+void pv_platform_network_free(struct pv_platform_network *net);
+
+// Add interface to platform network
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool);
+
+#endif // PV_IPAM_H

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -726,12 +726,21 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, pv_system_transition_t t)
 	pv_update_finish();
 
 	// stop childs leniently
-	pv_state_stop_lenient(pv->state);
+
+	if (pv->state)
+
+		pv_state_stop_lenient(pv->state);
+
 	ph_logger_stop_lenient();
 
 	// force stop childs
-	pv_state_stop_force(pv->state);
+
+	if (pv->state)
+
+		pv_state_stop_force(pv->state);
+
 	ph_logger_stop_force();
+
 	ph_logger_close();
 
 	pv_pantahub_close();
@@ -739,17 +748,28 @@ static pv_state_t pv_shutdown(struct pantavisor *pv, pv_system_transition_t t)
 	// stop pvctrl
 	pv_ctrl_stop();
 
+	// stop managed daemons
+	pv_init_stop_daemons();
+
 	pv_debug_stop_ssh();
 	pv_logserver_stop();
 
 	// unmounting
+
 	pv_volumes_umount_firmware_modules();
+
 	pv_log_umount();
+
 	pv_mount_umount();
+
 	pv_metadata_umount();
 
-	pv_disk_umount_all(&pv->state->disks);
+	if (pv->state)
+
+		pv_disk_umount_all(&pv->state->disks);
+
 	pv_storage_umount();
+
 	pv_init_umount();
 
 	pv_mount_print();

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -70,6 +70,7 @@
 #include "pantahub/pantahub.h"
 
 #include "parser/parser.h"
+#include "ipam.h"
 
 #include "utils/timer.h"
 #include "utils/fs.h"
@@ -179,6 +180,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_state_t next_state = PV_STATE_ROLLBACK;
 	char *json = NULL;
 
+	// Initialize IPAM subsystem
+	pv_ipam_init();
+
 	// resume update if we are booting up to test a new revision
 	if (pv_update_resume(pv_pantahub_queue_progress)) {
 		pv_log(ERROR, "update could not be resumed");
@@ -237,6 +241,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_update_set_factory();
 
 	pv_state_load_done(pv->state);
+
+	// Setup IPAM network bridges (must happen after state parsing)
+	pv_ipam_setup_bridges();
 
 	// once state is verified, we can load credentials, in case they are stored in a volume
 	if (!pv_update_get_state()) {

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -886,20 +886,33 @@ static int do_one_jka_action(struct json_key_action *jka)
 		break;
 
 	case JSMN_OBJECT:
+
 		//create a new buffer.
+
 		length = (jka->tokv + 1)->end - (jka->tokv + 1)->start;
+
 		value = calloc(length + 1, sizeof(char));
+
 		if (value) {
 			char *orig_buf = NULL;
-			snprintf(value, length + 1, "%s",
-				 buf + (jka->tokv + 1)->start);
+
+			memcpy(value, buf + (jka->tokv + 1)->start, length);
+
+			value[length] = '\0';
+
 			orig_buf = jka->buf;
+
 			jka->buf = value;
+
 			ret = do_json_key_action_object(jka);
+
 			free(value);
+
 			jka->buf = orig_buf;
 		}
+
 		break;
+
 	default:
 		break;
 	}
@@ -1245,9 +1258,65 @@ out:
 	return ret;
 }
 
-static int do_action_for_one_volume(struct json_key_action *jka, char *value)
+static recovery_type_t parse_recovery_type(char *value)
 {
-	/*
+	if (!strcmp(value, "no"))
+		return RECOVERY_NO;
+	if (!strcmp(value, "always"))
+		return RECOVERY_ALWAYS;
+	if (!strcmp(value, "on-failure"))
+		return RECOVERY_ON_FAILURE;
+	if (!strcmp(value, "unless-stopped"))
+		return RECOVERY_UNLESS_STOPPED;
+	return RECOVERY_NO;
+}
+
+static int do_action_for_auto_recovery(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+	struct pv_platform *p = *bundle->platform;
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *str = NULL;
+	char *buf = jka->buf;
+
+	if (!p || !buf)
+		return -1;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "wrong format auto_recovery");
+		return -1;
+	}
+
+	str = pv_json_get_value(buf, "policy", tokv, tokc);
+	if (str) {
+		p->auto_recovery.type = parse_recovery_type(str);
+		free(str);
+	}
+
+	p->auto_recovery.max_retries =
+		pv_json_get_value_int(buf, "max_retries", tokv, tokc);
+	p->auto_recovery.retry_delay =
+		pv_json_get_value_int(buf, "retry_delay", tokv, tokc);
+	p->auto_recovery.reset_window =
+		pv_json_get_value_int(buf, "reset_window", tokv, tokc);
+
+	// backoff_factor is double, but we only have get_value_int
+	// implementing simple int parsing for now
+	str = pv_json_get_value(buf, "backoff_factor", tokv, tokc);
+	if (str) {
+		p->auto_recovery.backoff_factor = atof(str);
+		free(str);
+	}
+
+	ret = 0;
+	if (tokv)
+		free(tokv);
+	return ret;
+}
+
+static int do_action_for_one_volume(struct json_key_action *jka, char *value)
+{ /*
 	 * Opaque will contain the platform
 	 * */
 	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
@@ -1443,6 +1512,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_roles_object, false),
 		ADD_JKA_ENTRY("roles", JSMN_ARRAY, &bundle,
 			      do_action_for_roles_array, false),
+		ADD_JKA_ENTRY("auto_recovery", JSMN_OBJECT, &bundle,
+			      do_action_for_auto_recovery, false),
 		ADD_JKA_ENTRY("config", JSMN_STRING, &config, NULL, true),
 		ADD_JKA_ENTRY("share", JSMN_STRING, &shares, NULL, true),
 		ADD_JKA_ENTRY("root-volume", JSMN_STRING, &bundle,

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -52,6 +52,7 @@
 #include "state.h"
 #include "pvlogger.h"
 #include "paths.h"
+#include "ipam.h"
 
 #include "utils/str.h"
 #include "utils/fs.h"
@@ -1315,6 +1316,106 @@ static int do_action_for_auto_recovery(struct json_key_action *jka, char *value)
 	return ret;
 }
 
+static int do_action_for_network(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+	struct pv_platform *p = *bundle->platform;
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *mode_str = NULL;
+	char *pool = NULL;
+	char *hostname = NULL;
+	char *static_ip = NULL;
+	char *static_mac = NULL;
+	char *buf = jka->buf;
+	pv_net_mode_t mode = NET_MODE_NONE;
+
+	if (!p || !buf)
+		return -1;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "wrong format network");
+		return -1;
+	}
+
+	// Check for mode first
+	mode_str = pv_json_get_value(buf, "mode", tokv, tokc);
+	if (mode_str) {
+		if (strcmp(mode_str, "host") == 0) {
+			mode = NET_MODE_HOST;
+		} else if (strcmp(mode_str, "pool") == 0) {
+			mode = NET_MODE_POOL;
+		}
+		free(mode_str);
+	}
+
+	// Check for pool (shorthand for single interface)
+	pool = pv_json_get_value(buf, "pool", tokv, tokc);
+	if (pool) {
+		mode = NET_MODE_POOL;
+	}
+
+	hostname = pv_json_get_value(buf, "hostname", tokv, tokc);
+	static_ip = pv_json_get_value(buf, "ip", tokv, tokc);
+	static_mac = pv_json_get_value(buf, "mac", tokv, tokc);
+
+	// Create network config for the platform
+	if (mode != NET_MODE_NONE) {
+		p->network = pv_platform_network_new(mode);
+		if (!p->network) {
+			pv_log(ERROR, "failed to create network config for %s",
+			       p->name);
+			ret = -1;
+			goto out;
+		}
+
+		if (hostname) {
+			p->network->hostname = strdup(hostname);
+		}
+
+		// If pool specified, create default eth0 interface
+		if (mode == NET_MODE_POOL && pool) {
+			struct pv_platform_network_iface *iface;
+			iface = pv_platform_network_add_iface(p->network,
+							      "eth0", pool);
+			if (!iface) {
+				pv_log(ERROR, "failed to add interface for %s",
+				       p->name);
+				ret = -1;
+				goto out;
+			}
+			// Set static overrides if provided
+			if (static_ip) {
+				iface->static_ip = strdup(static_ip);
+			}
+			if (static_mac) {
+				iface->static_mac = strdup(static_mac);
+			}
+			pv_log(DEBUG,
+			       "platform '%s' network: pool=%s, hostname=%s, ip=%s, mac=%s",
+			       p->name, pool, hostname ? hostname : "(none)",
+			       static_ip ? static_ip : "(auto)",
+			       static_mac ? static_mac : "(auto)");
+		} else if (mode == NET_MODE_HOST) {
+			pv_log(DEBUG, "platform '%s' network: mode=host",
+			       p->name);
+		}
+	}
+
+out:
+	if (pool)
+		free(pool);
+	if (hostname)
+		free(hostname);
+	if (static_ip)
+		free(static_ip);
+	if (static_mac)
+		free(static_mac);
+	if (tokv)
+		free(tokv);
+	return ret;
+}
+
 static int do_action_for_one_volume(struct json_key_action *jka, char *value)
 { /*
 	 * Opaque will contain the platform
@@ -1514,6 +1615,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_roles_array, false),
 		ADD_JKA_ENTRY("auto_recovery", JSMN_OBJECT, &bundle,
 			      do_action_for_auto_recovery, false),
+		ADD_JKA_ENTRY("network", JSMN_OBJECT, &bundle,
+			      do_action_for_network, false),
 		ADD_JKA_ENTRY("config", JSMN_STRING, &config, NULL, true),
 		ADD_JKA_ENTRY("share", JSMN_STRING, &shares, NULL, true),
 		ADD_JKA_ENTRY("root-volume", JSMN_STRING, &bundle,
@@ -1907,6 +2010,160 @@ out:
 	return this;
 }
 
+static int parse_network_pools(struct pv_state *s, char *buf)
+{
+	int tokc, size, ret = 1;
+	char *str = NULL;
+	jsmntok_t *tokv, *t, *poolv = NULL;
+	jsmntok_t **k, **keys;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network pools");
+		goto out;
+	}
+
+	// Get pool names (keys)
+	keys = jsmnutil_get_object_keys(buf, tokv);
+	if (!keys) {
+		pv_log(DEBUG, "no network pools defined");
+		ret = 0;
+		goto out;
+	}
+
+	k = keys;
+	while (*k) {
+		char *name, *type_str, *bridge, *parent, *subnet, *gateway;
+		char *nat_str;
+		pv_pool_type_t type;
+		bool nat;
+		int n, poolc;
+
+		n = (*k)->end - (*k)->start;
+
+		// Get pool name
+		name = malloc(n + 1);
+		snprintf(name, n + 1, "%s", buf + (*k)->start);
+
+		// Get pool value
+		n = (*k + 1)->end - (*k + 1)->start;
+		str = malloc(n + 1);
+		snprintf(str, n + 1, "%s", buf + (*k + 1)->start);
+
+		if (jsmnutil_parse_json(str, &poolv, &poolc) <= 0) {
+			pv_log(ERROR, "invalid pool entry for '%s'", name);
+			free(name);
+			free(str);
+			str = NULL;
+			goto out;
+		}
+
+		// Parse pool fields
+		type_str = pv_json_get_value(str, "type", poolv, poolc);
+		bridge = pv_json_get_value(str, "bridge", poolv, poolc);
+		parent = pv_json_get_value(str, "parent", poolv, poolc);
+		subnet = pv_json_get_value(str, "subnet", poolv, poolc);
+		gateway = pv_json_get_value(str, "gateway", poolv, poolc);
+		nat_str = pv_json_get_value(str, "nat", poolv, poolc);
+
+		// Determine pool type
+		if (type_str && strcmp(type_str, "macvlan") == 0)
+			type = POOL_TYPE_MACVLAN;
+		else
+			type = POOL_TYPE_BRIDGE;
+
+		// Parse NAT flag
+		nat = (nat_str && strcmp(nat_str, "true") == 0);
+
+		// Validate required fields
+		if (!subnet || !gateway) {
+			pv_log(ERROR, "pool '%s' missing subnet or gateway",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_BRIDGE && !bridge) {
+			pv_log(ERROR, "bridge pool '%s' missing bridge name",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_MACVLAN && !parent) {
+			pv_log(ERROR,
+			       "macvlan pool '%s' missing parent interface",
+			       name);
+			goto free_pool;
+		}
+
+		// Add pool to IPAM
+		if (!pv_ipam_add_pool(name, type,
+				      type == POOL_TYPE_BRIDGE ? bridge :
+								 parent,
+				      subnet, gateway, nat)) {
+			pv_log(ERROR, "failed to add pool '%s'", name);
+		} else {
+			pv_log(DEBUG, "added network pool '%s'", name);
+		}
+
+	free_pool:
+		if (type_str)
+			free(type_str);
+		if (bridge)
+			free(bridge);
+		if (parent)
+			free(parent);
+		if (subnet)
+			free(subnet);
+		if (gateway)
+			free(gateway);
+		if (nat_str)
+			free(nat_str);
+		if (poolv) {
+			free(poolv);
+			poolv = NULL;
+		}
+		free(name);
+		free(str);
+		str = NULL;
+
+		k++;
+	}
+	jsmnutil_tokv_free(keys);
+	ret = 0;
+
+out:
+	if (str)
+		free(str);
+	if (poolv)
+		free(poolv);
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
+static int parse_network(struct pv_state *s, char *buf)
+{
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *pools_str = NULL;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network section");
+		return -1;
+	}
+
+	pools_str = pv_json_get_value(buf, "pools", tokv, tokc);
+	if (pools_str) {
+		ret = parse_network_pools(s, pools_str);
+		free(pools_str);
+	}
+
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
 static struct pv_state *parse_device(struct pv_state *this, char *buf)
 {
 	int tokc;
@@ -1932,32 +2189,70 @@ static struct pv_state *parse_device(struct pv_state *this, char *buf)
 
 	value = pv_json_get_value(buf, "disks", tokv, tokc);
 	if (!value) {
-		pv_log(WARN, "disks not defined in device.json");
-		goto out;
+		pv_log(DEBUG, "disks not defined in device.json");
+	} else {
+		// Only parse if non-empty (parse_disks errors on empty array)
+		jsmntok_t *disk_tokv;
+		int disk_tokc;
+		if (jsmnutil_parse_json(value, &disk_tokv, &disk_tokc) >= 0) {
+			int disk_count = jsmnutil_array_count(value, disk_tokv);
+			free(disk_tokv);
+			if (disk_count > 0) {
+				if (parse_disks(this, value)) {
+					pv_log(ERROR,
+					       "cannot parse disks in device.json");
+					free(value);
+					this = NULL;
+					goto out;
+				}
+			} else {
+				pv_log(DEBUG,
+				       "empty disks array in device.json");
+			}
+		}
+		free(value);
+		value = NULL;
+
+		value = pv_json_get_value(buf, "disks_v2", tokv, tokc);
+		if (value) {
+			if (jsmnutil_parse_json(value, &disk_tokv,
+						&disk_tokc) >= 0) {
+				int disk_count =
+					jsmnutil_array_count(value, disk_tokv);
+				free(disk_tokv);
+				if (disk_count > 0 &&
+				    parse_disks(this, value)) {
+					pv_log(ERROR,
+					       "cannot parse disks_v2 in device.json");
+					free(value);
+					this = NULL;
+					goto out;
+				}
+			}
+			free(value);
+			value = NULL;
+		}
 	}
-	if (parse_disks(this, value)) {
-		pv_log(ERROR, "cannot parse disks in device.json");
-		this = NULL;
-		goto out;
-	}
-	free(value);
-	value = pv_json_get_value(buf, "disks_v2", tokv, tokc);
-	if (value && parse_disks(this, value)) {
-		pv_log(ERROR, "cannot parse disks_v2 in device.json");
-		this = NULL;
-		goto out;
-	}
-	free(value);
 
 	value = pv_json_get_value(buf, "volumes", tokv, tokc);
 	if (!value) {
 		pv_log(WARN, "volumes not defined in device.json");
-		goto out;
+	} else {
+		if (!parse_storage(this, NULL, value)) {
+			pv_log(ERROR, "cannot parse storage in device.json");
+			this = NULL;
+			goto out;
+		}
+		free(value);
+		value = NULL;
 	}
-	if (!parse_storage(this, NULL, value)) {
-		pv_log(ERROR, "cannot parse storage in device.json");
-		this = NULL;
-		goto out;
+
+	// Parse network pools (optional)
+	value = pv_json_get_value(buf, "network", tokv, tokc);
+	if (value) {
+		if (parse_network(this, value)) {
+			pv_log(WARN, "failed to parse network in device.json");
+		}
 	}
 
 out:

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -599,13 +599,16 @@ static service_type_t service_str_to_type(char *str)
 		return SVC_TYPE_DRM;
 	if (!strcmp(str, "wayland"))
 		return SVC_TYPE_WAYLAND;
-	if (!strcmp(str, "input"))
-		return SVC_TYPE_INPUT;
+	if (!strcmp(str, "tcp"))
+		return SVC_TYPE_TCP;
+	if (!strcmp(str, "http"))
+		return SVC_TYPE_HTTP;
+
 	return SVC_TYPE_UNKNOWN;
 }
 
-static int platform_services_add(struct pv_platform *p, plat_service_t type,
-				 char *buf)
+static int services_add_to_list(struct dl_list *list, plat_service_t type,
+				char *buf)
 {
 	int tokc, size, ret = 0;
 	jsmntok_t *tokv, *t, *sv;
@@ -615,22 +618,36 @@ static int platform_services_add(struct pv_platform *p, plat_service_t type,
 	if (size <= 0)
 		goto out;
 	t = tokv + 1;
+
 	for (int i = 0; i < size; i++) {
 		int svc_c;
-		char *svc_s = pv_json_array_get_one_str(buf, &size, &t);
+		char *svc_s = pv_json_get_one_str(buf, &t);
 		if (!svc_s)
 			break;
+
 		if (jsmnutil_parse_json(svc_s, &sv, &svc_c) > 0) {
-			char *n = pv_json_get_value(svc_s, "name", sv, svc_c);
+			char *n =
+				pv_json_get_value(svc_s, "service", sv, svc_c);
+			if (!n)
+				n = pv_json_get_value(svc_s, "name", sv, svc_c);
+
 			char *t_s = pv_json_get_value(svc_s, "type", sv, svc_c);
-			char *r = pv_json_get_value(svc_s, "role", sv, svc_c);
+			char *r =
+				pv_json_get_value(svc_s, "provider", sv, svc_c);
+			if (!r)
+				r = pv_json_get_value(svc_s, "role", sv, svc_c);
 			char *iface = pv_json_get_value(svc_s, "interface", sv,
 							svc_c);
+
 			char *target =
-				pv_json_get_value(svc_s, "target", sv, svc_c);
-			pv_platform_add_service(p, type,
-						service_str_to_type(t_s), n, r,
-						iface, target);
+				pv_json_get_value(svc_s, "external", sv, svc_c);
+			if (!target)
+				target = pv_json_get_value(svc_s, "target", sv,
+							   svc_c);
+
+			pv_service_add_to_list(list, type,
+					       service_str_to_type(t_s), n, r,
+					       iface, target);
 			if (n)
 				free(n);
 			if (t_s)
@@ -643,9 +660,10 @@ static int platform_services_add(struct pv_platform *p, plat_service_t type,
 				free(target);
 			free(sv);
 		} else {
-			pv_platform_add_service(p, type, SVC_TYPE_UNKNOWN,
-						svc_s, NULL, NULL, NULL);
+			pv_service_add_to_list(list, type, SVC_TYPE_UNKNOWN,
+					       svc_s, NULL, NULL, NULL);
 		}
+		t += jsmnutil_traverse_token(buf, t);
 		free(svc_s);
 	}
 	ret = 1;
@@ -653,6 +671,17 @@ out:
 	if (tokv)
 		free(tokv);
 	return ret;
+}
+
+static int platform_services_add(struct pv_platform *p, plat_service_t type,
+				 char *buf)
+{
+	return services_add_to_list(&p->services, type, buf);
+}
+
+static int parse_ingress(struct pv_state *this, char *buf)
+{
+	return services_add_to_list(&this->ingress, SERVICE_REQUIRED, buf);
 }
 
 static int parse_platform_services(struct pv_state *s, struct pv_platform *p,
@@ -721,7 +750,7 @@ static int parse_service_exports(struct pv_state *s, struct pv_platform *p,
 	}
 	for (int i = 0; i < size; i++) {
 		int svc_c;
-		char *svc_s = pv_json_array_get_one_str(buf, &size, &t);
+		char *svc_s = pv_json_get_one_str(buf, &t);
 		if (!svc_s)
 			break;
 		if (jsmnutil_parse_json(svc_s, &sv, &svc_c) > 0) {
@@ -729,16 +758,22 @@ static int parse_service_exports(struct pv_state *s, struct pv_platform *p,
 			char *t_s = pv_json_get_value(svc_s, "type", sv, svc_c);
 			char *sock =
 				pv_json_get_value(svc_s, "socket", sv, svc_c);
+			char *port_s =
+				pv_json_get_value(svc_s, "port", sv, svc_c);
+			int port = port_s ? atoi(port_s) : 0;
 			pv_platform_add_service_export(
-				p, service_str_to_type(t_s), n, sock);
+				p, service_str_to_type(t_s), n, sock, port);
 			if (n)
 				free(n);
 			if (t_s)
 				free(t_s);
 			if (sock)
 				free(sock);
+			if (port_s)
+				free(port_s);
 			free(sv);
 		}
+		t += jsmnutil_traverse_token(buf, t);
 		free(svc_s);
 	}
 	ret = 1;
@@ -2252,6 +2287,14 @@ static struct pv_state *parse_device(struct pv_state *this, char *buf)
 	if (value) {
 		if (parse_network(this, value)) {
 			pv_log(WARN, "failed to parse network in device.json");
+		}
+	}
+
+	// Parse global ingress (optional)
+	value = pv_json_get_value(buf, "ingress", tokv, tokc);
+	if (value) {
+		if (!parse_ingress(this, value)) {
+			pv_log(WARN, "failed to parse ingress in device.json");
 		}
 	}
 

--- a/platforms.c
+++ b/platforms.c
@@ -128,8 +128,11 @@ const char *pv_platform_status_string(plat_status_t status)
 		return "STARTED";
 	case PLAT_READY:
 		return "READY";
+	case PLAT_RECOVERING:
+		return "RECOVERING";
 	case PLAT_STOPPING:
 		return "STOPPING";
+
 	case PLAT_STOPPED:
 		return "STOPPED";
 	default:
@@ -1070,11 +1073,19 @@ void pv_platform_set_mounted(struct pv_platform *p)
 }
 
 void pv_platform_set_blocked(struct pv_platform *p)
+
 {
 	pv_platform_set_status(p, PLAT_BLOCKED);
 }
 
+void pv_platform_set_recovering(struct pv_platform *p)
+
+{
+	pv_platform_set_status(p, PLAT_RECOVERING);
+}
+
 int pv_platform_set_ready(struct pv_platform *p)
+
 {
 	if (p->status.goal != PLAT_READY)
 		return -1;
@@ -1131,11 +1142,15 @@ bool pv_platform_is_ready(struct pv_platform *p)
 	return (p->status.current == PLAT_READY);
 }
 
+bool pv_platform_is_recovering(struct pv_platform *p)
+{
+	return (p->status.current == PLAT_RECOVERING);
+}
+
 bool pv_platform_is_stopping(struct pv_platform *p)
 {
 	return (p->status.current == PLAT_STOPPING);
 }
-
 bool pv_platform_is_stopped(struct pv_platform *p)
 {
 	return (p->status.current == PLAT_STOPPED);

--- a/platforms.c
+++ b/platforms.c
@@ -56,6 +56,9 @@
 #include "utils/pvsignals.h"
 #include "utils/tsh.h"
 #include "utils/system.h"
+#include "ipam.h"
+
+#include <time.h>
 
 #define MODULE_NAME "platforms"
 #define pv_log(level, msg, ...)                                                \
@@ -310,6 +313,20 @@ void pv_platform_free(struct pv_platform *p)
 	pv_platform_empty_logger_list(p);
 	pv_platform_empty_logger_configs(p);
 
+	// Release IPAM allocations for this platform
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+
+	if (p->network)
+		pv_platform_network_free(p->network);
+
 	free(p);
 }
 
@@ -353,18 +370,78 @@ const char *pv_platforms_restart_policy_str(restart_policy_t policy)
 	return "unknown";
 }
 
+static const char *pv_recovery_type_str(recovery_type_t type)
+{
+	switch (type) {
+	case RECOVERY_NO:
+		return "no";
+	case RECOVERY_ALWAYS:
+		return "always";
+	case RECOVERY_ON_FAILURE:
+		return "on-failure";
+	case RECOVERY_UNLESS_STOPPED:
+		return "unless-stopped";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *pv_service_type_str(service_type_t type)
+{
+	switch (type) {
+	case SVC_TYPE_REST:
+		return "rest";
+	case SVC_TYPE_DBUS:
+		return "dbus";
+	case SVC_TYPE_UNIX:
+		return "unix";
+	case SVC_TYPE_DRM:
+		return "drm";
+	case SVC_TYPE_WAYLAND:
+		return "wayland";
+	case SVC_TYPE_INPUT:
+		return "input";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *pv_service_requirement_str(plat_service_t type)
+{
+	if (type & SERVICE_REQUIRED)
+		return "required";
+	if (type & SERVICE_OPTIONAL)
+		return "optional";
+	if (type & SERVICE_MANUAL)
+		return "manual";
+	return "unknown";
+}
+
 void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p)
 {
 	char *group = NULL;
 	const char *status = pv_platform_status_string(p->status.current);
 	const char *status_goal = pv_platform_status_string(p->status.goal);
 	int i;
+	time_t now;
+	long uptime_secs = 0;
+	struct pv_platform_service *svc, *svc_tmp;
+	struct pv_platform_service_export *exp, *exp_tmp;
 
 	if (p->group)
 		group = p->group->name;
 
+	// Calculate uptime if container is running
+	if (p->init_pid > 0 && p->auto_recovery.last_start > 0) {
+		now = time(NULL);
+		uptime_secs = (long)(now - p->auto_recovery.last_start);
+		if (uptime_secs < 0)
+			uptime_secs = 0;
+	}
+
 	pv_json_ser_object(js);
 	{
+		// Basic info
 		pv_json_ser_key(js, "name");
 		pv_json_ser_string(js, p->name);
 		pv_json_ser_key(js, "group");
@@ -376,6 +453,37 @@ void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p)
 		pv_json_ser_key(js, "restart_policy");
 		pv_json_ser_string(
 			js, pv_platforms_restart_policy_str(p->restart_policy));
+
+		// Runtime info
+		pv_json_ser_key(js, "pid");
+		pv_json_ser_number(js, p->init_pid);
+		pv_json_ser_key(js, "uptime_secs");
+		pv_json_ser_number(js, uptime_secs);
+
+		// Auto-recovery details
+		pv_json_ser_key(js, "auto_recovery");
+		pv_json_ser_object(js);
+		{
+			pv_json_ser_key(js, "type");
+			pv_json_ser_string(js, pv_recovery_type_str(
+						       p->auto_recovery.type));
+			pv_json_ser_key(js, "max_retries");
+			pv_json_ser_number(js, p->auto_recovery.max_retries);
+			pv_json_ser_key(js, "current_retries");
+			pv_json_ser_number(js,
+					   p->auto_recovery.current_retries);
+			pv_json_ser_key(js, "retry_delay");
+			pv_json_ser_number(js, p->auto_recovery.retry_delay);
+			pv_json_ser_key(js, "backoff_factor");
+			pv_json_ser_number(
+				js,
+				(int)(p->auto_recovery.backoff_factor * 100));
+			pv_json_ser_key(js, "reset_window");
+			pv_json_ser_number(js, p->auto_recovery.reset_window);
+			pv_json_ser_object_pop(js);
+		}
+
+		// Roles
 		pv_json_ser_key(js, "roles");
 		pv_json_ser_array(js);
 		{
@@ -393,6 +501,63 @@ void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p)
 						js, pv_platforms_role_str(i));
 			}
 		close_roles:
+			pv_json_ser_array_pop(js);
+		}
+
+		// Services provided (exports)
+		pv_json_ser_key(js, "provides");
+		pv_json_ser_array(js);
+		{
+			dl_list_for_each_safe(exp, exp_tmp, &p->service_exports,
+					      struct pv_platform_service_export,
+					      list)
+			{
+				pv_json_ser_object(js);
+				{
+					pv_json_ser_key(js, "name");
+					pv_json_ser_string(js, exp->name);
+					pv_json_ser_key(js, "type");
+					pv_json_ser_string(
+						js, pv_service_type_str(
+							    exp->svc_type));
+					pv_json_ser_key(js, "socket");
+					pv_json_ser_string(js, exp->socket);
+					pv_json_ser_object_pop(js);
+				}
+			}
+			pv_json_ser_array_pop(js);
+		}
+
+		// Services consumed
+		pv_json_ser_key(js, "consumes");
+		pv_json_ser_array(js);
+		{
+			dl_list_for_each_safe(svc, svc_tmp, &p->services,
+					      struct pv_platform_service, list)
+			{
+				pv_json_ser_object(js);
+				{
+					pv_json_ser_key(js, "name");
+					pv_json_ser_string(js, svc->name);
+					pv_json_ser_key(js, "type");
+					pv_json_ser_string(
+						js, pv_service_type_str(
+							    svc->svc_type));
+					pv_json_ser_key(js, "requirement");
+					pv_json_ser_string(
+						js, pv_service_requirement_str(
+							    svc->type));
+					pv_json_ser_key(js, "role");
+					pv_json_ser_string(
+						js,
+						svc->role ? svc->role : "any");
+					pv_json_ser_key(js, "interface");
+					pv_json_ser_string(js, svc->interface);
+					pv_json_ser_key(js, "target");
+					pv_json_ser_string(js, svc->target);
+					pv_json_ser_object_pop(js);
+				}
+			}
 			pv_json_ser_array_pop(js);
 		}
 
@@ -932,7 +1097,97 @@ int pv_platform_start(struct pv_platform *p)
 	timer_start(&p->timer_status_goal,
 		    p->group->default_status_goal_timeout, 0, RELATIV_TIMER);
 
+	// Allocate IPAM network resources if platform uses pool-based networking
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (!iface->pool)
+				continue;
+
+			struct pv_ip_pool *pool =
+				pv_ipam_find_pool(iface->pool);
+			if (!pool) {
+				pv_log(ERROR,
+				       "platform '%s' references unknown pool '%s', refusing to start",
+				       p->name, iface->pool);
+				goto ipam_error;
+			}
+
+			// Allocate or reserve IP from pool
+			char *ip = NULL;
+			if (iface->static_ip) {
+				// Use static IP - reserve it in the pool
+				if (pv_ipam_reserve(iface->pool, p->name,
+						    iface->static_ip) == 0) {
+					ip = strdup(iface->static_ip);
+					pv_log(DEBUG,
+					       "platform '%s' using static IP %s",
+					       p->name, ip);
+				} else {
+					pv_log(ERROR,
+					       "failed to reserve static IP %s for platform '%s' (already in use or outside subnet), refusing to start",
+					       iface->static_ip, p->name);
+					goto ipam_error;
+				}
+			} else {
+				// Allocate IP dynamically
+				ip = pv_ipam_allocate(iface->pool, p->name);
+				if (!ip) {
+					pv_log(ERROR,
+					       "failed to allocate IP for platform '%s' from pool '%s' (pool exhausted), refusing to start",
+					       p->name, iface->pool);
+					goto ipam_error;
+				}
+			}
+
+			// Store allocated info in interface struct
+			iface->ipv4_address = ip;
+			iface->ipv4_gateway = pv_ipam_ip_to_str(pool->gateway);
+			iface->bridge = strdup(pool->bridge);
+
+			// Use static MAC if provided, otherwise generate from IP
+			if (iface->static_mac) {
+				iface->mac_address = strdup(iface->static_mac);
+			} else {
+				struct pv_ip_lease *lease =
+					pv_ipam_get_lease(iface->pool, p->name);
+				iface->mac_address =
+					lease ? pv_ipam_generate_mac(
+							lease->ip) :
+						NULL;
+			}
+
+			pv_log(INFO, "platform '%s' IP %s MAC %s on bridge %s",
+			       p->name, iface->ipv4_address,
+			       iface->mac_address ? iface->mac_address : "auto",
+			       iface->bridge);
+		}
+	}
+
 	pv_log(DEBUG, "starting platform '%s'", p->name);
+
+	goto ipam_ok;
+
+ipam_error:
+	// Release any IPAM leases allocated for this platform before failing
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+	pv_log(ERROR,
+	       "platform '%s' failed IPAM network validation, triggering rollback if in try-boot",
+	       p->name);
+	pv_platform_stop(p);
+	return -1;
+
+ipam_ok:
 
 	if (ctrl->start(p, s->rev, path, p->log.lxc_pipe[1], p->pipefd[1])) {
 		pv_log(ERROR, "could not start platform '%s'", p->name);

--- a/platforms.c
+++ b/platforms.c
@@ -401,11 +401,14 @@ static const char *pv_service_type_str(service_type_t type)
 		return "wayland";
 	case SVC_TYPE_INPUT:
 		return "input";
+	case SVC_TYPE_TCP:
+		return "tcp";
+	case SVC_TYPE_HTTP:
+		return "http";
 	default:
 		return "unknown";
 	}
 }
-
 static const char *pv_service_requirement_str(plat_service_t type)
 {
 	if (type & SERVICE_REQUIRED)
@@ -1522,7 +1525,7 @@ void pv_platform_add_service(struct pv_platform *p, plat_service_t type,
 
 void pv_platform_add_service_export(struct pv_platform *p,
 				    service_type_t svc_type, char *name,
-				    char *socket)
+				    char *socket, int port)
 {
 	struct pv_platform_service_export *se =
 		calloc(1, sizeof(struct pv_platform_service_export));
@@ -1534,6 +1537,63 @@ void pv_platform_add_service_export(struct pv_platform *p,
 		se->name = strdup(name);
 	if (socket)
 		se->socket = strdup(socket);
+	se->port = port;
 	dl_list_init(&se->list);
 	dl_list_add_tail(&p->service_exports, &se->list);
+}
+
+const char *pv_platform_get_ipv4_address(struct pv_platform *p)
+{
+	if (!p || !p->network || p->network->mode != NET_MODE_POOL)
+		return NULL;
+
+	struct pv_platform_network_iface *iface;
+	dl_list_for_each(iface, &p->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (iface->ipv4_address)
+			return iface->ipv4_address;
+	}
+	return NULL;
+}
+
+void pv_ingress_empty(struct pv_state *s)
+{
+	struct pv_platform_service *srv, *tmp;
+	dl_list_for_each_safe(srv, tmp, &s->ingress, struct pv_platform_service,
+			      list)
+	{
+		dl_list_del(&srv->list);
+		if (srv->name)
+			free(srv->name);
+		if (srv->role)
+			free(srv->role);
+		if (srv->interface)
+			free(srv->interface);
+		if (srv->target)
+			free(srv->target);
+		free(srv);
+	}
+}
+
+void pv_service_add_to_list(struct dl_list *list, plat_service_t type,
+			    service_type_t svc_type, char *name, char *role,
+			    char *interface, char *target)
+{
+	struct pv_platform_service *s =
+		calloc(1, sizeof(struct pv_platform_service));
+	if (s) {
+		s->type = type;
+		s->svc_type = svc_type;
+		if (name)
+			s->name = strdup(name);
+		if (role)
+			s->role = strdup(role);
+		if (interface)
+			s->interface = strdup(interface);
+		if (target)
+			s->target = strdup(target);
+		dl_list_init(&s->list);
+		dl_list_add_tail(list, &s->list);
+	}
 }

--- a/platforms.h
+++ b/platforms.h
@@ -31,6 +31,7 @@
 #include "utils/timer.h"
 
 #include "event/event_socket.h"
+#include "ipam.h"
 
 typedef enum {
 	PLAT_NONE,
@@ -157,6 +158,7 @@ struct pv_platform {
 	struct dl_list drivers; // pv_platform_driver
 	struct dl_list services; // pv_platform_service
 	struct dl_list service_exports; // pv_platform_service_export
+	struct pv_platform_network *network; // dynamic IPAM network config
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
 	/*

--- a/platforms.h
+++ b/platforms.h
@@ -40,7 +40,9 @@ typedef enum {
 	PLAT_STARTING,
 	PLAT_STARTED,
 	PLAT_READY,
+	PLAT_RECOVERING,
 	PLAT_STOPPING,
+
 	PLAT_STOPPED
 } plat_status_t;
 
@@ -95,6 +97,24 @@ typedef enum {
 	RESTART_CONTAINER
 } restart_policy_t;
 
+typedef enum {
+	RECOVERY_NO,
+	RECOVERY_ALWAYS,
+	RECOVERY_ON_FAILURE,
+	RECOVERY_UNLESS_STOPPED
+} recovery_type_t;
+
+struct pv_auto_recovery {
+	recovery_type_t type;
+	int max_retries;
+	int current_retries;
+	int retry_delay;
+	double backoff_factor;
+	int reset_window;
+	struct timer timer_retry;
+	time_t last_start;
+};
+
 struct pv_platform_driver {
 	plat_driver_t type;
 	char *match;
@@ -127,6 +147,7 @@ struct pv_platform {
 	struct pv_state *state;
 	int roles;
 	restart_policy_t restart_policy;
+	struct pv_auto_recovery auto_recovery;
 	bool updated;
 	bool automodfw; // auto mount modfw
 	bool export;
@@ -167,8 +188,7 @@ bool pv_platform_check_running(struct pv_platform *p);
 void pv_platform_set_installed(struct pv_platform *p);
 void pv_platform_set_mounted(struct pv_platform *p);
 void pv_platform_set_blocked(struct pv_platform *p);
-void pv_platform_set_updated(struct pv_platform *p);
-
+void pv_platform_set_recovering(struct pv_platform *p);
 int pv_platform_set_ready(struct pv_platform *p);
 
 bool pv_platform_is_installed(struct pv_platform *p);
@@ -176,6 +196,7 @@ bool pv_platform_is_blocked(struct pv_platform *p);
 bool pv_platform_is_starting(struct pv_platform *p);
 bool pv_platform_is_started(struct pv_platform *p);
 bool pv_platform_is_ready(struct pv_platform *p);
+bool pv_platform_is_recovering(struct pv_platform *p);
 bool pv_platform_is_stopping(struct pv_platform *p);
 bool pv_platform_is_stopped(struct pv_platform *p);
 bool pv_platform_is_updated(struct pv_platform *p);

--- a/platforms.h
+++ b/platforms.h
@@ -67,9 +67,10 @@ typedef enum {
 	SVC_TYPE_UNIX,
 	SVC_TYPE_DRM,
 	SVC_TYPE_WAYLAND,
-	SVC_TYPE_INPUT
+	SVC_TYPE_INPUT,
+	SVC_TYPE_TCP,
+	SVC_TYPE_HTTP
 } service_type_t;
-
 typedef enum {
 	SERVICE_REQUIRED = (1 << 0),
 	SERVICE_OPTIONAL = (1 << 1),
@@ -90,6 +91,7 @@ struct pv_platform_service_export {
 	service_type_t svc_type;
 	char *name;
 	char *socket;
+	int port; // TCP port number (0 if not specified, used for IPAM backends)
 	struct dl_list list;
 };
 typedef enum {
@@ -170,12 +172,16 @@ void pv_platform_free(struct pv_platform *p);
 
 void pv_platform_add_driver(struct pv_platform *p, plat_driver_t type,
 			    char *value);
+void pv_service_add_to_list(struct dl_list *list, plat_service_t type,
+			    service_type_t svc_type, char *name, char *role,
+			    char *interface, char *target);
 void pv_platform_add_service(struct pv_platform *p, plat_service_t type,
 			     service_type_t svc_type, char *name, char *role,
 			     char *interface, char *target);
 void pv_platform_add_service_export(struct pv_platform *p,
 				    service_type_t svc_type, char *name,
-				    char *socket);
+				    char *socket, int port);
+const char *pv_platform_get_ipv4_address(struct pv_platform *p);
 int pv_platform_load_drivers(struct pv_platform *p, char *namematch,
 			     plat_driver_t typematch);
 void pv_platform_unload_drivers(struct pv_platform *p, char *namematch,
@@ -202,6 +208,7 @@ bool pv_platform_is_recovering(struct pv_platform *p);
 bool pv_platform_is_stopping(struct pv_platform *p);
 bool pv_platform_is_stopped(struct pv_platform *p);
 bool pv_platform_is_updated(struct pv_platform *p);
+void pv_platform_set_updated(struct pv_platform *p);
 
 void pv_platform_set_status_goal(struct pv_platform *p, plat_status_t goal);
 plat_goal_state_t pv_platform_check_goal(struct pv_platform *p);
@@ -226,6 +233,7 @@ void pv_platforms_remove_not_installed(struct pv_state *s);
 void pv_platforms_add_all_loggers(struct pv_state *s);
 
 void pv_platforms_empty(struct pv_state *s);
+void pv_ingress_empty(struct pv_state *s);
 
 struct pv_platform_ref {
 	struct pv_platform *ref;

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -47,6 +47,7 @@
 #include "paths.h"
 #include "utils/pvsignals.h"
 #include "utils/system.h"
+#include "ipam.h"
 
 #define PV_VLOG __vlog
 #include "utils/tsh.h"
@@ -226,6 +227,106 @@ static char *inschr(char *path, int n, char chr, char *seed)
 	*(path + pl + sl + 1) = 0;
 
 	return path;
+}
+
+static void pv_setup_lxc_network(struct lxc_container *c, struct pv_platform *p)
+{
+	struct pv_platform_network_iface *iface;
+	int idx = 0;
+	char key[64], value[256];
+
+	if (!p->network || p->network->mode != NET_MODE_POOL)
+		return;
+
+	// Set hostname if configured
+	if (p->network->hostname) {
+		c->set_config_item(c, "lxc.uts.name", p->network->hostname);
+		pv_log(DEBUG, "set container hostname to '%s'",
+		       p->network->hostname);
+	}
+
+	// Configure each network interface
+	dl_list_for_each(iface, &p->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (!iface->ipv4_address || !iface->bridge) {
+			pv_log(WARN, "skipping interface without IP or bridge");
+			continue;
+		}
+
+		// Set interface type to veth
+		snprintf(key, sizeof(key), "lxc.net.%d.type", idx);
+		c->set_config_item(c, key, "veth");
+
+		// Link to bridge
+		snprintf(key, sizeof(key), "lxc.net.%d.link", idx);
+		c->set_config_item(c, key, iface->bridge);
+
+		// Set container-side interface name
+		snprintf(key, sizeof(key), "lxc.net.%d.name", idx);
+		c->set_config_item(c, key, iface->name ? iface->name : "eth0");
+
+		// Set IPv4 address
+		snprintf(key, sizeof(key), "lxc.net.%d.ipv4.address", idx);
+		c->set_config_item(c, key, iface->ipv4_address);
+
+		// Set gateway
+		if (iface->ipv4_gateway) {
+			snprintf(key, sizeof(key), "lxc.net.%d.ipv4.gateway",
+				 idx);
+			c->set_config_item(c, key, iface->ipv4_gateway);
+		}
+
+		// Set MAC address if available
+		if (iface->mac_address) {
+			snprintf(key, sizeof(key), "lxc.net.%d.hwaddr", idx);
+			c->set_config_item(c, key, iface->mac_address);
+		}
+
+		// Bring interface up
+		snprintf(key, sizeof(key), "lxc.net.%d.flags", idx);
+		c->set_config_item(c, key, "up");
+
+		pv_log(INFO, "configured net.%d: type=veth link=%s ip=%s gw=%s",
+		       idx, iface->bridge, iface->ipv4_address,
+		       iface->ipv4_gateway ? iface->ipv4_gateway : "none");
+
+		idx++;
+	}
+
+	// If we configured any interfaces, we need to remove 'net' from namespace.keep
+	// The container will get its own network namespace
+	if (idx > 0) {
+		// Check current namespace.keep setting and remove 'net' if present
+		char ns_keep[256] = { 0 };
+		c->get_config_item(c, "lxc.namespace.keep", ns_keep,
+				   sizeof(ns_keep));
+
+		if (strlen(ns_keep) > 0) {
+			// Remove 'net' from the list (values separated by newlines)
+			char new_ns_keep[256] = { 0 };
+			char *saveptr = NULL;
+			char *tok = strtok_r(ns_keep, " \t\n", &saveptr);
+			while (tok) {
+				if (strcmp(tok, "net") != 0) {
+					if (strlen(new_ns_keep) > 0)
+						strcat(new_ns_keep, "\n");
+					strcat(new_ns_keep, tok);
+				}
+				tok = strtok_r(NULL, " \t\n", &saveptr);
+			}
+			// Clear and set each namespace individually
+			c->clear_config_item(c, "lxc.namespace.keep");
+			char *ns_saveptr = NULL;
+			char *ns = strtok_r(new_ns_keep, "\n", &ns_saveptr);
+			while (ns) {
+				c->set_config_item(c, "lxc.namespace.keep", ns);
+				ns = strtok_r(NULL, "\n", &ns_saveptr);
+			}
+			pv_log(DEBUG,
+			       "updated lxc.namespace.keep (removed 'net')");
+		}
+	}
 }
 
 static void pv_setup_lxc_container(struct lxc_container *c,
@@ -410,6 +511,9 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 		c->set_config_item(c, "lxc.hook.mount", path);
 	}
 	closedir(d);
+
+	// Configure IPAM network if platform has pool-based networking
+	pv_setup_lxc_network(c, p);
 }
 
 static void pv_setup_default_log(struct pv_platform *p, struct lxc_container *c,

--- a/state.c
+++ b/state.c
@@ -41,6 +41,7 @@
 #include "jsons.h"
 #include "addons.h"
 #include "pantavisor.h"
+#include "ipam.h"
 #include "storage.h"
 #include "metadata.h"
 #include "utils/tsh.h"
@@ -692,11 +693,31 @@ static int pv_state_validate_services(struct pv_state *s)
 static bool pv_state_check_auto_recovery(struct pv_state *s,
 					 struct pv_platform *p)
 {
-	if (p->auto_recovery.type == RECOVERY_NO)
+	if (p->auto_recovery.type == RECOVERY_NO) {
+		if (p->restart_policy == RESTART_CONTAINER) {
+			pv_log(INFO,
+			       "platform '%s' suddenly stopped. Restarting (restart_policy: container)...",
+			       p->name);
+			// Release any IPAM leases before restarting
+			if (p->network && p->network->mode == NET_MODE_POOL) {
+				struct pv_platform_network_iface *iface;
+				dl_list_for_each(
+					iface, &p->network->interfaces,
+					struct pv_platform_network_iface, list)
+				{
+					if (iface->pool)
+						pv_ipam_release(iface->pool,
+								p->name);
+				}
+			}
+			pv_platform_set_installed(p);
+			return true;
+		}
 		return false;
+	}
 
-	// Check if we are within the reset window to reset retries
 	struct timespec now;
+	// Check if we are within the reset window to reset retries
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	if (p->auto_recovery.reset_window > 0 &&
 	    (now.tv_sec - p->auto_recovery.last_start) >
@@ -739,6 +760,18 @@ static bool pv_state_check_auto_recovery(struct pv_state *s,
 				    RELATIV_TIMER);
 			pv_platform_set_recovering(p);
 		} else {
+			// Release any IPAM leases before restarting
+			if (p->network && p->network->mode == NET_MODE_POOL) {
+				struct pv_platform_network_iface *iface;
+				dl_list_for_each(
+					iface, &p->network->interfaces,
+					struct pv_platform_network_iface, list)
+				{
+					if (iface->pool)
+						pv_ipam_release(iface->pool,
+								p->name);
+				}
+			}
 			pv_platform_set_installed(p);
 		}
 		return true;
@@ -800,7 +833,9 @@ int pv_state_run(struct pv_state *s)
 				pv_platform_set_installed(p);
 			}
 		} else if (pv_platform_is_stopped(p)) {
-			// Platform was intentionally stopped via ctrl API
+			// If the status goal is STOPPED, this is an intentional
+			// stop via API - skip without triggering auto-recovery
+			// or error
 			if (p->status.goal == PLAT_STOPPED)
 				continue;
 

--- a/state.c
+++ b/state.c
@@ -75,6 +75,7 @@ struct pv_state *pv_state_new(const char *rev, state_spec_t spec)
 		dl_list_init(&s->installs);
 		dl_list_init(&s->jsons);
 		dl_list_init(&s->groups);
+		dl_list_init(&s->ingress);
 		dl_list_init(&s->bsp.drivers);
 		s->using_runlevels = false;
 		s->done = false;
@@ -130,6 +131,7 @@ void pv_state_free(struct pv_state *s)
 
 	pv_drivers_empty(s);
 	pv_platforms_empty(s);
+	pv_ingress_empty(s);
 	pv_volumes_empty(s);
 	pv_disk_empty(&s->disks);
 	pv_addons_empty(s);
@@ -1812,8 +1814,7 @@ char *pv_state_get_containers_json(struct pv_state *s)
 {
 	struct pv_json_ser js;
 
-	pv_json_ser_init(&js, 512);
-
+	pv_json_ser_init(&js, 8192);
 	pv_json_ser_array(&js);
 	{
 		struct pv_platform *p, *tmp;
@@ -1834,8 +1835,7 @@ char *pv_state_get_groups_json(struct pv_state *s)
 {
 	struct pv_json_ser js;
 
-	pv_json_ser_init(&js, 512);
-
+	pv_json_ser_init(&js, 4096);
 	pv_json_ser_array(&js);
 	{
 		struct pv_group *g, *tmp_g;
@@ -1892,15 +1892,18 @@ static const char *pvx_svc_type_to_str(service_type_t type)
 		return "wayland";
 	case SVC_TYPE_INPUT:
 		return "input";
+	case SVC_TYPE_TCP:
+		return "tcp";
+	case SVC_TYPE_HTTP:
+		return "http";
 	default:
 		return "unknown";
 	}
 }
-
 char *pv_state_get_xconnect_graph_json(struct pv_state *s)
 {
 	struct pv_json_ser js;
-	pv_json_ser_init(&js, 1024);
+	pv_json_ser_init(&js, 4096);
 	pv_json_ser_array(&js);
 	{
 		struct pv_platform *cp, *cp_tmp;
@@ -1923,9 +1926,15 @@ char *pv_state_get_xconnect_graph_json(struct pv_state *s)
 						struct pv_platform_service_export,
 						list)
 					{
+						pv_log(DEBUG,
+						       "Checking match: consumer=%s svc=%s provider=%s exp=%s",
+						       cp->name, svc->name,
+						       pp->name, exp->name);
 						if (svc->name && exp->name &&
 						    !strcmp(svc->name,
 							    exp->name)) {
+							pv_log(DEBUG,
+							       "MATCH FOUND!");
 							pv_json_ser_object(&js);
 							{
 								pv_json_ser_key(
@@ -1964,7 +1973,7 @@ char *pv_state_get_xconnect_graph_json(struct pv_state *s)
 								pv_json_ser_string(
 									&js,
 									pvx_svc_type_to_str(
-										exp->svc_type));
+										svc->svc_type));
 								pv_json_ser_key(
 									&js,
 									"role");
@@ -1998,6 +2007,125 @@ char *pv_state_get_xconnect_graph_json(struct pv_state *s)
 							pv_json_ser_object_pop(
 								&js);
 						}
+					}
+				}
+			}
+		}
+	}
+
+	{
+		struct pv_platform_service *svc, *svc_tmp;
+		dl_list_for_each_safe(svc, svc_tmp, &s->ingress,
+				      struct pv_platform_service, list)
+		{
+			struct pv_platform *pp, *pp_tmp;
+			dl_list_for_each_safe(pp, pp_tmp, &s->platforms,
+					      struct pv_platform, list)
+			{
+				struct pv_platform_service_export *exp, *se_tmp;
+				dl_list_for_each_safe(
+					exp, se_tmp, &pp->service_exports,
+					struct pv_platform_service_export, list)
+				{
+					if (svc->name && exp->name &&
+					    svc->role && pp->name &&
+					    !strcmp(svc->name, exp->name) &&
+					    !strcmp(svc->role, pp->name)) {
+						pv_json_ser_object(&js);
+						{
+							pv_json_ser_key(
+								&js,
+								"consumer");
+							pv_json_ser_string(
+								&js,
+								"EXTERNAL");
+							pv_json_ser_key(
+								&js,
+								"consumer_pid");
+							pv_json_ser_number(&js,
+									   0);
+							pv_json_ser_key(
+								&js,
+								"provider");
+							pv_json_ser_string(
+								&js, pp->name);
+							pv_json_ser_key(
+								&js,
+								"provider_pid");
+							pv_json_ser_number(
+								&js,
+								pp->init_pid);
+							pv_json_ser_key(&js,
+									"name");
+							pv_json_ser_string(
+								&js, svc->name);
+							pv_json_ser_key(&js,
+									"type");
+							pv_json_ser_string(
+								&js,
+								pvx_svc_type_to_str(
+									svc->svc_type));
+							pv_json_ser_key(&js,
+									"role");
+							pv_json_ser_string(
+								&js,
+								"EXTERNAL");
+							pv_json_ser_key(
+								&js,
+								"interface");
+							pv_json_ser_string(
+								&js,
+								svc->interface ?
+									svc->interface :
+									"");
+							pv_json_ser_key(
+								&js, "target");
+							pv_json_ser_string(
+								&js,
+								svc->target ?
+									svc->target :
+									"");
+
+							// Construct socket address for TCP services with port
+							char socket_buf[64] =
+								"";
+							if (exp->svc_type ==
+								    SVC_TYPE_TCP &&
+							    exp->port > 0 &&
+							    !exp->socket) {
+								const char *ip =
+									pv_platform_get_ipv4_address(
+										pp);
+								if (ip) {
+									// ip is CIDR format (e.g., "10.0.4.2/24")
+									const char *slash = strchr(
+										ip,
+										'/');
+									int ip_len =
+										slash ? (int)(slash -
+											      ip) :
+											(int)strlen(
+												ip);
+									snprintf(
+										socket_buf,
+										sizeof(socket_buf),
+										"%.*s:%d",
+										ip_len,
+										ip,
+										exp->port);
+								}
+							}
+							pv_json_ser_key(
+								&js, "socket");
+							pv_json_ser_string(
+								&js,
+								socket_buf[0] ?
+									socket_buf :
+									(exp->socket ?
+										 exp->socket :
+										 ""));
+						}
+						pv_json_ser_object_pop(&js);
 					}
 				}
 			}

--- a/state.c
+++ b/state.c
@@ -800,6 +800,10 @@ int pv_state_run(struct pv_state *s)
 				pv_platform_set_installed(p);
 			}
 		} else if (pv_platform_is_stopped(p)) {
+			// Platform was intentionally stopped via ctrl API
+			if (p->status.goal == PLAT_STOPPED)
+				continue;
+
 			if (pv_state_check_auto_recovery(s, p))
 				continue;
 

--- a/state.h
+++ b/state.h
@@ -61,6 +61,7 @@ struct pv_state {
 	struct dl_list installs; //pv_object
 	struct dl_list jsons; //pv_json
 	struct dl_list groups; //pv_group
+	struct dl_list ingress; // pv_platform_service
 	bool using_runlevels;
 	int tryonce;
 	bool done;

--- a/utils/json.c
+++ b/utils/json.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#include <jsmn/jsmnutil.h>
 #include "json.h"
 #include "json-build/json-build.h"
 
@@ -131,7 +132,6 @@ char *pv_json_array_get_one_str(const char *buf, int *n, jsmntok_t **tok)
 	}
 	return value;
 }
-
 int pv_json_get_value_int(const char *buf, const char *key, jsmntok_t *tok,
 			  int tokc)
 {

--- a/utils/timer.c
+++ b/utils/timer.c
@@ -85,6 +85,7 @@ int timer_start(struct timer *t, time_t sec, long nsec, timer_type_t type)
 {
 	struct timespec now;
 
+	t->type = type;
 	if (type == RELATIV_TIMER) {
 		get_current_time(t->type, &now);
 
@@ -97,7 +98,6 @@ int timer_start(struct timer *t, time_t sec, long nsec, timer_type_t type)
 
 	return 1;
 }
-
 void timer_stop(struct timer *t)
 {
 	if (!t)

--- a/xconnect/CMakeLists.txt
+++ b/xconnect/CMakeLists.txt
@@ -22,12 +22,15 @@ add_executable(pv-xconnect
     plugins/drm.c
     plugins/wayland.c
     plugins/dbus.c
+    plugins/tcp.c
+    plugins/http.c
     ../utils/json.c
     ../utils/str.c
 )
 
 target_link_libraries(pv-xconnect
     ${LIBEVENT_LIB}
+    event_extra
     ${PICOHTTPPARSER_LIB}
     ${THTTP_LIB}
     dl

--- a/xconnect/TCP-BACKEND.md
+++ b/xconnect/TCP-BACKEND.md
@@ -1,0 +1,266 @@
+# TCP Backend Connection Support for Ingress
+
+This document describes the implementation required to support TCP backend connections for Pattern 2b (Isolated Hybrid Proxy) ingress.
+
+## Problem Statement
+
+Currently, the TCP ingress plugin can bind a listening socket on the host (or in a consumer namespace), but it cannot proxy connections to TCP backends in IPAM containers. The current implementation only supports Unix socket backends.
+
+### Current Flow (Working)
+
+```
+External Request → 0.0.0.0:80 (pv-xconnect listener) → ??? (backend)
+```
+
+### Current Limitation
+
+In `xconnect/plugins/tcp.c:123-127`:
+```c
+// Connect to provider (currently assuming Unix socket provider)
+struct sockaddr_un sun;
+memset(&sun, 0, sizeof(sun));
+sun.sun_family = AF_UNIX;
+strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
+```
+
+For IPAM containers with TCP services:
+- Container has IP 10.0.4.2 (from IPAM pool)
+- Nginx listens on port 80 inside container's network namespace
+- Backend address should be `10.0.4.2:80`
+- But `link->provider_socket` is empty because parser doesn't construct it
+
+## Solution Overview
+
+Three components need changes:
+
+1. **Parser**: Extract `"port"` from services.json and store it
+2. **xconnect-graph builder**: Construct `<ip>:<port>` socket address for TCP services
+3. **TCP plugin**: Support TCP backend connections (not just Unix sockets)
+
+## Implementation
+
+### Phase 1: Parser Changes (`parser/parser_system1.c`)
+
+**1.1 Add port field to service export structure** (`platforms.h`):
+
+```c
+struct pv_platform_service_export {
+    service_type_t svc_type;
+    char *name;
+    char *socket;
+    int port;           // NEW: TCP port number (0 if not specified)
+    struct dl_list list;
+};
+```
+
+**1.2 Update `pv_platform_add_service_export()`** to accept port parameter.
+
+**1.3 Update `parse_service_exports()`** (~line 730):
+
+```c
+char *sock = pv_json_get_value(svc_s, "socket", sv, svc_c);
+char *port_s = pv_json_get_value(svc_s, "port", sv, svc_c);  // NEW
+int port = port_s ? atoi(port_s) : 0;                        // NEW
+
+pv_platform_add_service_export(p, service_str_to_type(t_s), n, sock, port);
+
+if (port_s)
+    free(port_s);
+```
+
+### Phase 2: xconnect-graph Builder (`state.c`)
+
+**2.1 Construct socket address for TCP services with port**
+
+In `pv_state_get_xconnect_graph_json()` around line 2090, when serializing the `"socket"` field for ingress entries:
+
+```c
+// For TCP services with port, construct IP:port from IPAM address
+char socket_buf[64] = "";
+if (exp->svc_type == SVC_TYPE_TCP && exp->port > 0 && !exp->socket) {
+    // Get container's IPAM IP address
+    const char *ip = pv_platform_get_ipv4_address(pp);
+    if (ip) {
+        // ip is in CIDR format (e.g., "10.0.4.2/24"), extract just the IP
+        char *slash = strchr(ip, '/');
+        int ip_len = slash ? (slash - ip) : strlen(ip);
+        snprintf(socket_buf, sizeof(socket_buf), "%.*s:%d", ip_len, ip, exp->port);
+    }
+}
+pv_json_ser_key(&js, "socket");
+pv_json_ser_string(&js, socket_buf[0] ? socket_buf : (exp->socket ? exp->socket : ""));
+```
+
+**2.2 Add helper function** to get platform's IPAM IP:
+
+```c
+// In platforms.c or ipam.c
+const char *pv_platform_get_ipv4_address(struct pv_platform *p)
+{
+    if (!p || !p->network)
+        return NULL;
+
+    struct pv_platform_network_iface *iface;
+    dl_list_for_each(iface, &p->network->interfaces,
+                     struct pv_platform_network_iface, list) {
+        if (iface->ipv4_address)
+            return iface->ipv4_address;
+    }
+    return NULL;
+}
+```
+
+### Phase 3: TCP Plugin (`xconnect/plugins/tcp.c`)
+
+**3.1 Detect TCP vs Unix socket backend**
+
+Update `tcp_on_accept()` to handle both TCP and Unix socket backends:
+
+```c
+static void tcp_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
+                          struct sockaddr *address, int socklen, void *arg)
+{
+    struct pvx_link *link = arg;
+    struct event_base *base = pvx_get_base();
+
+    if (!link->name || !link->provider_socket) {
+        close(fd);
+        return;
+    }
+
+    // Determine if provider_socket is TCP (IP:port) or Unix socket (path)
+    bool is_tcp_backend = (strchr(link->provider_socket, ':') != NULL &&
+                           link->provider_socket[0] != '/');
+
+    struct tcp_proxy_session *session = calloc(1, sizeof(*session));
+    if (!session) {
+        close(fd);
+        return;
+    }
+
+    session->link = link;
+    session->be_client = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+    session->be_provider = bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+
+    int connect_result;
+    if (is_tcp_backend) {
+        connect_result = tcp_connect_to_tcp_backend(session, link->provider_socket);
+    } else {
+        connect_result = tcp_connect_to_unix_backend(session, link);
+    }
+
+    if (connect_result < 0) {
+        bufferevent_free(session->be_client);
+        bufferevent_free(session->be_provider);
+        free(session);
+        return;
+    }
+
+    bufferevent_setcb(session->be_client, tcp_read_cb, NULL, proxy_event_cb, session);
+    bufferevent_setcb(session->be_provider, tcp_read_cb, NULL, proxy_event_cb, session);
+    bufferevent_enable(session->be_client, EV_READ | EV_WRITE);
+    bufferevent_enable(session->be_provider, EV_READ | EV_WRITE);
+}
+```
+
+**3.2 Add TCP backend connection function**:
+
+```c
+static int tcp_connect_to_tcp_backend(struct tcp_proxy_session *session,
+                                      const char *addr_str)
+{
+    char host[256];
+    int port;
+
+    // Parse "IP:port" format
+    const char *colon = strchr(addr_str, ':');
+    if (!colon)
+        return -1;
+
+    size_t host_len = colon - addr_str;
+    if (host_len >= sizeof(host))
+        return -1;
+
+    strncpy(host, addr_str, host_len);
+    host[host_len] = '\0';
+    port = atoi(colon + 1);
+
+    if (port <= 0 || port > 65535)
+        return -1;
+
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = htons(port);
+
+    if (inet_pton(AF_INET, host, &sin.sin_addr) <= 0)
+        return -1;
+
+    printf("%s: Connecting to TCP backend %s:%d\n", MODULE_NAME, host, port);
+
+    return bufferevent_socket_connect(session->be_provider,
+                                      (struct sockaddr *)&sin, sizeof(sin));
+}
+```
+
+**3.3 Refactor Unix socket connection** (existing code):
+
+```c
+static int tcp_connect_to_unix_backend(struct tcp_proxy_session *session,
+                                       struct pvx_link *link)
+{
+    char provider_path[256];
+
+    if (link->provider_pid > 0) {
+        snprintf(provider_path, sizeof(provider_path),
+                 "/proc/%d/root%s", link->provider_pid, link->provider_socket);
+    } else {
+        strncpy(provider_path, link->provider_socket, sizeof(provider_path) - 1);
+        provider_path[sizeof(provider_path) - 1] = '\0';
+    }
+
+    struct sockaddr_un sun;
+    memset(&sun, 0, sizeof(sun));
+    sun.sun_family = AF_UNIX;
+    strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
+
+    printf("%s: Connecting to Unix backend %s\n", MODULE_NAME, provider_path);
+
+    return bufferevent_socket_connect(session->be_provider,
+                                      (struct sockaddr *)&sun, sizeof(sun));
+}
+```
+
+## Testing
+
+After implementation, Test 11 should pass:
+
+```bash
+# Verify xconnect-graph shows constructed socket address
+docker exec pva-test sh -c 'echo -e "GET /xconnect-graph HTTP/1.0\r\n\r\n" | nc -U /run/pantavisor/pv/pv-ctrl' | tail -1 | jq '.[] | select(.name=="nginx-http") | .socket'
+# Expected: "10.0.4.2:80"
+
+# Verify end-to-end HTTP via ingress
+docker exec pva-test wget -q -O - http://127.0.0.1:80/ | head -5
+# Expected: <!DOCTYPE html> ... Welcome to nginx!
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `platforms.h` | Add `port` field to `pv_platform_service_export` |
+| `platforms.c` | Update `pv_platform_add_service_export()`, add `pv_platform_get_ipv4_address()` |
+| `parser/parser_system1.c` | Parse `"port"` field from services.json |
+| `state.c` | Construct `IP:port` socket address for TCP services |
+| `xconnect/plugins/tcp.c` | Support TCP backend connections |
+
+## Alternative Approaches Considered
+
+### A. Namespace injection approach
+Instead of connecting to the container's IP from the host network, pv-xconnect could enter the container's network namespace and connect to `localhost:port`. This would work but adds complexity and requires namespace management in the proxy path.
+
+### B. iptables/nftables DNAT
+Use iptables rules to DNAT traffic to the container IP. This works for simple cases but doesn't provide the visibility and control that pv-xconnect offers (logging, access control, service mesh features).
+
+The chosen approach (TCP backend connection) is simplest and maintains pv-xconnect's role as the service mesh proxy.

--- a/xconnect/XCONNECT-INGRESS-DESIGN.md
+++ b/xconnect/XCONNECT-INGRESS-DESIGN.md
@@ -1,0 +1,217 @@
+# Design: pv-xconnect Ingress & Routing
+
+This document outlines the design and implementation plan for adding TCP and HTTP Ingress capabilities to `pv-xconnect`. This enables automatic routing and filtering behind a single ingress point.
+
+## 1. Overview
+
+The goal is to allow a single "Ingress" container to expose ports (e.g., 80, 443, 2222) that are automatically routed to other containers based on `pv-xconnect` topology.
+
+- **TCP Ingress**: L4 tunneling. Maps an external port on the ingress container to a provider's socket or port.
+- **HTTP Ingress**: L7 routing. Maps HTTP paths (e.g., `/api`, `/app`) on a single port (80) to different provider containers.
+
+## 2. Architecture
+
+### 2.1 TCP Plugin (`plugins/tcp.c`)
+- **Type**: `"tcp"`
+- **Target**: `IP:PORT` (e.g., `0.0.0.0:2222`) inside the *Consumer* namespace.
+- **Behavior**:
+  - `pv-xconnect` enters Consumer namespace.
+  - Binds a listening TCP socket at `target`.
+  - Proxies incoming connections to the Provider's socket (Unix or TCP).
+
+### 2.2 HTTP Plugin (`plugins/http.c`)
+- **Type**: `"http"`
+- **Target**: `IP:PORT/PATH` (e.g., `0.0.0.0:80/api/v1`) inside the *Consumer* namespace.
+- **Behavior**:
+  - **Multiplexing**: Maintains a registry of active `evhttp` servers keyed by `IP:PORT`.
+  - If a server exists for `0.0.0.0:80`, it registers a new handle for `/api/v1`.
+  - If no server exists, it creates a new `evhttp` server and binds it (inside Consumer namespace).
+  - **Routing**: Requests matching the prefix are proxied to the Provider (stripping the prefix if configured, or keeping it).
+
+## 3. Configuration Format
+
+### 3.1 run.json Specification
+
+The `run.json` manifest for the consumer (ingress) container must specify the required services. These are processed by `pv-xconnect` to establish the listeners.
+
+```json
+{
+  "services": {
+    "required": [
+      {
+        "name": "<service-name>",
+        "type": "tcp",
+        "target": "<bind-ip>:<bind-port>"
+      },
+      {
+        "name": "<service-name>",
+        "type": "http",
+        "target": "<bind-ip>:<bind-port>/<path-prefix>"
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description | Example |
+|---|---|---|---|
+| `name` | string | Name of the service to connect to (must match a provider). | `"ssh-service"` |
+| `type` | string | Protocol type: `"tcp"` or `"http"`. | `"tcp"` |
+| `target` | string | **TCP**: `IP:PORT` to bind in the consumer.<br>**HTTP**: `IP:PORT/PATH` to bind/route. | `"0.0.0.0:2222"`<br>`"0.0.0.0:80/api"` |
+| `interface`| string | (Optional) Protocol interface. | |
+
+### 3.2 PVR Template (`args.json`)
+
+When using `pvr` or the `pvr-native` template system, you typically configure these requirements via `args.json`. The standard template variable `PV_SERVICES_REQUIRED` is used to inject the service array into `run.json`.
+
+**Example `args.json`**:
+
+```json
+{
+  "PV_SERVICES_REQUIRED": [
+    {
+      "name": "ssh-service",
+      "type": "tcp",
+      "target": "0.0.0.0:2222"
+    },
+    {
+      "name": "web-ui",
+      "type": "http",
+      "target": "0.0.0.0:80/"
+    },
+    {
+      "name": "api-backend",
+      "type": "http",
+      "target": "0.0.0.0:80/api/v1"
+    }
+  ]
+}
+```
+
+This configuration will tell `pv-xconnect` to:
+1.  Open port **2222** (TCP) in the container and tunnel it to the provider of `ssh-service`.
+2.  Open port **80** (HTTP) in the container.
+3.  Route requests for **`/`** to the provider of `web-ui`.
+4.  Route requests for **`/api/v1`** to the provider of `api-backend`.
+
+## 4. Implementation Plan
+
+### 4.1 Plumbing Changes (`plumbing.c`)
+
+We need a helper to inject TCP sockets. This is similar to `pvx_helper_inject_unix_socket` but uses `sockaddr_in`.
+
+```c
+/* plumbing.c additions */
+
+int pvx_helper_inject_tcp_socket(const char *addr_str, int pid);
+```
+
+### 4.2 Header Updates (`include/xconnect.h`)
+
+```c
+/* include/xconnect.h diff */
+
++ int pvx_helper_inject_tcp_socket(const char *addr_str, int pid);
+
+// Add plugin declarations if we don't use dynamic loading yet
++ extern struct pvx_plugin pvx_plugin_tcp;
++ extern struct pvx_plugin pvx_plugin_http;
+```
+
+### 4.3 TCP Plugin (`plugins/tcp.c`)
+
+```c
+/* plugins/tcp.c (New File) */
+
+static int tcp_on_link_added(struct pvx_link *link)
+{
+    // 1. Inject TCP listener into consumer
+    int fd = pvx_helper_inject_tcp_socket(link->consumer_socket, link->consumer_pid);
+    
+    // 2. Create listener event
+    link->listener = evconnlistener_new(..., tcp_on_accept, ...);
+    return 0;
+}
+
+static void tcp_on_accept(...)
+{
+    // Standard proxy logic (similar to existing rest.c/unix.c)
+    // Connects to link->provider_socket
+}
+
+struct pvx_plugin pvx_plugin_tcp = {
+    .type = "tcp",
+    .on_link_added = tcp_on_link_added,
+    .on_accept = tcp_on_accept
+};
+```
+
+### 4.4 HTTP Plugin (`plugins/http.c`)
+
+This is more complex due to the shared `evhttp` server state.
+
+```c
+/* plugins/http.c (New File) */
+
+struct http_ingress_server {
+    char *listen_addr; // "0.0.0.0:80"
+    struct evhttp *http;
+    struct evhttp_bound_socket *handle;
+    struct dl_list list; // Global list of servers
+};
+
+static void http_generic_cb(struct evhttp_request *req, void *arg)
+{
+    struct pvx_link *link = arg;
+    // Proxy logic:
+    // 1. Convert evhttp_request to raw buffer or use a client bev
+    // 2. Forward to provider link->provider_socket
+}
+
+static int http_on_link_added(struct pvx_link *link)
+{
+    // 1. Parse target "0.0.0.0:80/path" -> host="0.0.0.0:80", path="/path"
+    
+    // 2. Find or Create Server
+    struct http_ingress_server *srv = find_server(host);
+    if (!srv) {
+        srv = create_server(host);
+        // Inject socket into consumer namespace
+        int fd = pvx_helper_inject_tcp_socket(host, link->consumer_pid);
+        srv->http = evhttp_new(pvx_get_base());
+        evhttp_accept_socket(srv->http, fd);
+    }
+
+    // 3. Register Callback
+    evhttp_set_cb(srv->http, path, http_generic_cb, link);
+    
+    return 0;
+}
+```
+
+### 4.5 Integration (`main.c`)
+
+Register the new plugins in the array.
+
+```c
+/* main.c diff */
+
+static struct pvx_plugin *plugins[] = { 
+    &pvx_plugin_unix, 
+    &pvx_plugin_rest,
+    &pvx_plugin_dbus, 
+    &pvx_plugin_drm,
+    &pvx_plugin_wayland,
++   &pvx_plugin_tcp,
++   &pvx_plugin_http,
+    NULL 
+};
+```
+
+## 5. Security & Roles
+
+The HTTP plugin can inject `X-PV-Role` headers based on the `role` field in the link. This allows the backend provider to trust the header because the connection comes from the `pv-xconnect` proxy (via UDS), which is trusted.
+
+- **Ingress**: Public facing (Port 80).
+- **Proxy**: Adds `X-PV-Role: anonymous` (or specific role).
+- **Provider**: Reads header to determine access.

--- a/xconnect/include/xconnect.h
+++ b/xconnect/include/xconnect.h
@@ -65,7 +65,7 @@ struct pvx_plugin {
 // Core Helpers
 struct event_base *pvx_get_base(void);
 int pvx_helper_inject_unix_socket(const char *path, int pid);
+int pvx_helper_inject_tcp_socket(const char *addr_str, int pid);
 int pvx_helper_inject_devnode(const char *target_path, int consumer_pid,
 			      const char *source_path, int provider_pid);
-
 #endif

--- a/xconnect/main.c
+++ b/xconnect/main.c
@@ -25,39 +25,62 @@ static struct dl_list g_links;
 static struct event *g_reconcile_timer;
 
 extern struct pvx_plugin pvx_plugin_unix;
+
 extern struct pvx_plugin pvx_plugin_rest;
+
 extern struct pvx_plugin pvx_plugin_dbus;
+
 extern struct pvx_plugin pvx_plugin_drm;
+
 extern struct pvx_plugin pvx_plugin_wayland;
 
+extern struct pvx_plugin pvx_plugin_tcp;
+
+extern struct pvx_plugin pvx_plugin_http;
+
 static struct pvx_plugin *plugins[] = { &pvx_plugin_unix,    &pvx_plugin_rest,
+
 					&pvx_plugin_dbus,    &pvx_plugin_drm,
-					&pvx_plugin_wayland, NULL };
+
+					&pvx_plugin_wayland, &pvx_plugin_tcp,
+
+					&pvx_plugin_http,    NULL };
 
 struct event_base *pvx_get_base(void)
+
 {
 	return g_base;
 }
 
 static struct pvx_plugin *find_plugin(const char *type)
+
 {
 	for (int i = 0; plugins[i]; i++) {
 		if (!strcmp(plugins[i]->type, type))
+
 			return plugins[i];
 	}
+
 	return NULL;
 }
 
 static struct pvx_link *find_link(const char *consumer, const char *name)
+
 {
 	struct pvx_link *link;
+
 	dl_list_for_each(link, &g_links, struct pvx_link, list)
+
 	{
 		if (link->consumer && link->name &&
+
 		    !strcmp(link->consumer, consumer) &&
+
 		    !strcmp(link->name, name))
+
 			return link;
 	}
+
 	return NULL;
 }
 
@@ -188,27 +211,35 @@ static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
 }
 
 static void reconcile_graph(const char *json)
+
 {
 	jsmntok_t *tokv;
+
 	int tokc;
 
 	if (jsmnutil_parse_json(json, &tokv, &tokc) < 0) {
 		fprintf(stderr, "Failed to parse graph JSON\n");
+
 		return;
 	}
 
 	if (tokv->type != JSMN_ARRAY) {
 		fprintf(stderr, "Graph JSON is not an array\n");
+
 		free(tokv);
+
 		return;
 	}
 
 	int count = jsmnutil_array_count(json, tokv);
+
 	printf("Reconciling graph with %d links\n", count);
 
 	jsmntok_t **items = jsmnutil_get_array_toks(json, tokv);
+
 	if (!items) {
 		free(tokv);
+
 		return;
 	}
 
@@ -220,130 +251,191 @@ static void reconcile_graph(const char *json)
 	}
 
 	jsmnutil_tokv_free(items);
+
 	free(tokv);
 }
+
 static void ctrl_read_cb(struct bufferevent *bev, void *ctx)
+
 {
 	struct evbuffer *input = bufferevent_get_input(bev);
+
 	size_t len = evbuffer_get_length(input);
+
 	char *data = malloc(len + 1);
+
 	evbuffer_remove(input, data, len);
+
 	data[len] = '\0';
 
 	const char *msg;
+
 	int minor_version, status;
+
 	struct phr_header headers[100];
+
 	size_t msg_len, num_headers = 100;
+
 	int pret = phr_parse_response(data, len, &minor_version, &status, &msg,
+
 				      &msg_len, headers, &num_headers, 0);
 
 	if (pret > 0 && status == 200) {
 		reconcile_graph(data + pret);
+
 	} else {
 		fprintf(stderr, "Failed to fetch graph: pret=%d, status=%d\n",
+
 			pret, status);
 	}
 
 	free(data);
+
 	bufferevent_free(bev);
 }
 
 static void ctrl_event_cb(struct bufferevent *bev, short events, void *ctx)
+
 {
 	if (events & BEV_EVENT_CONNECTED) {
 		printf("Connected to pv-ctrl\n");
+
 		evbuffer_add_printf(
+
 			bufferevent_get_output(bev),
+
 			"GET /xconnect-graph HTTP/1.0\r\nHost: localhost\r\n\r\n");
+
 	} else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF)) {
 		if (events & BEV_EVENT_ERROR) {
 			fprintf(stderr, "Error connecting to pv-ctrl: %s\n",
+
 				strerror(errno));
 		}
+
 		bufferevent_free(bev);
 	}
 }
 
 static void fetch_graph(void)
+
 {
 	struct bufferevent *bev;
+
 	struct sockaddr_un sun;
 
 	memset(&sun, 0, sizeof(sun));
+
 	sun.sun_family = AF_UNIX;
+
 	strncpy(sun.sun_path, PV_CTRL_SOCKET, sizeof(sun.sun_path) - 1);
 
 	bev = bufferevent_socket_new(g_base, -1, BEV_OPT_CLOSE_ON_FREE);
+
 	bufferevent_setcb(bev, ctrl_read_cb, NULL, ctrl_event_cb, NULL);
+
 	bufferevent_enable(bev, EV_READ | EV_WRITE);
 
 	if (bufferevent_socket_connect(bev, (struct sockaddr *)&sun,
+
 				       sizeof(sun)) < 0) {
 		fprintf(stderr, "Failed to initiate connection to pv-ctrl\n");
+
 		bufferevent_free(bev);
 	}
 }
 
 static void signal_cb(evutil_socket_t fd, short event, void *arg)
+
 {
 	struct event_base *base = arg;
+
 	printf("Caught an interrupt signal; terminating cleanly.\n");
+
 	event_base_loopexit(base, NULL);
 }
 
 static void reconcile_timer_cb(evutil_socket_t fd, short event, void *arg)
+
 {
 	printf("Periodic reconciliation check...\n");
+
 	fetch_graph();
 
 	// Re-arm the timer
+
 	struct timeval tv = { RECONCILE_INTERVAL_SEC, 0 };
+
 	evtimer_add(g_reconcile_timer, &tv);
 }
 
 int main(int argc, char **argv)
+
 {
 	struct event *signal_event;
+
 	struct event *term_event;
 
 	g_base = event_base_new();
+
 	if (!g_base) {
 		fprintf(stderr, "Could not initialize libevent!\n");
+
 		return 1;
 	}
 
 	dl_list_init(&g_links);
 
+	for (int i = 0; plugins[i]; i++) {
+		if (plugins[i]->init)
+
+			plugins[i]->init();
+	}
+
 	signal_event = evsignal_new(g_base, SIGINT, signal_cb, (void *)g_base);
+
 	if (!signal_event || event_add(signal_event, NULL) < 0) {
 		fprintf(stderr, "Could not create/add a signal event!\n");
+
 		return 1;
 	}
 
 	term_event = evsignal_new(g_base, SIGTERM, signal_cb, (void *)g_base);
+
 	if (!term_event || event_add(term_event, NULL) < 0) {
 		fprintf(stderr, "Could not create/add a term event!\n");
+
 		return 1;
 	}
+
 	printf("pv-xconnect starting...\n");
 
 	// Set up periodic reconciliation timer
+
 	g_reconcile_timer = evtimer_new(g_base, reconcile_timer_cb, NULL);
+
 	if (!g_reconcile_timer) {
 		fprintf(stderr, "Could not create reconcile timer!\n");
+
 		return 1;
 	}
+
 	struct timeval tv = { RECONCILE_INTERVAL_SEC, 0 };
+
 	evtimer_add(g_reconcile_timer, &tv);
 
 	// Initial graph fetch
+
 	fetch_graph();
 
 	event_base_dispatch(g_base);
 
 	event_free(g_reconcile_timer);
+
 	event_free(signal_event);
+
 	event_free(term_event);
+
 	event_base_free(g_base);
 
 	return 0;

--- a/xconnect/main.c
+++ b/xconnect/main.c
@@ -182,6 +182,20 @@ static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
 			       consumer, name, existing->provider_pid, new_pid);
 			existing->provider_pid = new_pid;
 		}
+		// Update provider_socket if it was empty (e.g. IP not
+		// yet allocated when link was first established)
+		char *new_socket =
+			pv_json_get_value(json, "socket", itok, obj_tokc);
+		if (new_socket && new_socket[0] &&
+		    (!existing->provider_socket ||
+		     !existing->provider_socket[0])) {
+			free(existing->provider_socket);
+			existing->provider_socket = new_socket;
+			printf("Updating provider_socket for %s/%s: %s\n",
+			       consumer, name, new_socket);
+		} else {
+			free(new_socket);
+		}
 		free(consumer);
 		free(name);
 		return;

--- a/xconnect/main.c
+++ b/xconnect/main.c
@@ -175,6 +175,13 @@ static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
 	struct pvx_link *existing = find_link(consumer, name);
 
 	if (existing && existing->established) {
+		int new_pid =
+			parse_pid_field(json, "provider_pid", itok, obj_tokc);
+		if (new_pid > 0 && existing->provider_pid != new_pid) {
+			printf("Updating provider_pid for %s/%s: %d -> %d\n",
+			       consumer, name, existing->provider_pid, new_pid);
+			existing->provider_pid = new_pid;
+		}
 		free(consumer);
 		free(name);
 		return;

--- a/xconnect/plugins/http.c
+++ b/xconnect/plugins/http.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <event2/http.h>
+#include <event2/buffer.h>
+#include <event2/keyvalq_struct.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "../include/xconnect.h"
+
+#define MODULE_NAME "pvx-http"
+
+struct http_route {
+	char *path;
+	struct pvx_link *link;
+	struct dl_list list;
+};
+
+struct http_ingress_server {
+	char *listen_addr;
+	struct evhttp *http;
+	struct dl_list routes;
+	struct dl_list list;
+};
+
+static struct dl_list g_http_servers;
+
+struct http_proxy_session {
+	struct evhttp_request *req;
+	struct bufferevent *be_provider;
+	struct pvx_link *link;
+	char *backend_path;
+	bool replied;
+};
+
+static void http_provider_event_cb(struct bufferevent *bev, short events,
+				   void *arg)
+{
+	struct http_proxy_session *session = arg;
+
+	if (events & BEV_EVENT_CONNECTED) {
+		struct evbuffer *output = bufferevent_get_output(bev);
+		const char *cmd_str = "GET";
+		switch (evhttp_request_get_command(session->req)) {
+		case EVHTTP_REQ_GET:
+			cmd_str = "GET";
+			break;
+		case EVHTTP_REQ_POST:
+			cmd_str = "POST";
+			break;
+		case EVHTTP_REQ_PUT:
+			cmd_str = "PUT";
+			break;
+		case EVHTTP_REQ_DELETE:
+			cmd_str = "DELETE";
+			break;
+		default:
+			break;
+		}
+
+		evbuffer_add_printf(output, "%s %s HTTP/1.0\r\n", cmd_str,
+				    session->backend_path);
+
+		struct evkeyvalq *headers =
+			evhttp_request_get_input_headers(session->req);
+		struct evkeyval *header;
+		TAILQ_FOREACH(header, headers, next)
+		{
+			if (strcasecmp(header->key, "Host") == 0)
+				continue;
+			if (strcasecmp(header->key, "Connection") == 0)
+				continue;
+			evbuffer_add_printf(output, "%s: %s\r\n", header->key,
+					    header->value);
+		}
+		evbuffer_add_printf(output, "Host: localhost\r\n");
+		evbuffer_add_printf(output, "Connection: close\r\n\r\n");
+
+		struct evbuffer *input_body =
+			evhttp_request_get_input_buffer(session->req);
+		if (evbuffer_get_length(input_body) > 0) {
+			evbuffer_add_buffer(output, input_body);
+		}
+		return;
+	}
+
+	if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF)) {
+		if (!session->replied) {
+			evhttp_send_reply(session->req, 200, "OK",
+					  bufferevent_get_input(bev));
+			session->replied = true;
+		}
+		if (session->backend_path)
+			free(session->backend_path);
+		bufferevent_free(bev);
+		free(session);
+	}
+}
+
+static void http_provider_read_cb(struct bufferevent *bev, void *arg)
+{
+}
+
+static void http_ingress_gencb(struct evhttp_request *req, void *arg)
+{
+	struct http_ingress_server *srv = arg;
+	const char *uri = evhttp_request_get_uri(req);
+	struct http_route *route, *tmp;
+	struct http_route *matched = NULL;
+
+	dl_list_for_each_safe(route, tmp, &srv->routes, struct http_route, list)
+	{
+		if (strncmp(uri, route->path, strlen(route->path)) == 0) {
+			matched = route;
+			break;
+		}
+	}
+
+	if (!matched) {
+		evhttp_send_error(req, 404, "Not Found");
+		return;
+	}
+
+	struct pvx_link *link = matched->link;
+	struct event_base *base = pvx_get_base();
+	char provider_path[256];
+
+	const char *subpath = uri + strlen(matched->path);
+	if (subpath[0] != '/') {
+		// ensure it starts with /
+		char *new_path = malloc(strlen(subpath) + 2);
+		sprintf(new_path, "/%s", subpath);
+		subpath = new_path;
+	} else {
+		subpath = strdup(subpath);
+	}
+
+	printf("%s: Proxying %s -> %s (provider: %s)\n", MODULE_NAME, uri,
+	       subpath, link->name);
+
+	if (link->provider_pid > 0) {
+		snprintf(provider_path, sizeof(provider_path),
+			 "/proc/%d/root%s", link->provider_pid,
+			 link->provider_socket);
+	} else {
+		strncpy(provider_path, link->provider_socket,
+			sizeof(provider_path) - 1);
+	}
+
+	struct http_proxy_session *session = calloc(1, sizeof(*session));
+	session->req = req;
+	session->link = link;
+	session->backend_path = (char *)subpath;
+	session->be_provider =
+		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+
+	struct sockaddr_un sun;
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
+
+	bufferevent_setcb(session->be_provider, http_provider_read_cb, NULL,
+			  http_provider_event_cb, session);
+	bufferevent_enable(session->be_provider, EV_READ | EV_WRITE);
+
+	if (bufferevent_socket_connect(session->be_provider,
+				       (struct sockaddr *)&sun,
+				       sizeof(sun)) < 0) {
+		evhttp_send_error(req, 502, "Provider Gateway Error");
+		bufferevent_free(session->be_provider);
+		if (session->backend_path)
+			free(session->backend_path);
+		free(session);
+		return;
+	}
+}
+
+static struct http_ingress_server *find_server(const char *addr)
+{
+	struct http_ingress_server *srv;
+	dl_list_for_each(srv, &g_http_servers, struct http_ingress_server, list)
+	{
+		if (!strcmp(srv->listen_addr, addr))
+			return srv;
+	}
+	return NULL;
+}
+
+static int http_on_link_added(struct pvx_link *link)
+{
+	char *host = strdup(link->consumer_socket);
+	char *path = strchr(host, '/');
+	char full_path[256];
+
+	if (path) {
+		*path = '\0';
+		snprintf(full_path, sizeof(full_path), "/%s", path + 1);
+	} else {
+		strcpy(full_path, "/");
+	}
+
+	struct http_ingress_server *srv = find_server(host);
+	if (!srv) {
+		if (link->consumer_pid > 0) {
+			printf("%s: Injecting HTTP listener %s into pid %d\n",
+			       MODULE_NAME, host, link->consumer_pid);
+		} else {
+			printf("%s: Binding HTTP listener %s on host network\n",
+			       MODULE_NAME, host);
+		}
+		int fd = pvx_helper_inject_tcp_socket(host, link->consumer_pid);
+		if (fd < 0) {
+			free(host);
+			return -1;
+		}
+
+		srv = calloc(1, sizeof(*srv));
+		srv->listen_addr = strdup(host);
+		srv->http = evhttp_new(pvx_get_base());
+		dl_list_init(&srv->routes);
+		evhttp_accept_socket(srv->http, fd);
+		evhttp_set_gencb(srv->http, http_ingress_gencb, srv);
+		dl_list_init(&srv->list);
+		dl_list_add_tail(&g_http_servers, &srv->list);
+	}
+
+	struct http_route *route = calloc(1, sizeof(*route));
+	route->path = strdup(full_path);
+	route->link = link;
+	dl_list_init(&route->list);
+	dl_list_add_tail(&srv->routes, &route->list);
+
+	printf("%s: Registered HTTP route %s on %s for %s\n", MODULE_NAME,
+	       full_path, host, link->name);
+
+	free(host);
+	return 0;
+}
+
+static int http_init(void)
+{
+	dl_list_init(&g_http_servers);
+	return 0;
+}
+
+struct pvx_plugin pvx_plugin_http = { .type = "http",
+				      .init = http_init,
+				      .on_link_added = http_on_link_added };

--- a/xconnect/plugins/tcp.c
+++ b/xconnect/plugins/tcp.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "../include/xconnect.h"
+
+#define MODULE_NAME "pvx-tcp"
+
+struct tcp_proxy_session {
+	struct bufferevent *be_client;
+	struct bufferevent *be_provider;
+	struct pvx_link *link;
+	int client_eof;
+	int provider_eof;
+};
+
+static void proxy_check_close(struct tcp_proxy_session *session)
+{
+	if (session->client_eof && session->provider_eof) {
+		if (session->be_client)
+			bufferevent_free(session->be_client);
+		if (session->be_provider)
+			bufferevent_free(session->be_provider);
+		free(session);
+	}
+}
+
+static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
+{
+	struct tcp_proxy_session *session = arg;
+
+	if (events & BEV_EVENT_ERROR) {
+		session->client_eof = 1;
+		session->provider_eof = 1;
+		proxy_check_close(session);
+		return;
+	}
+
+	if (events & BEV_EVENT_EOF) {
+		if (bev == session->be_client) {
+			session->client_eof = 1;
+			bufferevent_disable(bev, EV_READ);
+		} else {
+			session->provider_eof = 1;
+			bufferevent_disable(bev, EV_READ);
+		}
+		proxy_check_close(session);
+	}
+}
+
+static void tcp_read_cb(struct bufferevent *bev, void *arg)
+{
+	struct tcp_proxy_session *session = arg;
+	struct bufferevent *other = (bev == session->be_client) ?
+					    session->be_provider :
+					    session->be_client;
+	struct evbuffer *src = bufferevent_get_input(bev);
+	struct evbuffer *dst = bufferevent_get_output(other);
+	evbuffer_add_buffer(dst, src);
+}
+
+// Check if address is TCP format (IP:port) vs Unix socket path
+static int is_tcp_address(const char *addr)
+{
+	if (!addr || addr[0] == '/')
+		return 0;
+	// TCP address contains colon and no leading slash
+	return strchr(addr, ':') != NULL;
+}
+
+// Connect to TCP backend (IP:port format)
+static int tcp_connect_backend_tcp(struct tcp_proxy_session *session,
+				   const char *addr_str)
+{
+	char host[256];
+	int port;
+
+	// Parse "IP:port" format
+	const char *colon = strchr(addr_str, ':');
+	if (!colon)
+		return -1;
+
+	size_t host_len = colon - addr_str;
+	if (host_len >= sizeof(host))
+		return -1;
+
+	strncpy(host, addr_str, host_len);
+	host[host_len] = '\0';
+	port = atoi(colon + 1);
+
+	if (port <= 0 || port > 65535)
+		return -1;
+
+	struct sockaddr_in sin;
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+
+	if (inet_pton(AF_INET, host, &sin.sin_addr) <= 0)
+		return -1;
+
+	printf("%s: Connecting to TCP backend %s:%d\n", MODULE_NAME, host,
+	       port);
+
+	return bufferevent_socket_connect(session->be_provider,
+					  (struct sockaddr *)&sin, sizeof(sin));
+}
+
+// Connect to Unix socket backend
+static int tcp_connect_backend_unix(struct tcp_proxy_session *session,
+				    struct pvx_link *link)
+{
+	char provider_path[256];
+
+	// Build provider socket path
+	if (link->provider_pid > 0) {
+		snprintf(provider_path, sizeof(provider_path),
+			 "/proc/%d/root%s", link->provider_pid,
+			 link->provider_socket);
+	} else {
+		strncpy(provider_path, link->provider_socket,
+			sizeof(provider_path) - 1);
+		provider_path[sizeof(provider_path) - 1] = '\0';
+	}
+
+	struct sockaddr_un sun;
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
+
+	printf("%s: Connecting to Unix backend %s\n", MODULE_NAME,
+	       provider_path);
+
+	return bufferevent_socket_connect(session->be_provider,
+					  (struct sockaddr *)&sun, sizeof(sun));
+}
+
+static void tcp_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
+			  struct sockaddr *address, int socklen, void *arg)
+{
+	struct pvx_link *link = arg;
+	struct event_base *base = pvx_get_base();
+	int connect_result;
+
+	if (!link->name || !link->provider_socket) {
+		printf("%s: Missing link name or provider_socket\n",
+		       MODULE_NAME);
+		close(fd);
+		return;
+	}
+
+	struct tcp_proxy_session *session = calloc(1, sizeof(*session));
+	if (!session) {
+		close(fd);
+		return;
+	}
+
+	session->link = link;
+	session->be_client =
+		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+	session->be_provider =
+		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+
+	// Determine backend type and connect
+	if (is_tcp_address(link->provider_socket)) {
+		connect_result =
+			tcp_connect_backend_tcp(session, link->provider_socket);
+	} else {
+		connect_result = tcp_connect_backend_unix(session, link);
+	}
+
+	if (connect_result < 0) {
+		printf("%s: Failed to connect to backend %s\n", MODULE_NAME,
+		       link->provider_socket);
+		bufferevent_free(session->be_client);
+		bufferevent_free(session->be_provider);
+		free(session);
+		return;
+	}
+
+	bufferevent_setcb(session->be_client, tcp_read_cb, NULL, proxy_event_cb,
+			  session);
+	bufferevent_setcb(session->be_provider, tcp_read_cb, NULL,
+			  proxy_event_cb, session);
+
+	bufferevent_enable(session->be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(session->be_provider, EV_READ | EV_WRITE);
+}
+
+static int tcp_on_link_added(struct pvx_link *link)
+{
+	struct event_base *base = pvx_get_base();
+	int fd;
+
+	if (link->consumer_pid > 0) {
+		printf("%s: Injecting TCP listener %s into pid %d\n",
+		       MODULE_NAME, link->consumer_socket, link->consumer_pid);
+	} else {
+		printf("%s: Binding TCP listener %s on host network\n",
+		       MODULE_NAME, link->consumer_socket);
+	}
+
+	fd = pvx_helper_inject_tcp_socket(link->consumer_socket,
+					  link->consumer_pid);
+	if (fd < 0)
+		return -1;
+
+	link->listener =
+		evconnlistener_new(base, tcp_on_accept, link,
+				   LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE,
+				   -1, fd);
+
+	if (!link->listener) {
+		close(fd);
+		return -1;
+	}
+
+	return 0;
+}
+
+struct pvx_plugin pvx_plugin_tcp = { .type = "tcp",
+				     .on_link_added = tcp_on_link_added,
+				     .on_accept = tcp_on_accept };

--- a/xconnect/plugins/tcp.c
+++ b/xconnect/plugins/tcp.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <event2/util.h>
 #include "../include/xconnect.h"
 
 #define MODULE_NAME "pvx-tcp"
@@ -54,8 +55,18 @@ static void proxy_check_close(struct tcp_proxy_session *session)
 static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
 {
 	struct tcp_proxy_session *session = arg;
+	const char *side =
+		(bev == session->be_client) ? "client" : "provider";
+
+	if (events & BEV_EVENT_CONNECTED) {
+		fprintf(stderr, "%s: %s connected\n", MODULE_NAME, side);
+		return;
+	}
 
 	if (events & BEV_EVENT_ERROR) {
+		fprintf(stderr, "%s: %s error: %s\n", MODULE_NAME, side,
+			evutil_socket_error_to_string(
+				EVUTIL_SOCKET_ERROR()));
 		session->client_eof = 1;
 		session->provider_eof = 1;
 		proxy_check_close(session);
@@ -63,6 +74,7 @@ static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
 	}
 
 	if (events & BEV_EVENT_EOF) {
+		fprintf(stderr, "%s: %s EOF\n", MODULE_NAME, side);
 		if (bev == session->be_client) {
 			session->client_eof = 1;
 			bufferevent_disable(bev, EV_READ);
@@ -125,6 +137,7 @@ static int tcp_connect_backend_tcp(struct tcp_proxy_session *session,
 	if (inet_pton(AF_INET, host, &sin.sin_addr) <= 0)
 		return -1;
 
+	// be_provider already has an AF_INET socket from tcp_on_accept
 	printf("%s: Connecting to TCP backend %s:%d\n", MODULE_NAME, host,
 	       port);
 
@@ -184,14 +197,26 @@ static void tcp_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 	session->link = link;
 	session->be_client =
 		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
-	session->be_provider =
-		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
 
-	// Determine backend type and connect
+	// For TCP backends, create an AF_INET socket directly
+	// For Unix backends, use fd=-1 (libevent auto-creates AF_UNIX)
 	if (is_tcp_address(link->provider_socket)) {
+		int tcp_fd = socket(AF_INET, SOCK_STREAM, 0);
+		if (tcp_fd < 0) {
+			fprintf(stderr, "%s: socket(AF_INET) failed: %s\n",
+				MODULE_NAME, strerror(errno));
+			bufferevent_free(session->be_client);
+			free(session);
+			return;
+		}
+		evutil_make_socket_nonblocking(tcp_fd);
+		session->be_provider = bufferevent_socket_new(
+			base, tcp_fd, BEV_OPT_CLOSE_ON_FREE);
 		connect_result =
 			tcp_connect_backend_tcp(session, link->provider_socket);
 	} else {
+		session->be_provider =
+			bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
 		connect_result = tcp_connect_backend_unix(session, link);
 	}
 

--- a/xconnect/plumbing.c
+++ b/xconnect/plumbing.c
@@ -31,6 +31,8 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <linux/limits.h>
 #include <libgen.h>
 #include <stddef.h>
@@ -136,6 +138,104 @@ out:
 	if (setns(old_ns_fd, CLONE_NEWNS) < 0) {
 		perror("setns back");
 		// This is fatal for the process if it fails
+		exit(1);
+	}
+
+	if (old_ns_fd >= 0)
+		close(old_ns_fd);
+	if (target_ns_fd >= 0)
+		close(target_ns_fd);
+
+	return fd;
+}
+
+int pvx_helper_inject_tcp_socket(const char *addr_str, int pid)
+{
+	int old_ns_fd = -1;
+	int target_ns_fd = -1;
+	int fd = -1;
+	char ns_path[PATH_MAX];
+	struct sockaddr_in sin;
+	char *host = NULL;
+	int port = 0;
+
+	if (!addr_str)
+		return -1;
+
+	// Parse IP:PORT
+	char *tmp = strdup(addr_str);
+	char *colon = strchr(tmp, ':');
+	if (!colon) {
+		free(tmp);
+		return -1;
+	}
+	*colon = '\0';
+	host = tmp;
+	port = atoi(colon + 1);
+
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(port);
+	if (inet_pton(AF_INET, host, &sin.sin_addr) <= 0) {
+		free(tmp);
+		return -1;
+	}
+	free(tmp);
+
+	// 1. Save current network namespace
+	old_ns_fd = open("/proc/self/ns/net", O_RDONLY);
+	if (old_ns_fd < 0) {
+		perror("open current net ns");
+		return -1;
+	}
+
+	if (pid > 0) {
+		// 2. Open target network namespace
+		snprintf(ns_path, sizeof(ns_path), "/proc/%d/ns/net", pid);
+		target_ns_fd = open(ns_path, O_RDONLY);
+		if (target_ns_fd < 0) {
+			perror("open target net ns");
+			close(old_ns_fd);
+			return -1;
+		}
+
+		// 3. Enter target network namespace
+		if (setns(target_ns_fd, CLONE_NEWNET) < 0) {
+			perror("setns net");
+			goto out;
+		}
+	}
+
+	// 4. Create and bind socket
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) {
+		perror("socket");
+		goto out;
+	}
+
+	evutil_make_socket_nonblocking(fd);
+
+	int on = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+	if (bind(fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+		perror("bind tcp");
+		close(fd);
+		fd = -1;
+		goto out;
+	}
+
+	if (listen(fd, 10) < 0) {
+		perror("listen tcp");
+		close(fd);
+		fd = -1;
+		goto out;
+	}
+
+out:
+	// 5. Always switch back to host network namespace
+	if (setns(old_ns_fd, CLONE_NEWNET) < 0) {
+		perror("setns net back");
 		exit(1);
 	}
 


### PR DESCRIPTION
This PR implements L4 TCP and L7 HTTP ingress routing plugins for pvx-connect.

Key changes:
- New plugins for TCP and HTTP proxying.
- Network namespace Port injection support.
- Fixed critical bug in JSON parser array iteration.
- Updated Graph API to correctly report consumer-requested protocol types.
- Increased JSON buffer sizes to prevent graph truncation.