### PR TITLE
fix(logserver): fix ratelimit bypass not applied for stdout output

### DIFF
--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -956,6 +956,20 @@ int pv_logserver_init(const char *rev)
 		if (logserver_utils_ignore_loglevel() == 0)
 			pv_log(DEBUG,
 			       "stdout: ignoring kernel log level, all messages will be shown");
+		else
+			pv_log(WARN,
+			       "stdout: could not set ignore_loglevel: %s",
+			       strerror(errno));
+		if ((logserver.active_out & LOG_SERVER_OUTPUT_STDOUT) ||
+		    (logserver.active_out & LOG_SERVER_OUTPUT_STDOUT_DIRECT)) {
+			if (logserver_utils_printk_devmsg_on() == 0)
+				pv_log(DEBUG,
+				       "stdout: setting printk_devmsg=on, all messages will be captured");
+			else
+				pv_log(WARN,
+				       "stdout: could not set printk_devkmsg=on: %s",
+				       strerror(errno));
+		}
 	}
 
 	errno = 0;

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -337,5 +337,5 @@ int logserver_utils_printk_devmsg_on()
 int logserver_utils_ignore_loglevel()
 {
 	return write_option("/sys/module/printk/parameters/ignore_loglevel",
-			    "Y");
+			    "Y\n");
 }


### PR DESCRIPTION
## Problem

When `stdout` or `stdout_direct` outputs were enabled in logserver, kernel
messages were still being ratelimited. Two root causes:

1. The sysfs write to `/sys/module/printk/parameters/ignore_loglevel` was
   missing a trailing newline, so the parameter was silently ignored.
2. `printk.devkmsg=on` was never set automatically when stdout outputs
   were active.

## Solution

- Fix the `\n`-terminated write to `ignore_loglevel`
- Automatically call `logserver_utils_printk_devkmsg_on()` when stdout or
  stdout_direct outputs are enabled
- Add WARN-level error logging for both operations

## Trade-off

`ignore_loglevel` and `printk.devkmsg=on` are applied during logserver
initialization, so messages produced **before** logserver starts may be
lost. To capture the full boot log, set these in the kernel cmdline:

```
printk.devkmsg=on ignore_loglevel
```