### PR TITLE
fix(cgroup): run cgroup cleanup on all init modes, not just appengine

### DIFF
--- a/cgroup.c
+++ b/cgroup.c
@@ -277,9 +277,6 @@ int pv_cgroup_init()
 	if (pv_cgroup_mkcgroup_root())
 		return -1;
 
-	struct pantavisor *pv = pv_get_instance();
-	pv->cgroupv = pv_cgroup_get_version();
-
 	if (pv_cgroup_mkcgroup_init("systemd"))
 		return -1;
 	if (pv_cgroup_mkcgroup_init("pantavisor"))
@@ -301,6 +298,12 @@ int pv_cgroup_init()
 	pv_cgroup_mkcgroup_resource("rdma");
 
 	pv_cgroup_mkcgroup_unified();
+
+	// Detect after all mounts are in place so HYBRID is recognised
+	// via the presence of /sys/fs/cgroup/unified/. Running this before
+	// the unified mount misreports HYBRID setups as LEGACY.
+	struct pantavisor *pv = pv_get_instance();
+	pv->cgroupv = pv_cgroup_get_version();
 
 	return 0;
 }

--- a/cgroup.c
+++ b/cgroup.c
@@ -22,6 +22,7 @@
 
 #define _GNU_SOURCE
 #include <ctype.h>
+#include <dirent.h>
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -406,29 +407,101 @@ char *pv_cgroup_get_process_name(pid_t pid)
 	return pname;
 }
 
-#define CGROUP_PATH "/sys/fs/cgroup/lxc/%s/"
-
-void pv_cgroup_destroy(const char *name)
+static void pv_cgroup_remove_retry(const char *path)
 {
-	// only relevant for cgroup v2
-	struct pantavisor *pv = pv_get_instance();
-	if (pv->cgroupv != CGROUP_UNIFIED)
+	struct stat st;
+
+	if (stat(path, &st))
 		return;
 
-	int i;
-	struct stat st;
-	char path[PATH_MAX];
-	snprintf(path, strlen(name) + strlen(CGROUP_PATH), CGROUP_PATH, name);
-
-	for (i = 0; i < 5; i++) {
+	for (int i = 0; i < 5; i++) {
 		if (stat(path, &st))
 			return;
-
-		pv_log(WARN, "/sys/fs/cgroup/lxc/%s/ still exists. Removing...",
-		       name);
+		pv_log(WARN, "%s still exists. Removing...", path);
 		pv_fs_path_remove(path, false);
 		sleep(1);
 	}
 
-	pv_log(ERROR, "/sys/fs/cgroup/lxc/%s/ still exists", name);
+	pv_log(ERROR, "%s still exists after retries", path);
+}
+
+// Remove lxc.monitor.<name> and any lxc.monitor.<name>-<digit>* variants
+// that LXC creates when it finds the preferred path occupied.
+static void pv_cgroup_remove_monitor_variants(const char *tree,
+					      const char *name)
+{
+	DIR *d = opendir(tree);
+	if (!d)
+		return;
+
+	char prefix[NAME_MAX];
+	int plen = snprintf(prefix, sizeof(prefix), "lxc.monitor.%s", name);
+	if (plen < 0 || (size_t)plen >= sizeof(prefix)) {
+		closedir(d);
+		return;
+	}
+
+	struct dirent *entry;
+	while ((entry = readdir(d)) != NULL) {
+		if (strncmp(entry->d_name, prefix, plen))
+			continue;
+
+		const char *rest = entry->d_name + plen;
+		// match exact or "<prefix>-<digit>..."
+		if (*rest != '\0' &&
+		    !(*rest == '-' && isdigit((unsigned char)*(rest + 1))))
+			continue;
+
+		char path[PATH_MAX];
+		snprintf(path, sizeof(path), "%s/%s", tree, entry->d_name);
+		pv_cgroup_remove_retry(path);
+	}
+
+	closedir(d);
+}
+
+// Clean lxc/<name>/ and lxc.monitor.<name>[-N]/ leaves in a single hierarchy.
+static void pv_cgroup_remove_hierarchy_leaves(const char *hierarchy,
+					      const char *name)
+{
+	char path[PATH_MAX];
+	snprintf(path, sizeof(path), "%s/lxc/%s", hierarchy, name);
+	pv_cgroup_remove_retry(path);
+
+	pv_cgroup_remove_monitor_variants(hierarchy, name);
+}
+
+void pv_cgroup_destroy(const char *name)
+{
+	struct pantavisor *pv = pv_get_instance();
+
+	switch (pv->cgroupv) {
+	case CGROUP_UNIFIED:
+		pv_cgroup_remove_hierarchy_leaves("/sys/fs/cgroup", name);
+		break;
+	case CGROUP_HYBRID: {
+		// Walk every cgroup hierarchy under /sys/fs/cgroup. The
+		// container is attached to all v1 controllers plus the v2
+		// unified tree; each retains its own lxc/<name>/ and
+		// lxc.monitor.<name>[-N]/ leaves that need cleaning.
+		DIR *d = opendir("/sys/fs/cgroup");
+		if (!d)
+			return;
+
+		struct dirent *entry;
+		while ((entry = readdir(d)) != NULL) {
+			if (entry->d_name[0] == '.')
+				continue;
+
+			char hierarchy[PATH_MAX];
+			snprintf(hierarchy, sizeof(hierarchy),
+				 "/sys/fs/cgroup/%s", entry->d_name);
+			pv_cgroup_remove_hierarchy_leaves(hierarchy, name);
+		}
+		closedir(d);
+		break;
+	}
+	default:
+		return;
+	}
 }

--- a/cgroup.c
+++ b/cgroup.c
@@ -407,11 +407,7 @@ char *pv_cgroup_get_process_name(pid_t pid)
 
 void pv_cgroup_destroy(const char *name)
 {
-	// keep this only for appengine for now
-	if (pv_config_get_system_init_mode() != IM_APPENGINE)
-		return;
-
-	// hanging cgroup has not been seen out of cgroup v2
+	// only relevant for cgroup v2
 	struct pantavisor *pv = pv_get_instance();
 	if (pv->cgroupv != CGROUP_UNIFIED)
 		return;


### PR DESCRIPTION
## Summary

Fix cgroup cleanup for HYBRID-mode devices (embedded/standalone init).

This PR now contains three fixes that build on each other:

### 1. `80a3120` — run cleanup on all init modes, not just appengine
Removes the `IM_APPENGINE`-only guard from `pv_cgroup_destroy()`. Necessary but not sufficient on its own for HYBRID devices (see #2 and #3 below).

### 2. `aa24c46` — detect HYBRID layout after the unified mount
`pv_cgroup_get_version()` ran before `pv_cgroup_mkcgroup_unified()`, so `statfs("/sys/fs/cgroup/unified/")` failed and we reported `CGROUP_LEGACY` on what is actually a HYBRID layout. All existing consumers already treat LEGACY and HYBRID identically, so this is behaviour-preserving prep work.

### 3. `b058a8e` — clean all hierarchy leaves on destroy, including HYBRID
The previous `pv_cgroup_destroy()` only handled `CGROUP_UNIFIED` and cleaned only `/sys/fs/cgroup/lxc/<name>/`. On HYBRID devices LXC creates leaves in every hierarchy (v1 controllers plus unified), both `lxc/<name>/` and `lxc.monitor.<name>/`. When force-stop (SIGKILL) races with LXC's own `rmdir`, dirt accumulates and monitor cgroups end up as `-1`, `-2`, ... suffixed variants on subsequent starts.

Rewrite to iterate every hierarchy under `/sys/fs/cgroup/` and clean both leaf patterns in each, with retries.

## Root cause of the dirt

- LXC sends SIGPWR for graceful shutdown, which many app containers don't handle → LXC force_stop fires → SIGKILL races with `rmdir` in `cgfsng_payload_destroy` → `rmdir` fails `EBUSY` on some hierarchies → dirt left.
- Pantavisor now acts as a safety net.

## Test plan

- [x] Verified on an orange-pi-3lts HYBRID device.
- [x] Lenient stop path (container traps signals): 3× stop/start cycles, zero leaves, no `-N` suffix.
- [x] SIGKILL path (container ignores signals): 3× stop/start cycles, zero leaves, no `-N` suffix.
- [x] Log confirms detection now reports `CGROUP_HYBRID` (previously `CGROUP_LEGACY`).
- [x] Full testplan lands in meta-pantavisor#275 (`TESTPLAN-cgroup.md`).

## Notes

- `CGROUP_LEGACY` (pure v1, no unified) case is still a no-op — not observed on supported kernels. Can be added if needed.
- Upstream LXC could retry `rmdir` with backoff to eliminate this race — worth a separate issue.