### PR TITLE
feat(ctrl): add container lifecycle control API

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -68,6 +68,8 @@ Changes to `docs/**` on master automatically trigger a GitLab CI pipeline in the
 ## Development Guidelines
 
 - **Documentation**: Always check if [reference documentation](docs/reference/) should be updated after making changes to the code.
+  - **Reference links from overview docs**: Link to `../../../reference/legacy/` for content that already exists there, or `../../../reference/027/` (current development tag) for new content appearing for the first time.
+  - **Overview docs**: Use relative links within `docs/overview/` (e.g., `containers.md#restart-policy`).
 - **Commits**: Always use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (v1.0.0) for all commit messages.
 - **Formatting**: Run `clang-format -i` on modified `.c`/`.h` files before committing
 - **API testing**: Use `pvcurl` (not `curl`) inside appengine containers

--- a/ctrl/ctrl_containers_ep.c
+++ b/ctrl/ctrl_containers_ep.c
@@ -26,8 +26,13 @@
 #include "ctrl_util.h"
 #include "state.h"
 #include "pantavisor.h"
+#include "platforms.h"
+#include "group.h"
+#include "utils/json.h"
 
 #include <event2/http.h>
+#include <event2/buffer.h>
+#include <linux/limits.h>
 
 #include <string.h>
 
@@ -58,9 +63,201 @@ static void ctrl_containers_list(struct evhttp_request *req, void *ctx)
 	pv_ctrl_utils_send_json(req, HTTP_OK, NULL, cont);
 }
 
+static void ctrl_on_stopped_user_stop(struct pv_platform *p, void *opaque)
+{
+	pv_log(DEBUG, "Container %s stopped (user stop)", p->name);
+	p->auto_recovery.user_stopped = true;
+}
+
+static void ctrl_on_stopped_restart(struct pv_platform *p, void *opaque)
+{
+	pv_log(DEBUG, "Container %s stopped (restart), setting INSTALLED",
+	       p->name);
+	p->auto_recovery.current_retries = 0;
+	p->auto_recovery.recovery_failed = false;
+	p->auto_recovery.user_stopped = false;
+	pv_platform_set_installed(p);
+}
+
+static void ctrl_container_process_action(struct evbuffer *buf,
+					  const struct evbuffer_cb_info *info,
+					  void *ctx)
+{
+	struct evhttp_request *req = ctx;
+	char *data = NULL;
+	char *action = NULL;
+	int tokc;
+	jsmntok_t *tokv = NULL;
+	struct pv_platform *p = NULL;
+	struct pantavisor *pv = pv_get_instance();
+
+	if (!info->n_added)
+		return;
+
+	const char *uri = evhttp_request_get_uri(req);
+	char split[PV_CTRL_MAX_SPLIT][NAME_MAX] = { 0 };
+	int size = pv_ctrl_utils_split_path(uri, split);
+
+	if (size < 2) {
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST,
+					 "Missing container name");
+		return;
+	}
+
+	p = pv_state_fetch_platform(pv->state, split[1]);
+	if (!p) {
+		pv_ctrl_utils_send_error(req, HTTP_NOTFOUND,
+					 "Container not found");
+		return;
+	}
+
+	if (p->restart_policy != RESTART_CONTAINER) {
+		pv_ctrl_utils_send_error(
+			req, HTTP_FORBIDDEN,
+			"Container has restart_policy 'system' and cannot be controlled via API");
+		return;
+	}
+
+	data = pv_ctrl_utils_get_data(req, 1024, NULL);
+	if (!data) {
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST, "No data");
+		return;
+	}
+
+	jsmn_parser parser;
+	jsmn_init(&parser);
+	tokc = jsmn_parse(&parser, data, strlen(data), NULL, 0);
+	if (tokc < 0) {
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST, "Invalid JSON");
+		return;
+	}
+	tokv = calloc(tokc, sizeof(jsmntok_t));
+	if (!tokv) {
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_INTERNAL, "Out of memory");
+		return;
+	}
+	jsmn_init(&parser);
+	jsmn_parse(&parser, data, strlen(data), tokv, tokc);
+
+	action = pv_json_get_value(data, "action", tokv, tokc);
+
+	if (!action) {
+		free(tokv);
+		free(data);
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST,
+					 "Missing 'action' field");
+		return;
+	}
+
+	if (strcmp(action, "stop") == 0) {
+		pv_log(DEBUG, "Stopping container %s via ctrl", p->name);
+
+		if (pv_platform_is_stopped(p) &&
+		    p->auto_recovery.user_stopped) {
+			pv_log(DEBUG, "Container %s is already stopped by user",
+			       p->name);
+		} else if (pv_platform_is_stopped(p) ||
+			   pv_platform_is_recovering(p)) {
+			p->auto_recovery.user_stopped = true;
+		} else if (pv_platform_is_stopping(p)) {
+			// Already stopping — ensure callback sets user_stopped
+			p->on_stopped = ctrl_on_stopped_user_stop;
+			p->on_stopped_opaque = NULL;
+		} else {
+			pv_platform_stop_with_callback(
+				p, ctrl_on_stopped_user_stop, NULL);
+		}
+	} else if (strcmp(action, "start") == 0) {
+		pv_log(DEBUG, "Starting container %s via ctrl", p->name);
+
+		if (pv_platform_is_started(p) || pv_platform_is_starting(p) ||
+		    pv_platform_is_ready(p)) {
+			pv_log(DEBUG, "Container %s is already running",
+			       p->name);
+		} else if (pv_platform_is_stopped(p) ||
+			   pv_platform_is_recovering(p)) {
+			p->auto_recovery.user_stopped = false;
+			p->auto_recovery.current_retries = 0;
+			p->auto_recovery.recovery_failed = false;
+			pv_platform_set_installed(p);
+		} else if (pv_platform_is_stopping(p)) {
+			// Already stopping — swap callback to restart
+			p->on_stopped = ctrl_on_stopped_restart;
+			p->on_stopped_opaque = NULL;
+		} else {
+			free(action);
+			free(tokv);
+			free(data);
+			pv_ctrl_utils_send_error(
+				req, HTTP_BADREQUEST,
+				"Container must be in STOPPED, STOPPING, or RECOVERING state to start");
+			return;
+		}
+	} else if (strcmp(action, "restart") == 0) {
+		pv_log(DEBUG, "Restarting container %s via ctrl", p->name);
+
+		if (pv_platform_is_stopped(p) || pv_platform_is_recovering(p)) {
+			p->auto_recovery.user_stopped = false;
+			p->auto_recovery.current_retries = 0;
+			p->auto_recovery.recovery_failed = false;
+			pv_platform_set_installed(p);
+		} else if (pv_platform_is_started(p) ||
+			   pv_platform_is_starting(p) ||
+			   pv_platform_is_ready(p)) {
+			pv_platform_stop_with_callback(
+				p, ctrl_on_stopped_restart, NULL);
+		} else if (pv_platform_is_stopping(p)) {
+			// Already stopping — swap callback to restart
+			p->on_stopped = ctrl_on_stopped_restart;
+			p->on_stopped_opaque = NULL;
+		} else {
+			free(action);
+			free(tokv);
+			free(data);
+			pv_ctrl_utils_send_error(
+				req, HTTP_BADREQUEST,
+				"Container state does not allow restart");
+			return;
+		}
+	} else {
+		free(action);
+		free(tokv);
+		free(data);
+		pv_ctrl_utils_send_error(
+			req, HTTP_BADREQUEST,
+			"Invalid action. Use 'start', 'stop', or 'restart'");
+		return;
+	}
+
+	free(action);
+	free(tokv);
+	free(data);
+
+	pv_ctrl_utils_send_ok(req);
+}
+
+static void ctrl_container_put(struct evhttp_request *req, void *ctx)
+{
+	char err[PV_CTRL_MAX_ERR] = { 0 };
+	int code = pv_ctrl_utils_is_req_ok(req, ctx, err);
+	if (code != 0) {
+		pv_ctrl_utils_drain_on_arrive_with_err(req, code, err);
+		return;
+	}
+
+	pv_log(DEBUG, "PUT request for containers");
+
+	evbuffer_add_cb(evhttp_request_get_input_buffer(req),
+			ctrl_container_process_action, req);
+}
+
 int pv_ctrl_endpoints_containers_init()
 {
 	pv_ctrl_add_endpoint("/containers", EVHTTP_REQ_GET, true,
 			     ctrl_containers_list);
+	pv_ctrl_add_endpoint("/containers/{}", EVHTTP_REQ_PUT, true,
+			     ctrl_container_put);
 	return 0;
 }

--- a/docs/overview/containers.md
+++ b/docs/overview/containers.md
@@ -174,6 +174,24 @@ During [TESTING](updates.md#testing), `max_retries` exhaustion always triggers a
 
 Groups in [device.json](pantavisor-state-format-v2.md#devicejson) can define a default `auto_recovery` object. Containers inherit this configuration **all-or-nothing**: if a container has its own `auto_recovery` in `run.json`, it is used entirely; otherwise the group's default applies. No field-level merging is performed. The default `app` group ships with an on-failure recovery policy.
 
+## Lifecycle Control
+
+Containers with [restart_policy](containers.md#restart-policy): "container" can be stopped, started, and restarted at runtime via the [control socket](../../../reference/027/pantavisor-commands.md#containers). Containers with [restart_policy](containers.md#restart-policy): "system" cannot be controlled this way — they require a system-level transition ([reboot](../../../reference/027/pantavisor-commands.md#commands) or [update](updates.md)).
+
+### Stop
+
+Stopping a container via the API is fundamentally different from a crash. It sets the `user_stopped` flag on the container's auto-recovery state, which tells the recovery engine to leave the container stopped. No retry counters are consumed and no [backoff policy](#backoff-policy) is triggered — even for containers with `max_retries: 0` that would normally go to backoff on first crash.
+
+When a container transitions to [STOPPED](#status), its volumes are unmounted. This ensures clean state for a subsequent start.
+
+### Start
+
+Starting a previously stopped container clears the `user_stopped` flag and transitions the container to INSTALLED, which triggers the normal engine lifecycle: volumes are mounted, drivers are loaded, and the container process is started. Auto-recovery is fully restored with its original configuration.
+
+### Restart
+
+Restart force-stops the container and resets the auto-recovery retry counter to zero. For containers with auto-recovery configured, the recovery engine picks up the stopped container and restarts it through the standard recovery path (respecting [retry delays and backoff](#exponential-backoff)). For containers without auto-recovery, the restart transitions the container directly to INSTALLED for an immediate start.
+
 ## Drivers
 
 Containers can [reference](../../../reference/legacy/pantavisor-state-format-v2.md#containerrunjson) the BSP [managed drivers](bsp.md#managed-drivers) as required, optional or manual.

--- a/docs/overview/local-control.md
+++ b/docs/overview/local-control.md
@@ -7,6 +7,18 @@ With local control, we mean the control that is performed from one of the [conta
 
 This kind of control can be performed even if the device is already [claimed in Pantacor Hub](remote-control.md#pantacor-hub). It can also be the only option if you [disable remote control](../../../reference/legacy/pantavisor-configuration.md#summary) or if you install a [local revision](../../../reference/legacy/pantavisor-commands.md#steps) at any given time, which will interrupt Pantacor Hub remote control unless a [go remote command](../../../reference/legacy/pantavisor-commands.md#commands) is issued. This behavior can be avoided with the [remote always configuration](../../../reference/legacy/pantavisor-configuration.md#summary).
 
+## Available Operations
+
+The [control socket](../../../reference/027/pantavisor-commands.md) exposes a REST API for managing the device from within a container. Key operations include:
+
+* [List and manage containers](../../../reference/027/pantavisor-commands.md#containers) — query status, [stop/start/restart](containers.md#lifecycle-control) individual containers with [restart_policy](containers.md#restart-policy) "container"
+* [Send signals](../../../reference/027/pantavisor-commands.md#signal) — report [readiness](containers.md#signals) to Pantavisor
+* [Issue commands](../../../reference/027/pantavisor-commands.md#commands) — [reboot](../../../reference/027/pantavisor-commands.md#commands), run revisions, trigger [updates](updates.md)
+* [Manage metadata](../../../reference/027/pantavisor-commands.md#user-meta) — read and write user/device metadata
+* [Manage steps](../../../reference/027/pantavisor-commands.md#steps) — install and query [revisions](revisions.md)
+* [Manage daemons](../../../reference/027/pantavisor-commands.md#daemons) — start/stop internal Pantavisor daemons
+* [Query service mesh](../../../reference/027/pantavisor-commands.md#xconnect-graph) — inspect the [xconnect](xconnect.md) graph
+
 ## Pantabox
 
 [Pantabox](../../../pvr-sdk/reference/pantabox.md) is the top level control tool that can be run inside of a [container](containers.md). It offers a [ncurses](https://invisible-island.net/ncurses/) user interface that lets you interact with Pantavisor (install new [revisions](revisions.md), exchange [metadata](storage.md#metadata), reboot or shutdown your device...).

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -9,13 +9,50 @@ The following subsections describe the behaviour of the HTTP API for the differe
 
 ## /containers
 
-This endpoint can be used to list the containers (with their [status](../../pantavisor-src/docs/overview/containers.md#status)) that are installed in the current revision.
+This endpoint can be used to list and manage [containers](../../pantavisor-src/docs/overview/containers.md) in the current revision.
 
-An example of use:
+### List containers
+
+Returns all containers with their [status](../../pantavisor-src/docs/overview/containers.md#status), [restart policy](../../pantavisor-src/docs/overview/containers.md#restart-policy), [auto-recovery](../../pantavisor-src/docs/overview/containers.md#auto-recovery) state, and service mesh information.
 
 ```
 $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/containers"
 ```
+
+### Lifecycle control
+
+Containers with `restart_policy: "container"` can be stopped, started, and restarted via the API. Containers with `restart_policy: "system"` are protected and will return HTTP 403.
+
+To stop a container:
+
+```
+$ curl -X PUT --header "Content-Type: application/json" --data "{\"action\":\"stop\"}" --unix-socket /pantavisor/pv-ctrl "http://localhost/containers/my-container"
+```
+
+Stopping a container sets the `user_stopped` flag, which prevents [auto-recovery](#auto-recovery) from restarting it. The container's auto-recovery configuration is preserved — no retry counters are consumed and no backoff is triggered.
+
+To start a previously stopped container:
+
+```
+$ curl -X PUT --header "Content-Type: application/json" --data "{\"action\":\"start\"}" --unix-socket /pantavisor/pv-ctrl "http://localhost/containers/my-container"
+```
+
+Starting clears the `user_stopped` flag and returns the container to the normal engine lifecycle. Auto-recovery is fully restored.
+
+To restart a running container:
+
+```
+$ curl -X PUT --header "Content-Type: application/json" --data "{\"action\":\"restart\"}" --unix-socket /pantavisor/pv-ctrl "http://localhost/containers/my-container"
+```
+
+Restart force-stops the container and resets the retry counter to zero. For containers with auto-recovery configured, the recovery engine restarts it naturally through the standard path. For containers without auto-recovery (`RECOVERY_NO`), the container is restarted directly.
+
+| Action | State change | Auto-recovery effect |
+| ------ | ------------ | -------------------- |
+| stop | Running → STOPPED | `user_stopped` set; recovery skipped |
+| start | STOPPED → INSTALLED → start | `user_stopped` cleared; recovery restored |
+| restart (with recovery) | Running → STOPPED → recovery engine restarts | Retry counter reset to 0 |
+| restart (no recovery) | Running → STOPPED → INSTALLED → start | Direct restart |
 
 ## /daemons
 

--- a/platforms.c
+++ b/platforms.c
@@ -392,6 +392,22 @@ static const char *pv_platforms_role_str(roles_mask_t role)
 	return "unknown";
 }
 
+static const char *pv_recovery_type_str(recovery_type_t type)
+{
+	switch (type) {
+	case RECOVERY_NO:
+		return "no";
+	case RECOVERY_ALWAYS:
+		return "always";
+	case RECOVERY_ON_FAILURE:
+		return "on-failure";
+	case RECOVERY_UNLESS_STOPPED:
+		return "unless-stopped";
+	}
+
+	return "no";
+}
+
 const char *pv_platforms_restart_policy_str(restart_policy_t policy)
 {
 	switch (policy) {
@@ -499,27 +515,45 @@ void pv_platform_add_json(struct pv_json_ser *js, struct pv_platform *p)
 			pv_json_ser_array_pop(js);
 		}
 
-		pv_json_ser_key(js, "auto_recovery");
-		pv_json_ser_object(js);
-		{
-			pv_json_ser_key(js, "max_retries");
-			pv_json_ser_number(js, p->auto_recovery.max_retries);
-			pv_json_ser_key(js, "current_retries");
-			pv_json_ser_number(js,
-					   p->auto_recovery.current_retries);
-			pv_json_ser_key(js, "stable_timeout");
-			pv_json_ser_number(js, p->auto_recovery.stable_timeout);
-			pv_json_ser_key(js, "is_stable");
-			pv_json_ser_string(js, p->auto_recovery.is_stable ?
+		if (p->auto_recovery.type != RECOVERY_NO) {
+			pv_json_ser_key(js, "auto_recovery");
+			pv_json_ser_object(js);
+			{
+				pv_json_ser_key(js, "policy");
+				pv_json_ser_string(
+					js, pv_recovery_type_str(
+						    p->auto_recovery.type));
+				pv_json_ser_key(js, "max_retries");
+				pv_json_ser_number(
+					js, p->auto_recovery.max_retries);
+				pv_json_ser_key(js, "current_retries");
+				pv_json_ser_number(
+					js, p->auto_recovery.current_retries);
+				pv_json_ser_key(js, "stable_timeout");
+				pv_json_ser_number(
+					js, p->auto_recovery.stable_timeout);
+				pv_json_ser_key(js, "is_stable");
+				pv_json_ser_string(js,
+						   p->auto_recovery.is_stable ?
+							   "true" :
+							   "false");
+				pv_json_ser_key(js, "backoff_policy");
+				pv_json_ser_string(
+					js,
+					pv_backoff_policy_str(
+						p->auto_recovery.backoff_policy,
+						p->auto_recovery
+							.backoff_duration));
+
+				pv_json_ser_object_pop(js);
+			}
+		}
+
+		if (p->restart_policy == RESTART_CONTAINER) {
+			pv_json_ser_key(js, "user_stopped");
+			pv_json_ser_string(js, p->auto_recovery.user_stopped ?
 						       "true" :
 						       "false");
-			pv_json_ser_key(js, "backoff_policy");
-			pv_json_ser_string(
-				js, pv_backoff_policy_str(
-					    p->auto_recovery.backoff_policy,
-					    p->auto_recovery.backoff_duration));
-
-			pv_json_ser_object_pop(js);
 		}
 
 		pv_json_ser_object_pop(js);
@@ -1193,9 +1227,20 @@ int pv_platform_stop(struct pv_platform *p)
 		pv_log(ERROR, "no plugin for platform type '%s'", p->type);
 	pv_platform_set_status(p, PLAT_STOPPING);
 
+	// Grace period for lenient stop — force-stop after 5 seconds
+	timer_start(&p->timer_status_goal, 5, 0, RELATIV_TIMER);
+
 	pv_platform_remove_config_overlay(p->name);
 
 	return 0;
+}
+
+void pv_platform_stop_with_callback(struct pv_platform *p,
+				    pv_platform_stopped_cb cb, void *opaque)
+{
+	p->on_stopped = cb;
+	p->on_stopped_opaque = opaque;
+	pv_platform_stop(p);
 }
 
 void pv_platform_force_stop(struct pv_platform *p)

--- a/platforms.h
+++ b/platforms.h
@@ -125,6 +125,7 @@ struct pv_auto_recovery {
 	bool timer_stable_armed;
 	bool is_stable;
 	bool recovery_failed;
+	bool user_stopped;
 };
 
 struct pv_platform_driver {
@@ -145,6 +146,9 @@ struct pv_platform_log {
 	int console_pt;
 	int lxc_pipe[2];
 };
+
+struct pv_platform;
+typedef void (*pv_platform_stopped_cb)(struct pv_platform *p, void *opaque);
 
 struct pv_platform {
 	char *name;
@@ -175,6 +179,8 @@ struct pv_platform {
 	 * To be freed once logger_list is setup.
 	 */
 	struct dl_list logger_configs; // pv_logger_config
+	pv_platform_stopped_cb on_stopped;
+	void *on_stopped_opaque;
 };
 void pv_platform_free(struct pv_platform *p);
 
@@ -193,6 +199,8 @@ void pv_platform_unload_drivers(struct pv_platform *p, char *namematch,
 
 int pv_platform_start(struct pv_platform *p);
 int pv_platform_stop(struct pv_platform *p);
+void pv_platform_stop_with_callback(struct pv_platform *p,
+				    pv_platform_stopped_cb cb, void *opaque);
 void pv_platform_force_stop(struct pv_platform *p);
 
 bool pv_platform_check_running(struct pv_platform *p);

--- a/state.c
+++ b/state.c
@@ -650,10 +650,13 @@ static int pv_state_start_platform(struct pv_state *s, struct pv_platform *p)
 	    p->group->default_auto_recovery.type != RECOVERY_NO)
 		p->auto_recovery = p->group->default_auto_recovery;
 
-	// Reset stability state on (re)start
+	// Reset stability and lifecycle state on (re)start
 	p->auto_recovery.is_stable = false;
 	p->auto_recovery.timer_stable_armed = false;
 	p->auto_recovery.recovery_failed = false;
+	p->auto_recovery.user_stopped = false;
+	p->on_stopped = NULL;
+	p->on_stopped_opaque = NULL;
 
 	return 0;
 }
@@ -834,6 +837,22 @@ int pv_state_run(struct pv_state *s)
 			} else {
 				pv_platform_track_stability(p);
 			}
+		} else if (pv_platform_is_stopping(p)) {
+			if (!pv_platform_check_running(p)) {
+				pv_log(DEBUG,
+				       "platform '%s' exited during lenient stop",
+				       p->name);
+				pv_platform_force_stop(p);
+			} else {
+				struct timer_state tstate = timer_current_state(
+					&p->timer_status_goal);
+				if (tstate.fin) {
+					pv_log(WARN,
+					       "platform '%s' did not exit after lenient stop, force stopping",
+					       p->name);
+					pv_platform_force_stop(p);
+				}
+			}
 		} else if (pv_platform_is_recovering(p)) {
 			struct timer_state tstate = timer_current_state(
 				&p->auto_recovery.timer_retry);
@@ -844,6 +863,18 @@ int pv_state_run(struct pv_state *s)
 				pv_platform_set_installed(p);
 			}
 		} else if (pv_platform_is_stopped(p)) {
+			if (p->on_stopped) {
+				pv_platform_stopped_cb cb = p->on_stopped;
+				void *opaque = p->on_stopped_opaque;
+				p->on_stopped = NULL;
+				p->on_stopped_opaque = NULL;
+				cb(p, opaque);
+				continue;
+			}
+
+			if (p->auto_recovery.user_stopped)
+				continue;
+
 			if (p->auto_recovery.recovery_failed)
 				continue;
 
@@ -871,7 +902,8 @@ bool pv_state_is_stability_pending(struct pv_state *s)
 		// Container with stable_timeout that hasn't proven stable yet
 		if (p->auto_recovery.stable_timeout > 0 &&
 		    !p->auto_recovery.is_stable &&
-		    !p->auto_recovery.recovery_failed) {
+		    !p->auto_recovery.recovery_failed &&
+		    !p->auto_recovery.user_stopped) {
 			pv_log(DEBUG,
 			       "platform '%s' stability pending (waiting for stable_timeout)",
 			       p->name);

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -46,7 +46,7 @@ OUTPUT=""
 MESSAGE=""
 
 usage() {
-	echo "Usage: pvcontrol [options] <ls|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons> [arguments]"
+	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons> [arguments]"
 	echo "Control Pantavisor from your container"
 	echo "options:"
 	echo "       -h           show help"
@@ -132,6 +132,15 @@ usage_graph() {
 	echo "Usage: pvcontrol graph <ls>"
 	echo "xconnect service mesh graph operations"
 	echo "       pvcontrol graph ls - show current xconnect graph"
+}
+
+usage_containers() {
+	echo "Usage: pvcontrol containers <ls|start|stop|restart> [arguments]"
+	echo "Container lifecycle operations"
+	echo "       pvcontrol containers ls               - list all containers and their status"
+	echo "       pvcontrol containers start <name>     - start a stopped container"
+	echo "       pvcontrol containers stop <name>      - stop a running container"
+	echo "       pvcontrol containers restart <name>   - restart a container"
 }
 
 usage_daemons() {
@@ -391,6 +400,37 @@ parse_graph_args() {
 	esac
 }
 
+container_name=''
+
+parse_containers_args() {
+	case "$1" in
+	ls|list)
+		cmd='containersls'
+		;;
+	start)
+		if [ -z "$2" ]; then usage_containers; exit 1; fi
+		cmd='containerstart'
+		container_name="$2"
+		;;
+	stop)
+		if [ -z "$2" ]; then usage_containers; exit 1; fi
+		cmd='containerstop'
+		container_name="$2"
+		;;
+	restart)
+		if [ -z "$2" ]; then usage_containers; exit 1; fi
+		cmd='containerrestart'
+		container_name="$2"
+		;;
+	--help)
+		usage_containers; exit 0
+		;;
+	*)
+		usage_containers; exit 1
+		;;
+	esac
+}
+
 parse_daemons_args() {
 	case "$1" in
 	ls|list)
@@ -481,6 +521,9 @@ parse_args() {
 	case "$1" in
 	ls|list)
 		parse_ls_args "$2"
+		;;
+	containers)
+		parse_containers_args "$2" "$3"
 		;;
 	groups)
 		parse_groups_args "$2"
@@ -701,6 +744,18 @@ exec_cmd() {
 			;;
 		steplist)
 			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/steps"`
+			;;
+		containersls)
+			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/containers"`
+			;;
+		containerstart)
+			response=`$CURL -X PUT --header "Content-Type: application/json" --data "{\"action\":\"start\"}" --unix-socket "$SOCKET" "http://localhost/containers/$container_name"`
+			;;
+		containerstop)
+			response=`$CURL -X PUT --header "Content-Type: application/json" --data "{\"action\":\"stop\"}" --unix-socket "$SOCKET" "http://localhost/containers/$container_name"`
+			;;
+		containerrestart)
+			response=`$CURL -X PUT --header "Content-Type: application/json" --data "{\"action\":\"restart\"}" --unix-socket "$SOCKET" "http://localhost/containers/$container_name"`
 			;;
 		graphls)
 			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/xconnect-graph"`


### PR DESCRIPTION
## Summary

- Add `PUT /containers/{name}` endpoint for stop/start/restart of individual containers
- Only containers with `restart_policy: "container"` can be controlled; system-policy containers return 403
- Lenient stop via `pv_platform_stop()` (LXC shutdown / SIGPWR) with a one-shot callback fired when STOPPED is reached
- Introduce `user_stopped` flag to distinguish intentional stops from crashes — no retries consumed, no backoff triggered
- Start/restart reset retry counters and clear `recovery_failed`, giving a clean slate
- Add `pvcontrol containers` subcommand (ls/start/stop/restart)
- Improve GET /containers JSON: add `policy` field, omit `auto_recovery` for RECOVERY_NO containers, add top-level `user_stopped`

### Design

Stop and restart use lenient shutdown with a callback-based post-stop handler:

| Action | Mechanism |
|--------|-----------|
| **stop** | `pv_platform_stop_with_callback(cb=user_stop)` → lenient stop → STOPPING → process exits or 5s grace timeout → STOPPED → callback sets `user_stopped = true` |
| **start** | Clear `user_stopped`, reset retries → set INSTALLED, engine starts normally |
| **restart** | `pv_platform_stop_with_callback(cb=restart)` → lenient stop → STOPPED → callback resets retries + sets INSTALLED → engine starts |

Callback infrastructure:
- `pv_platform_stopped_cb` typedef and `pv_platform_stop_with_callback()` register a one-shot callback on the platform struct
- Callback fires from the STOPPED block in `pv_state_run()`, cleared before invocation (fire-once)
- Cleared on platform start to prevent stale callbacks
- All actions handle STOPPING state (swap callback if container is already being stopped)

Engine STOPPING handler:
- New block in `pv_state_run()` for PLAT_STOPPING
- Checks `pv_platform_check_running()` each iteration — if process exited, calls `force_stop` for cleanup
- 5-second grace-period timer — if process ignores shutdown signal, `force_stop` sends SIGKILL

### Backlog

- Configurable `shutdown_timeout` (currently hardcoded 5s) via run.json → group → pantavisor.config → code default (target: 15s)

## Test plan

Tested in appengine with 4 containers:

| Container | restart_policy | SIGTERM | Purpose |
|-----------|---------------|---------|---------|
| `pv-example-app` | container | Yes (trap) | Lenient stop path (graceful exit) |
| `pv-example-unix-server` | container | No (socat) | Force-stop after grace timeout |
| `pv-example-unix-client` | system | N/A | System-policy rejection |
| `pv-example-cleanexit` | container (on-failure) | No | Batch job, retry reset |

- [x] Reject stop/start/restart on system-policy container (403)
- [x] Reject actions on nonexistent container (404)
- [x] Stop via lenient path — app container exits gracefully (< 5s)
- [x] Stop via timeout path — unix-server force-stopped after 5s grace period
- [x] user_stopped set after stop, container stays stopped
- [x] Start clears user_stopped, container runs, retries reset
- [x] Restart running container via lenient stop + restart callback
- [x] Restart stopped/recovering container — starts fresh
- [x] Actions on STOPPING containers — callback swapped correctly
- [x] No mount accumulation after multiple restart cycles (0 while stopped, 2 after start)
- [x] Batch job (cleanexit): start/restart reset retries to 0
- [x] JSON: no auto_recovery for RECOVERY_NO, user_stopped at top level
- [x] pvcontrol containers ls/start/stop/restart works