### PR TITLE
fix(state): avoid SIGKILL on graceful container exit during lenient stop

### DIFF
--- a/state.c
+++ b/state.c
@@ -37,6 +37,7 @@
 #include "volumes.h"
 #include "disk/disk.h"
 #include "platforms.h"
+#include "cgroup.h"
 #include "objects.h"
 #include "jsons.h"
 #include "addons.h"
@@ -842,7 +843,7 @@ int pv_state_run(struct pv_state *s)
 				pv_log(DEBUG,
 				       "platform '%s' exited during lenient stop",
 				       p->name);
-				pv_platform_force_stop(p);
+				pv_cgroup_destroy(p->name);
 			} else {
 				struct timer_state tstate = timer_current_state(
 					&p->timer_status_goal);


### PR DESCRIPTION
## Summary

- When a container exits gracefully during lenient stop, `pv_platform_check_running()` already transitions it to PLAT_STOPPED (triggering volume unmount)
- The subsequent `pv_platform_force_stop()` call was sending SIGKILL to an already-dead process — unnecessary
- Replace with `pv_cgroup_destroy()` which is the only cleanup needed after a graceful exit
- The force_stop path (SIGKILL) is still used when the grace-period timer expires (container ignores the shutdown signal)

### Note: LXC cgroup cleanup is unreliable

Testing in appengine (cgroup v2) confirmed that LXC's lenient shutdown does NOT reliably clean up cgroup directories. After `c->shutdown()`, `/sys/fs/cgroup/lxc/<container>/` lingers and `pv_cgroup_destroy()` is needed to remove it. This applies to both the graceful exit path and the force-stop path.

Currently `pv_cgroup_destroy()` only runs in appengine mode (`IM_APPENGINE`). With container lifecycle control now available on real devices, this restriction should be revisited in a follow-up.

## Test results

Tested in appengine with `pv-example-app` (SIGTERM trap), `pv-example-unix-server` (no SIGTERM handler), `pv-example-cleanexit` (batch job):

- [x] Stop app container — goes through lenient stop, cgroup cleaned, user_stopped=true
- [x] Stop unix-server — hits 5s grace timeout, force_stop with SIGKILL, cgroup cleaned
- [x] Start after stop — container starts fresh, user_stopped cleared
- [x] Restart running container — lenient stop → callback → INSTALLED → restarted
- [x] No mount accumulation — 2 mounts baseline, 2 after 3 restarts, 0 while stopped
- [x] Batch job restart — retries reset to 0
- [x] Cgroup dirs removed after both graceful and force-stop paths
- [x] Log confirms: `pv-example-cleanexit` exits via lenient path ("exited during lenient stop"), others via timeout ("did not exit after lenient stop, force stopping")