### PR TITLE
fix(pvtx): fix tar parser bugs, memory leaks, and fd leak

### DIFF
--- a/pvtx/pvtx_tar.c
+++ b/pvtx/pvtx_tar.c
@@ -25,7 +25,6 @@
 #endif
 
 #include "pvtx_tar_impl.h"
-#include "pvtx_buffer.h"
 #include "pvtx_tar.h"
 
 #include <unistd.h>
@@ -61,6 +60,8 @@ struct pv_pvtx_tar_metadata {
 	char prefix[155];
 };
 
+#define PVTX_TAR_TYPEFLAG_LONG_NAME 'L'
+
 extern struct pv_pvtx_tar_imp pv_pvtx_tar_raw;
 extern struct pv_pvtx_tar_imp pv_pvtx_tar_gzip;
 
@@ -92,33 +93,22 @@ static ssize_t read_nointr(struct pv_pvtx_tar_priv *priv, void *buf,
 static void get_name(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_metadata *meta,
 		     char *name)
 {
-	const char *long_link = "/./@LongLink";
-	if (strncmp(meta->name, long_link, strlen(long_link))) {
-		memccpy(name, meta->name, '\0', 100);
+	if (meta->typeflag == PVTX_TAR_TYPEFLAG_LONG_NAME) {
+		char buf[PVTX_TAR_BLOCK_SIZE] = { 0 };
+		read_nointr(tar->priv, buf, PVTX_TAR_BLOCK_SIZE);
+		memccpy(name, buf, '\0', NAME_MAX);
 		return;
 	}
 
-	// NOTE: here we could check the typeflag which
-	// for large name should be 'L' but seems redundant
-	char *buf[PVTX_TAR_BLOCK_SIZE] = { 0 };
-	read_nointr(tar->priv, buf, PVTX_TAR_BLOCK_SIZE);
-	memccpy(name, buf, '\0', NAME_MAX);
+	memccpy(name, meta->name, '\0', 100);
 }
 
 static int read_remaining_bytes(struct pv_pvtx_tar *tar,
 				struct pv_pvtx_tar_content *con)
 {
-	struct pv_pvtx_buffer *buf = pv_pvtx_buffer_from_env(
-		"PVTX_OBJECT_BUF_SIZE", 512, 10485760, 512);
-
-	if (!buf)
-		return -1;
-
-	while (pv_pvtx_tar_content_read_block(con, buf->data, buf->size) > 0)
+	char buf[4096];
+	while (pv_pvtx_tar_content_read_block(con, buf, sizeof(buf)) > 0)
 		;
-
-	pv_pvtx_buffer_free(buf);
-
 	return 0;
 }
 
@@ -131,16 +121,14 @@ int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con)
 		return -1;
 	}
 
-	char buf[PVTX_TAR_BLOCK_SIZE] = { 0 };
-	ssize_t size = read_nointr(tar->priv, buf, PVTX_TAR_BLOCK_SIZE);
+	struct pv_pvtx_tar_metadata meta = { 0 };
+	ssize_t size = read_nointr(tar->priv, &meta, PVTX_TAR_BLOCK_SIZE);
 
 	if (size < PVTX_TAR_BLOCK_SIZE) {
 		PVTX_ERROR_SET(&tar->err, -1, "couldn't read header");
 		return -1;
 	}
 
-	struct pv_pvtx_tar_metadata meta = { 0 };
-	memcpy(&meta, buf, sizeof(struct pv_pvtx_tar_metadata));
 	if (strncmp(meta.magic, "ustar", strlen("ustar"))) {
 		PVTX_ERROR_SET(&tar->err, -1, "ustar not found");
 		return -1;
@@ -150,7 +138,9 @@ int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con)
 	get_name(tar, &meta, con->name);
 
 	con->size = strtoll(meta.size, NULL, 8);
-	con->cap = (con->size | (PVTX_TAR_BLOCK_SIZE - 1)) + 1;
+	con->cap = con->size == 0
+			   ? 0
+			   : (con->size | (PVTX_TAR_BLOCK_SIZE - 1)) + 1;
 	if (!con->priv)
 		con->priv = tar->priv;
 	con->read = 0;
@@ -182,13 +172,12 @@ ssize_t pv_pvtx_tar_content_read_object(struct pv_pvtx_tar_content *con,
 					void *buf)
 {
 	memset(buf, 0, con->size);
-	while (con->read < con->cap) {
-		void *p = buf + con->read;
-		ssize_t size = read_nointr(con->priv, p, PVTX_TAR_BLOCK_SIZE);
-		if (size > 0)
-			con->read += size;
-		else
-			break;
+	ssize_t remaining = con->cap - con->read;
+	if (remaining > 0) {
+		ssize_t n = read_nointr(con->priv, (char *)buf + con->read,
+					remaining);
+		if (n > 0)
+			con->read += n;
 	}
 
 	return con->read;
@@ -199,19 +188,17 @@ void pv_pvtx_tar_free(struct pv_pvtx_tar *tar)
 	if (!tar)
 		return;
 
-	if (!tar->priv || !tar->priv->imp_data)
-		goto out;
-
 	struct pv_pvtx_tar_priv *priv = tar->priv;
+	if (priv) {
+		if (priv->imp_data) {
+			if (priv->imp)
+				priv->imp->close(priv->imp_data);
+			else
+				free(priv->imp_data);
+		}
+		free(priv);
+	}
 
-	if (priv->imp)
-		priv->imp->close(priv->imp_data);
-	else
-		free(priv->imp_data);
-
-	free(priv);
-
-out:
 	free(tar);
 }
 
@@ -308,6 +295,11 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_fd(int fd, enum pv_pvtx_tar_type type,
 	}
 
 	priv->imp_data = priv->imp->from_fd(fd);
+	if (!priv->imp_data) {
+		PVTX_ERROR_SET(err, errno,
+			       "couldn't initialize format implementation");
+		goto err;
+	}
 
 	return tar;
 
@@ -333,6 +325,8 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_path(const char *path,
 	}
 
 	struct pv_pvtx_tar *tar = pv_pvtx_tar_from_fd(fd, type, err);
+	if (!tar)
+		close(fd);
 
 	return tar;
 }

--- a/pvtx/pvtx_tar_formats.c
+++ b/pvtx/pvtx_tar_formats.c
@@ -48,6 +48,7 @@ static bool pv_pvtx_raw_is_fmt(int fd)
 static void *pv_pvtx_raw_from_fd(int fd)
 {
 	lseek(fd, 0, SEEK_SET);
+	posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 	int *tar_fd = malloc(sizeof(int));
 	if (!tar_fd)
 		return NULL;
@@ -89,7 +90,10 @@ static bool pv_pvtx_gzip_is_fmt(int fd)
 static void *pv_pvtx_gzip_from_fd(int fd)
 {
 	lseek(fd, 0, SEEK_SET);
-	return gzdopen(fd, "r");
+	gzFile gz = gzdopen(fd, "r");
+	if (gz)
+		gzbuffer(gz, 32768);
+	return gz;
 }
 
 static ssize_t pv_pvtx_gzip_read(void *impl_data, void *buf, size_t count)


### PR DESCRIPTION
# Fix tar parser correctness issues, memory/fd leaks, and improve I/O performance

## What changed

### Bug fixes (`pvtx_tar.c`)

- **Long-name detection** (`get_name`): The previous implementation detected GNU tar long-name entries by comparing the entry name against the magic string `"/./@LongLink"`. The correct approach is to check `typeflag == 'L'`, which is what the GNU tar spec requires. The old code also contained a latent type bug: `char *buf[PVTX_TAR_BLOCK_SIZE]` (array of char pointers) instead of `char buf[PVTX_TAR_BLOCK_SIZE]` (byte array).

- **fd leak** (`pv_pvtx_tar_from_path`): If `pv_pvtx_tar_from_fd()` failed, the file descriptor opened by `from_path` was never closed.

- **Missing null-check** (`pv_pvtx_tar_from_fd`): `imp->from_fd()` could return NULL (e.g., on `gzdopen` failure) with no error propagation, leading to a NULL dereference later.

- **Zero-size entry capacity** (`pv_pvtx_tar_next`): The block-alignment rounding `(size | (BLOCK_SIZE - 1)) + 1` produced `BLOCK_SIZE` instead of `0` for zero-size entries, causing an unnecessary read of a padding block.

- **Free path** (`pv_pvtx_tar_free`): Replaced a `goto`-based null guard with nested `if` checks, making the ownership and cleanup logic explicit.

### Memory/allocation improvements

- `read_remaining_bytes()` previously allocated a heap buffer (size configurable via `PVTX_OBJECT_BUF_SIZE`, up to 10 MiB) through `pv_pvtx_buffer_from_env()`. Since the function only drains remaining bytes and discards them, a 4 KiB stack buffer is sufficient and removes an allocation that could fail.

- `pv_pvtx_tar_next()` now reads the tar header directly into the `pv_pvtx_tar_metadata` struct, eliminating an intermediate `char buf[]` + `memcpy`.

- `pv_pvtx_tar_content_read_object()` now issues a single `read_nointr()` for all remaining bytes instead of looping one block at a time, reducing syscall overhead for large objects.

### I/O performance (`pvtx_tar_formats.c`)

- Raw format: `posix_fadvise(POSIX_FADV_SEQUENTIAL)` is now called after `lseek`, advising the kernel to prefetch ahead aggressively.
- Gzip format: `gzbuffer(gz, 32768)` increases the zlib internal read buffer from the default 8 KiB to 32 KiB, reducing the number of underlying `read()` calls during decompression.
