### PR TITLE
Timeout on tsh commands 

### DIFF
--- a/utils/tsh.c
+++ b/utils/tsh.c
@@ -31,14 +31,14 @@
 #include <unistd.h>
 #include <string.h>
 #include <signal.h>
+#include <sys/mman.h>
 
 #include <sys/types.h>
 #include <sys/wait.h>
 
 #include "tsh.h"
-#include "timer.h"
 #include "utils/pvsignals.h"
-#include "log.h"
+#include "utils/fs.h"
 
 #ifndef DISABLE_LOGSERVER
 #include "logserver/logserver.h"
@@ -46,11 +46,20 @@
 
 #define TSH_MAX_LENGTH 32
 #define TSH_DELIM " \t\r\n\a"
+#define TSH_PATH_VAR                                                           \
+	"/bin:/sbin:/usr/bin:/usr/sbin:/lib/pv:/lib/pv/volmount/crypt"
 
 #define MODULE_NAME "tsh"
+#ifdef DISABLE_LOGSERVER
+#define pv_log(level, msg, ...)                                                \
+	fprintf(stderr, "[tsh] (%s:%d) " msg "\n", __FUNCTION__, __LINE__,     \
+		##__VA_ARGS__)
+#else
 #define pv_log(level, msg, ...)                                                \
 	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
 	     ##__VA_ARGS__)
+#include "log.h"
+#endif
 
 /*
  * Split cmd into argv-style tokens on whitespace, with shell-like quoting:
@@ -113,21 +122,67 @@ static char **_tsh_split_cmd(char *cmd)
 	return ts;
 }
 
-static pid_t _tsh_exec(char **argv, int wait, int *status, int stdin_p[],
-		       int stdout_p[], int stderr_p[])
+// NOTE: timeout == 0  => TSH_DEFAULT_TIMEOUT
+//	 timeout == -1 => no timeout
+static int _tsh_wait(int timeout, sigset_t mask, sigset_t old, int pid)
 {
-	int pid = -1;
+	timeout = timeout == 0 ? TSH_DEFAULT_TIMEOUT : timeout;
+
+	struct timespec tm = {
+		.tv_sec = timeout,
+		.tv_nsec = 0,
+	};
+
+	int sig = 0;
+	while (1) {
+		errno = 0;
+		if (timeout < 0)
+			sig = sigwaitinfo(&mask, NULL);
+		else
+			sig = sigtimedwait(&mask, NULL, &tm);
+
+		if (sig == -1 && errno == EINTR)
+			continue;
+		break;
+	}
+
+	int status = 0;
+
+	if (sig == SIGCHLD) {
+		if (!waitpid(pid, &status, WNOHANG))
+			waitpid(pid, &status, 0);
+	} else if (sig == -1) {
+		if (errno == EAGAIN && timeout >= 0) {
+			pv_log(DEBUG, "timeout reached");
+		} else {
+			pv_log(DEBUG, "wait call fail");
+		}
+
+		kill(pid, SIGKILL);
+		waitpid(pid, &status, 0);
+	}
+	sigprocmask(SIG_SETMASK, &old, NULL);
+	return status;
+}
+
+static pid_t _tsh_exec(char **argv, int wait, int *status, int timeout,
+		       int stdin_p[], int stdout_p[], int stderr_p[])
+{
+	pid_t pid = -1;
 	sigset_t blocked_sig, old_sigset;
 	sigset_t oldmask;
-	int ret = 0;
+
+	int st = 0;
+	if (!status)
+		status = &st;
 
 	if (wait) {
 		sigemptyset(&blocked_sig);
 		sigaddset(&blocked_sig, SIGCHLD);
-		/*
-		 * Block SIGCHLD while we want to wait on this child.
-		 * */
-		ret = sigprocmask(SIG_BLOCK, &blocked_sig, &old_sigset);
+
+		// Block SIGCHLD while we want to wait on this child.
+		if (sigprocmask(SIG_BLOCK, &blocked_sig, &old_sigset) != 0)
+			return -1;
 	} else if (pvsignals_block_chld(&oldmask)) {
 		return -1;
 	}
@@ -135,24 +190,21 @@ static pid_t _tsh_exec(char **argv, int wait, int *status, int stdin_p[],
 	pid = fork();
 
 	if (pid == -1) {
-		pvsignals_setmask(&oldmask);
-
-		if ((ret == 0) && wait)
-			sigprocmask(SIG_SETMASK, &old_sigset, NULL);
-		return -1;
-	} else if (pid > 0) {
-		if (wait) {
-			if (ret == 0) {
-				/* wait only if we blocked SIGCHLD */
-				waitpid(pid, status, 0);
-				sigprocmask(SIG_SETMASK, &old_sigset, NULL);
-			}
-		} else {
+		if (!wait)
 			pvsignals_setmask(&oldmask);
-		}
-		free(argv);
+		else
+			sigprocmask(SIG_SETMASK, &old_sigset, NULL);
+
+		return -1;
+
+	} else if (pid > 0) {
+		if (!wait)
+			pvsignals_setmask(&oldmask);
+		else // wait only if we blocked SIGCHLD
+			*status = _tsh_wait(timeout, blocked_sig, old_sigset,
+					    pid);
 	} else {
-		ret = 0;
+		int ret = 0;
 		// closed all unused fds right away ..
 		if (stdin_p) // close writing end for stdin dup
 			close(stdin_p[1]);
@@ -165,9 +217,8 @@ static pid_t _tsh_exec(char **argv, int wait, int *status, int stdin_p[],
 
 		if (wait)
 			sigprocmask(SIG_SETMASK, &old_sigset, NULL);
-		else if (pvsignals_setmask(&oldmask)) {
-			goto exit_failure;
-		}
+		else if (pvsignals_setmask(&oldmask))
+			_exit(EXIT_FAILURE);
 
 		// dup2 things
 		while (stdin_p &&
@@ -175,19 +226,19 @@ static pid_t _tsh_exec(char **argv, int wait, int *status, int stdin_p[],
 		       (errno == EINTR)) {
 		}
 		if (ret == -1)
-			goto exit_failure;
+			_exit(EXIT_FAILURE);
 		while (stdout_p &&
 		       ((ret = dup2(stdout_p[1], STDOUT_FILENO)) == -1) &&
 		       (errno == EINTR)) {
 		}
 		if (ret == -1)
-			goto exit_failure;
+			_exit(EXIT_FAILURE);
 		while (stderr_p &&
 		       ((ret = dup2(stderr_p[1], STDERR_FILENO)) == -1) &&
 		       (errno == EINTR)) {
 		}
 		if (ret == -1)
-			goto exit_failure;
+			_exit(EXIT_FAILURE);
 
 		// close all the duped ones now too
 		if (stdin_p) // close reading end for stdin dup
@@ -198,49 +249,99 @@ static pid_t _tsh_exec(char **argv, int wait, int *status, int stdin_p[],
 			close(stderr_p[1]);
 
 		// now we let it flow ...
-		setenv("PATH",
-		       "/bin:/sbin:/usr/bin:/usr/sbin:/lib/pv:/lib/pv/volmount/crypt",
-		       0);
+		setenv("PATH", TSH_PATH_VAR, 0);
 		execvp(argv[0], argv);
-	exit_failure:
-		exit(EXIT_FAILURE);
+		_exit(EXIT_FAILURE);
 	}
 
 	return pid;
 }
-
-// Run command, either built-in or exec
-pid_t tsh_run(char *cmd, int wait, int *status)
+pid_t tsh_run_io_timeout(const char *cmd, int wait, int *status, int timeout_s,
+			 int stdin_p[], int stdout_p[], int stderr_p[])
 {
-	return tsh_run_io(cmd, wait, status, NULL, NULL, NULL);
-}
-
-// Run command, either built-in or exec
-pid_t tsh_run_io(char *cmd, int wait, int *status, int stdin_p[],
-		 int stdout_p[], int stderr_p[])
-{
-	pid_t pid;
-	char **args;
-	char *vcmd;
+	pid_t pid = -1;
+	char **args = NULL;
+	char *vcmd = NULL;
 
 	vcmd = strdup(cmd);
 	if (!vcmd)
-		return -1;
+		goto out;
 
 	args = _tsh_split_cmd(vcmd);
 	if (!args)
-		return -1;
+		goto out;
 
-	pid = _tsh_exec(args, wait, status, stdin_p, stdout_p, stderr_p);
-	free(vcmd);
-
+	pid = _tsh_exec(args, wait, status, timeout_s, stdin_p, stdout_p,
+			stderr_p);
 	if (pid < 0)
-		printf("Cannot run \"%s\"\n", cmd);
+		pv_log(DEBUG, "cannot run \"%s\"", cmd);
+
+out:
+	if (vcmd)
+		free(vcmd);
+	if (args)
+		free(args);
 
 	return pid;
 }
 
+pid_t tsh_run_timeout(const char *cmd, int wait, int *status, int timeout_s)
+{
+	return tsh_run_io_timeout(cmd, wait, status, timeout_s, NULL, NULL,
+				  NULL);
+}
+
+// Run command, either built-in or exec
+pid_t tsh_run(const char *cmd, int wait, int *status)
+{
+	return tsh_run_io_timeout(cmd, wait, status, TSH_DEFAULT_TIMEOUT, NULL,
+				  NULL, NULL);
+}
+
+// Run command, either built-in or exec
+pid_t tsh_run_io(const char *cmd, int wait, int *status, int stdin_p[],
+		 int stdout_p[], int stderr_p[])
+{
+	return tsh_run_io_timeout(cmd, wait, status, TSH_DEFAULT_TIMEOUT,
+				  stdin_p, stdout_p, stderr_p);
+}
+
+static int _tsh_eval_output(const char *cmd, int wstatus)
+{
+	int ret = 0;
+
+	if (WIFEXITED(wstatus) && WEXITSTATUS(wstatus)) {
+		pv_log(ERROR, "command failed %s status: %d", cmd,
+		       WEXITSTATUS(wstatus));
+		ret = -1;
+	} else if (WIFEXITED(wstatus)) {
+		pv_log(DEBUG, "command succeeded: %s", cmd);
+		ret = 0;
+	} else if (WIFSIGNALED(wstatus)) {
+		pv_log(ERROR, "command signalled %s: %d", cmd,
+		       WTERMSIG(wstatus));
+		ret = -2;
+	} else {
+		pv_log(ERROR, "command failed with wstatus: %d", wstatus);
+		ret = -3;
+	}
+	return ret;
+}
+
+static void _tsh_close_pipe(int *p)
+{
+	if (p[0] >= 0) {
+		close(p[0]);
+		p[0] = -1;
+	}
+	if (p[1] >= 0) {
+		close(p[1]);
+		p[1] = -1;
+	}
+}
+
 #ifndef DISABLE_LOGSERVER
+
 static int logserver_subscribe_pipe(int *cmd_pipe, const char *name, int level)
 {
 	errno = 0;
@@ -255,227 +356,146 @@ static int logserver_subscribe_pipe(int *cmd_pipe, const char *name, int level)
 	return 0;
 }
 
-int tsh_run_logserver(char *cmd, int *wstatus, const char *log_source_out,
-		      const char *log_source_err)
+int tsh_run_logserver_timeout(const char *cmd, int *wstatus, int timeout_s,
+			      const char *log_source_out,
+			      const char *log_source_err)
 {
-	int ret = 0;
-	int out_pipe[2] = { 0 };
-	int err_pipe[2] = { 0 };
+	int ret = -1;
+	int out_pipe[] = { -1, -1 };
+	int err_pipe[] = { -1, -1 };
 
 	if (logserver_subscribe_pipe(out_pipe, log_source_out, INFO) != 0 ||
 	    logserver_subscribe_pipe(err_pipe, log_source_err, WARN) != 0) {
-		return -1;
+		ret = -1;
+		goto out;
 	}
 
-	ret = tsh_run_io(cmd, 1, wstatus, NULL, out_pipe, err_pipe);
+	ret = tsh_run_io_timeout(cmd, 1, wstatus, timeout_s, NULL, out_pipe,
+				 err_pipe);
 
 	if (ret < 0) {
-		pv_log(ERROR, "command: %s error: %s", cmd);
-		return ret;
-	} else if (WIFEXITED(*wstatus) && WEXITSTATUS(*wstatus)) {
-		pv_log(ERROR, "command failed %s status: %d", cmd,
-		       WEXITSTATUS(*wstatus));
-		ret = -1;
-	} else if (WIFEXITED(*wstatus)) {
-		pv_log(DEBUG, "command succeeded: %s", cmd);
-		ret = 0;
-	} else if (WIFSIGNALED(*wstatus)) {
-		pv_log(ERROR, "command signalled %s: %d", cmd,
-		       WTERMSIG(*wstatus));
-		ret = -2;
-	} else {
-		pv_log(ERROR, "command failed with wstatus: %d", wstatus);
-		ret = -3;
+		pv_log(ERROR, "command: %s error", cmd);
+		goto out;
 	}
-	close(out_pipe[1]);
-	close(err_pipe[1]);
+
+	ret = _tsh_eval_output(cmd, *wstatus);
+
+out:
+	_tsh_close_pipe(out_pipe);
+	_tsh_close_pipe(err_pipe);
 
 	return ret;
 }
 
-pid_t tsh_run_daemon_logserver(char *cmd, const char *log_source_out,
+int tsh_run_logserver(const char *cmd, int *wstatus, const char *log_source_out,
+		      const char *log_source_err)
+{
+	return tsh_run_logserver_timeout(cmd, wstatus, TSH_DEFAULT_TIMEOUT,
+					 log_source_out, log_source_err);
+}
+
+pid_t tsh_run_daemon_logserver(const char *cmd, const char *log_source_out,
 			       const char *log_source_err)
 {
 	pid_t pid;
-	int out_pipe[2] = { 0 };
-	int err_pipe[2] = { 0 };
+	int out_pipe[] = { -1, -1 };
+	int err_pipe[] = { -1, -1 };
 
 	if (logserver_subscribe_pipe(out_pipe, log_source_out, INFO) != 0 ||
 	    logserver_subscribe_pipe(err_pipe, log_source_err, WARN) != 0) {
-		return -1;
+		pid = -1;
+		goto out;
 	}
 
-	pid = tsh_run_io(cmd, 0, NULL, NULL, out_pipe, err_pipe);
+	pid = tsh_run_io_timeout(cmd, 0, NULL, TSH_NO_TIMEOUT, NULL, out_pipe,
+				 err_pipe);
 
-	if (pid < 0) {
+	if (pid < 0)
 		pv_log(ERROR, "daemon start failed: %s", cmd);
-	}
-
-	// Close write ends in parent so only child has them
-	close(out_pipe[1]);
-	close(err_pipe[1]);
+out:
+	_tsh_close_pipe(out_pipe);
+	_tsh_close_pipe(err_pipe);
 
 	return pid;
 }
 
 #endif
 
-static int safe_fd_set(int fd, fd_set *fds, int *max_fd)
+static int _tsh_mem_pipe(const char *name, int *mem_pipe, int size)
 {
-	FD_SET(fd, fds);
-	if (fd > *max_fd) {
-		*max_fd = fd;
+	mem_pipe[1] = memfd_create(name, MFD_CLOEXEC | MFD_ALLOW_SEALING);
+	if (mem_pipe[1] < 0) {
+		pv_log(DEBUG, "couldn't create memfd for %s: %s", name,
+		       strerror(errno));
+		return -1;
 	}
+
+	mem_pipe[0] = fcntl(mem_pipe[1], F_DUPFD_CLOEXEC, 0);
+	if (mem_pipe[0] < 0) {
+		pv_log(DEBUG, "couldn't create %s dup: %s", name,
+		       strerror(errno));
+		goto err;
+	}
+
+	if (ftruncate(mem_pipe[1], size) < 0) {
+		pv_log(DEBUG, "couldn't trucate the mem_pipe %s: %s", name,
+		       strerror(errno));
+		goto err;
+	}
+
+	if (fcntl(mem_pipe[0], F_ADD_SEALS, F_SEAL_GROW) == -1) {
+		pv_log(DEBUG, "couldn't limit size in stdout");
+		goto err;
+	}
+
 	return 0;
+
+err:
+	_tsh_close_pipe(mem_pipe);
+	return -1;
+}
+
+static void _tsh_read(int fd, char *buf, int size)
+{
+	if (!buf || size <= 0)
+		return;
+
+	memset(buf, 0, size);
+	lseek(fd, 0, SEEK_SET);
+	read(fd, buf, size - 1);
 }
 
 int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 		   char *err_buf, int err_size)
 {
-	int ret = -1, max_fd = -1, res, out_i = 0, err_i = 0;
-	pid_t pid = -1;
-	char **args = NULL;
-	char *vcmd = NULL;
-	fd_set master;
-	int outfd[2], errfd[2];
-	struct timespec ts;
-	sighandler_t oldsig;
-	sigset_t mask;
-	sigset_t orig_mask;
+	int ret = -1;
+	int wstatus = 0;
 
-	memset(outfd, -1, sizeof(outfd));
-	memset(errfd, -1, sizeof(errfd));
+	int out_p[2] = { -1, -1 };
+	int err_p[2] = { -1, -1 };
 
-	vcmd = strdup(cmd);
-	if (!vcmd)
+	if (_tsh_mem_pipe("tsh_out", out_p, out_size) != 0)
+		goto out;
+	if (_tsh_mem_pipe("tsh_err", err_p, err_size) != 0)
 		goto out;
 
-	args = _tsh_split_cmd(vcmd);
-	if (!args)
+	ret = tsh_run_io_timeout(cmd, 1, &wstatus, timeout_s, NULL, out_p,
+				 err_p);
+
+	// command couldn't run
+	if (ret < 0)
 		goto out;
 
-	// pipes for communication between main process and command process
-	if (pipe(outfd) < 0)
-		goto out;
-	if (pipe(errfd) < 0)
-		goto out;
+	ret = _tsh_eval_output(cmd, wstatus);
 
-	// set SIGCHLD mask for timeout on waitpid()
-	sigemptyset(&mask);
-	sigaddset(&mask, SIGCHLD);
-	sigprocmask(SIG_BLOCK, &mask, &orig_mask);
+	if (ret == 0)
+		_tsh_read(out_p[0], out_buf, out_size);
 
-	pid = fork();
-	if (pid < 0)
-		goto out;
-	else if (pid == 0) {
-		// redirect out and err of command to pipe
-		dup2(outfd[1], STDOUT_FILENO);
-		dup2(errfd[1], STDERR_FILENO);
-		close(outfd[0]);
-		close(errfd[0]);
-		// uncomment below to try how child that ignores SIGTERM
-		// also gets reaped
-		// signal(SIGTERM, SIG_IGN);
-		if (args && args[0])
-			execvp(args[0], args);
-		goto out;
-	} else {
-		close(outfd[1]);
-		close(errfd[1]);
-		ts.tv_sec = timeout_s;
-		ts.tv_nsec = 0;
-
-		oldsig = signal(SIGCHLD, SIG_DFL);
-		while (1) {
-			int ret;
-
-			FD_ZERO(&master);
-			safe_fd_set(outfd[0], &master, &max_fd);
-			safe_fd_set(errfd[0], &master, &max_fd);
-			if ((ret = pselect(max_fd + 1, &master, NULL, NULL, &ts,
-					   &orig_mask)) < 0) {
-				break;
-			}
-			if (!ret) {
-				// if we timed out, we send a nice SIGTERM
-				// and break ....
-				kill(pid, SIGTERM);
-				break;
-			}
-
-			if (FD_ISSET(outfd[0], &master)) {
-				res = read(outfd[0], &out_buf[out_i], out_size);
-				if (res > 0) {
-					out_size -= res;
-					out_i += res;
-				} else if (res < 0 && errno != EAGAIN) {
-					break;
-				}
-				if (res == 0) {
-					break;
-				}
-			}
-
-			if (FD_ISSET(errfd[0], &master)) {
-				res = read(errfd[0], &err_buf[err_i], err_size);
-				if (res > 0) {
-					err_size -= res;
-					err_i += res;
-				} else if (res < 0 && errno != EAGAIN) {
-					break;
-				} else if (res == 0) {
-					break;
-				}
-			}
-		}
-		signal(SIGCHLD, oldsig);
-	}
-
+	else
+		_tsh_read(err_p[0], err_buf, err_size);
 out:
-	if (pid == 0) {
-		close(outfd[1]);
-		close(errfd[1]);
-		free(args);
-		exit(127);
-	} else {
-	waitpidagain:
-		if (waitpid(pid, &ret, WNOHANG)) {
-			if (WIFEXITED(ret)) {
-				ret = WEXITSTATUS(ret);
-			} else if (WIFSIGNALED(ret)) {
-				ret = WTERMSIG(ret);
-			} else {
-				printf("WARNING: waitpid returned unexpected state %d\n",
-				       ret);
-			}
-		} else {
-			if ((ret = sigtimedwait(&mask, NULL, &ts)) < 0) {
-				if (errno == EINTR) {
-					goto waitpidagain;
-				} else if (errno == EAGAIN) {
-					kill(pid, SIGKILL);
-					goto waitpidagain;
-				}
-			} else if (ret > 0) {
-				goto waitpidagain;
-			}
-			// usually this goto loop will leave through waitpid branch above.
-			printf("ERROR on sigtimedwait wait %s",
-			       strerror(errno));
-			ret = -1;
-		}
-
-		sigprocmask(SIG_SETMASK, &orig_mask, NULL);
-		close(outfd[0]);
-		close(errfd[0]);
-	}
-
-	if (vcmd)
-		free(vcmd);
-
-	if (args)
-		free(args);
+	_tsh_close_pipe(out_p);
+	_tsh_close_pipe(err_p);
 
 	return ret;
 }

--- a/utils/tsh.h
+++ b/utils/tsh.h
@@ -24,16 +24,29 @@
 
 #include <sys/types.h>
 
-pid_t tsh_run(char *cmd, int wait, int *status);
-pid_t tsh_run_io(char *cmd, int wait, int *status, int stdin_p[],
+#define TSH_DEFAULT_TIMEOUT (60)
+#define TSH_NO_TIMEOUT (-1)
+
+pid_t tsh_run(const char *cmd, int wait, int *status);
+pid_t tsh_run_io(const char *cmd, int wait, int *status, int stdin_p[],
 		 int stdout_p[], int stderr_p[]);
+
+pid_t tsh_run_timeout(const char *cmd, int wait, int *status, int timeout_s);
+pid_t tsh_run_io_timeout(const char *cmd, int wait, int *status, int timeout_s,
+			 int stdin_p[], int stdout_p[], int stderr_p[]);
+
 int tsh_run_output(const char *cmd, int timeout_s, char *out_buf, int out_size,
 		   char *err_buf, int err_size);
 
 #ifndef DISABLE_LOGSERVER
-int tsh_run_logserver(char *cmd, int *wstatus, const char *source,
-		      const char *level);
-pid_t tsh_run_daemon_logserver(char *cmd, const char *log_source_out,
+int tsh_run_logserver(const char *cmd, int *wstatus, const char *log_source_out,
+		      const char *log_source_err);
+
+int tsh_run_logserver_timeout(const char *cmd, int *wstatus, int timeout_s,
+			      const char *log_source_out,
+			      const char *log_source_err);
+
+pid_t tsh_run_daemon_logserver(const char *cmd, const char *log_source_out,
 			       const char *log_source_err);
 #endif
 


### PR DESCRIPTION
## Summary

- Add `tsh_run_timeout()` and `tsh_run_io_timeout()` — variants of `tsh_run()` and `tsh_run_io()` with an explicit `timeout_s` parameter; existing functions keep their signature and use the 60 s default
- Add `tsh_run_logserver_timeout()` — timeout variant of `tsh_run_logserver()`
- Replace `tsh_run_output()` pipe-based implementation with `memfd_create` to fix a deadlock: with pipes and `wait=1`, if the child output exceeded the pipe buffer (~64 KB) the child would block on write while the parent was blocked in `waitpid`; `memfd_create` gives the child an unbounded memory-backed file so writes never block
- Extract `_tsh_wait()` (signal-based wait with timeout) and `_tsh_eval_output()` (exit-status evaluation) to eliminate duplicated logic
- Harden all command parameters to `const char *`
- Fall back to `fprintf(stderr)` when the log server is unavailable (`DISABLE_LOGSERVER`)
- Fix memory leaks and logic errors found during refactor