### PR TITLE
fix(platforms): unmount volumes when container transitions to STOPPED

### DIFF
--- a/platforms.c
+++ b/platforms.c
@@ -41,6 +41,7 @@
 #include <sched.h>
 
 #include "platforms.h"
+#include "volumes.h"
 #include "paths.h"
 #include "wdt.h"
 #include "drivers.h"
@@ -193,6 +194,27 @@ bool pv_platform_track_stability(struct pv_platform *p)
 	return p->auto_recovery.is_stable;
 }
 
+static void pv_platform_unmount_volumes(struct pv_platform *p)
+{
+	if (!p->state)
+		return;
+
+	struct pv_volume *v, *tmp;
+	dl_list_for_each_safe(v, tmp, &p->state->volumes, struct pv_volume,
+			      list)
+	{
+		if (v->plat == p)
+			pv_volume_unmount(v);
+	}
+}
+
+/*
+ * All transitions to PLAT_STOPPED come through this function, whether from
+ * pv_platform_force_stop (intentional kill), pv_platform_check_running
+ * (crash detection), or a failed start. When entering STOPPED, we unmount
+ * platform volumes so the next start cycle gets clean mounts instead of
+ * accumulating overmounts.
+ */
 static void pv_platform_set_status(struct pv_platform *p, plat_status_t status)
 {
 	if (p->status.current == status)
@@ -201,6 +223,10 @@ static void pv_platform_set_status(struct pv_platform *p, plat_status_t status)
 	p->status.current = status;
 	pv_log(INFO, "platform '%s' status is now %s", p->name,
 	       pv_platform_status_string(status));
+
+	if (status == PLAT_STOPPED)
+		pv_platform_unmount_volumes(p);
+
 	pv_platform_on_status_goal_reached(p);
 
 	pv_group_eval_status(p->group);

--- a/state.c
+++ b/state.c
@@ -956,25 +956,6 @@ static int pv_state_unmount_platform_volumes(struct pv_state *s,
 	return ret;
 }
 
-static int pv_state_unmount_platforms_volumes(struct pv_state *s)
-{
-	int ret = 0;
-	struct pv_platform *p, *tmp_p;
-
-	// unmount platform volumes
-	dl_list_for_each_safe(p, tmp_p, &s->platforms, struct pv_platform, list)
-	{
-		if (!(pv_platform_is_stopping(p) ||
-		      pv_platform_is_starting(p) || pv_platform_is_started(p) ||
-		      pv_platform_is_ready(p))) {
-			if (pv_state_unmount_platform_volumes(s, p))
-				ret = -1;
-		}
-	}
-
-	return ret;
-}
-
 void pv_state_stop_lenient(struct pv_state *s)
 {
 	if (!s)
@@ -1004,11 +985,9 @@ int pv_state_stop_force(struct pv_state *s)
 		ret |= -2;
 	}
 
-	// unmount all platform related volumes
-	if (pv_state_unmount_platforms_volumes(s))
-		ret |= -4;
-
-	// unmount bsp volumes
+	// Platform volumes are unmounted when each platform transitions to
+	// STOPPED (in pv_platform_set_status). Only BSP volumes (plat==NULL)
+	// need explicit unmount here.
 	if (pv_state_unmount_platform_volumes(s, NULL))
 		ret |= -8;
 
@@ -1195,11 +1174,8 @@ int pv_state_stop_platforms(struct pv_state *current, struct pv_state *pending)
 	if (!pv_state_check_all_stopped(current))
 		pv_state_force_stop(current);
 
-	if (pv_state_unmount_platforms_volumes(current)) {
-		pv_log(ERROR, "could not unmount volumes");
-		return -1;
-	}
-
+	// Platform volumes are unmounted when each platform transitions to
+	// STOPPED (in pv_platform_set_status).
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

- Unmount platform volumes when a container transitions to PLAT_STOPPED
- Fixes mount accumulation (overmounting) during auto-recovery crash/restart cycles
- Each recovery cycle now gets clean mounts instead of stacking on top of existing ones

The fix is in `pv_platform_set_status()` which is the single chokepoint for all STOPPED transitions — crashes, force_stop, and failed starts.

## Test plan

- [x] Build with auto-recovery containers (e.g., `pv-example-recovery`)
- [x] Trigger multiple crash/recovery cycles
- [x] Verify `cat /proc/mounts | grep <container>` shows constant mount count (no accumulation)
- [ ] Verify normal shutdown/reboot still unmounts correctly