### PR TITLE
fix(pvtest): fail fast on startup errors

### DIFF
--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -112,7 +112,7 @@ stop_pv() {
 
 	local pv_pid=$(ps | grep " pantavisor$" | awk 'NR==1 {print $1}')
 	if [ -n "$pv_pid" ]; then
-		eval "pventer -c $control_container pvcontrol commands poweroff" > /dev/null 2>&1
+		eval "pvcontrol commands poweroff" > /dev/null 2>&1
 		wait_for_process " pantavisor$" "120" "-d"
 		if [ $? -ne 0 ]; then
 			echo "Warn: Pantavisor still running. Shutting it down..."
@@ -162,7 +162,7 @@ start_pv() {
 		fi
 	fi
 
-	wait_for_value "pventer -c $control_container pvcontrol devmeta ls | jq -r .'[\"pantavisor.status\"]'" "READY" "120"
+	wait_for_value "pvcontrol devmeta ls | jq -r .'[\"pantavisor.status\"]'" "READY" "120"
 	if [ $? != 0 ]; then
 		echo "Error: timed out waiting for pantavisor.status READY"
 		stop_pv

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -87,8 +87,6 @@ exec_interactive() {
 		echo "To run Pantavisor with stdout logs:"
 		echo "pv-appengine -e \"PV_LOG_SERVER_OUTPUTS=filetree,stdout\""
 		echo ""
-	elif [ "$pv_ready" = "false" ]; then
-		echo "Warn: Pantavisor not responding or not ready."
 	else
 		echo "Info: Pantavisor is already running."
 		echo "To run your test:"
@@ -123,7 +121,6 @@ stop_pv() {
 			if [ $? -ne 0 ]; then
 				echo "Error: Pantavisor still running. Exiting..."
 				kill -SIGKILL "$pv_pid"
-				pv_ready="false"
 			fi
 		fi
 	fi
@@ -153,7 +150,8 @@ start_pv() {
 	wait_for_process " pantavisor$" "30" "-a"
 	if [ $? != 0 ]; then
 		echo "Error: timed out waiting for Pantavisor PID"
-		return
+		stop_pv
+		exit 1
 	fi
 
 	if [ -n "$ready_script" ]; then
@@ -167,8 +165,8 @@ start_pv() {
 	wait_for_value "pventer -c $control_container pvcontrol devmeta ls | jq -r .'[\"pantavisor.status\"]'" "READY" "120"
 	if [ $? != 0 ]; then
 		echo "Error: timed out waiting for pantavisor.status READY"
-	else
-		pv_ready="true"
+		stop_pv
+		exit 1
 	fi
 
 	wait_for_status "LD_LIBRARY_PATH=/lib:/usr/lib curl -s X GET http://localhost:12368/cgi-bin/pvtx/status > /dev/null 2>&1" 0 120
@@ -179,54 +177,51 @@ start_pv() {
 	fi
 
 	if [ "$self_claim" = "true" ]; then
-		if [ -z "$PH_USER" ] || [ -z "$PH_PASS" ]; then
-			echo "Error: you need to set PH_USER and PH_PASS to execute the test"
-			stop_pv
-			exit 1
-		fi
 		pvr -u "$PH_USER" -p "$PH_PASS" login > /dev/null 2>&1
 
 		wait_for_pantahub_state "$control_container" "claim"
+		if [ $? -ne 0 ]; then
+			echo "Error: timed out waiting for pantahub.state claim"
+			stop_pv
+			exit 1
+		fi
 
-		device_id=`cat @CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/device-id`
-		challenge=`cat @CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/challenge`
+		device_id=$(cat @CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/device-id)
+		challenge=$(cat @CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/challenge)
 
 		pvr claim -c "$challenge" "$device_id"
+		if [ $? -ne 0 ]; then
+			echo "Error: pvr claim failed"
+			stop_pv
+			exit 1
+		fi
 
 		wait_for_pantahub_state "$control_container" "idle"
+		if [ $? -ne 0 ]; then
+			echo "Error: timed out waiting for pantahub.state idle after claim"
+			stop_pv
+			exit 1
+		fi
 	fi
 }
 
 exec_test() {
-	if [ "$pv_ready" = "false" ]; then
-		return
-	fi
-
-	script_path="$test_path/$test_script"
-	tmp_script_path=
-	if [ "$overwrite" = "true" ] || [ "$verbose" = "true" ]; then
-		tmp_script_path=$(mktemp /tmp/pv_appengine_script.XXXXXX)
-		sed '5iset -x' "$test_path/$test_script" > "$tmp_script_path"
-		script_path="$tmp_script_path"
-		chmod +x "$tmp_script_path"
-	fi
+	tmp_script_path=$(mktemp /tmp/pv_appengine_script.XXXXXX)
+	sed '5iset -x' "$test_path/$test_script" > "$tmp_script_path"
+	chmod +x "$tmp_script_path"
 
 	tmp_out_path=$(mktemp /tmp/pv_appengine_output.XXXXXX)
 	# we use script to get stdout and stderr in the same order we do in console
-	script -q -c "sh -c \"$script_path\"" > $tmp_out_path 2>&1
-	output=$(cat "$tmp_out_path")
+	# tee shows output in real-time while saving it for later comparison
+	script -q -c "sh -c \"$tmp_script_path\"" | tee $tmp_out_path
+
 	if [ "$overwrite" = "true" ]; then
-		echo "$output" > $test_path/output
-		rm -f "$tmp_script_path"
+		cat $tmp_out_path > $test_path/output
 	fi
+	rm -f "$tmp_script_path"
 }
 
 eval_test() {
-	if [ "$pv_ready" = "false" ]; then
-		stop_pv
-		exit 1
-	fi
-
 	if [ "$overwrite" != "true" ]; then
 		diff <(grep -vE '^(\+|\$)' $test_path/output) <(grep -vE '^(\+|\$)' "$tmp_out_path")
 		if [ $? -ne 0 ]; then
@@ -265,9 +260,14 @@ test_script=
 
 parse_test
 
-initial_setup
+if [ "$self_claim" = "true" ]; then
+	if [ -z "$PH_USER" ] || [ -z "$PH_PASS" ]; then
+		echo "Error: you need to set PH_USER and PH_PASS to execute the test"
+		exit 1
+	fi
+fi
 
-pv_ready="false"
+initial_setup
 
 if [ "$manual" = "false" ]; then
 	start_pv
@@ -276,8 +276,6 @@ fi
 if [ "$interactive" = "true" ]; then
 	exec_interactive
 fi
-
-tmp_out_path=
 
 if [ "$daemon" = "true" ]; then
 	sleep 100000

--- a/pvtest/utils.in
+++ b/pvtest/utils.in
@@ -88,9 +88,9 @@ wait_for_revision_state() {
 	local rev="$2"
 	local state="$3"
 
-	wait_for_value "pventer -c $control_container pvcontrol devmeta ls | jq -r '.[\"pantavisor.revision\"]'" "$rev" 30
-	wait_for_value "pventer -c $control_container pvcontrol devmeta ls | jq -r '.[\"pantavisor.status\"]'" "READY" 30
-	wait_for_value "pventer -c $control_container pvcontrol steps show-progress $rev | jq -r '.status'" "$state" 30
+	wait_for_value "pvcontrol devmeta ls | jq -r '.[\"pantavisor.revision\"]'" "$rev" 30 || return 1
+	wait_for_value "pvcontrol devmeta ls | jq -r '.[\"pantavisor.status\"]'" "READY" 30 || return 1
+	wait_for_value "pvcontrol steps show-progress $rev | jq -r '.status'" "$state" 30 || return 1
 }
 
 # wait for Pantahub to get to a given status
@@ -98,5 +98,5 @@ wait_for_pantahub_state() {
 	local control_container="$1"
 	local state="$2"
 
-	wait_for_value "pventer -c $control_container pvcontrol devmeta ls | jq -r '.[\"pantahub.state\"]'" "$state" 30
+	wait_for_value "pvcontrol devmeta ls | jq -r '.[\"pantahub.state\"]'" "$state" 30
 }


### PR DESCRIPTION
**Summary**

Improves the pvtest runner (pvtest-run.in) to fail fast and give better visibility:

- Early credential check: validates PH_USER/PH_PASS right after parsing test.json when self-claim is true, before any PV startup (~2 min saved on misconfigured runs)
- Fail fast on all startup errors: wait_for_process, pantavisor.status READY, pantahub.state claim, pvr claim, and pantahub.state idle all now call stop_pv;  exit 1 on failure instead of silently continuing
- Remove pv_ready: now that every failure exits immediately, the flag is unnecessary and removed throughout
- Real-time test output: set -x is always injected into the test script and  output is piped through tee, so traces appear live in the terminal; +-prefixed lines are already excluded from the diff comparison so test correctness is unaffected                                                        
- Update wait_for_revision_state and wait_for_pantahub_state in utils.in to call   pvcontrol directly, removing the pventer indirection                           
- Fix wait_for_revision_state to propagate failure: chain the three internal wait_for_value steps with || return 1 so a timeout on any step aborts the function instead of silently continuing                                         