### PR TITLE
perf: event-drive container group transitions, remove 2s polling tax

### DIFF
--- a/event/event.c
+++ b/event/event.c
@@ -135,7 +135,31 @@ void pv_event_timeout(int timeout, event_callback_fn cb)
 
 void pv_event_one_shot(event_callback_fn cb)
 {
-	pv_event_timeout(0, cb);
+	if (!base)
+		return;
+
+	// Schedule a one-shot to fire as soon as possible — but defer just long
+	// enough that libevent goes through its dispatch (epoll_wait) cycle
+	// first. With timeval={0,0} event_base_once takes a fast path that
+	// directly appends to the active queue (event.c:event_base_once at the
+	// "If the event is going to become active immediately, don't put it on
+	// the timeout queue" branch → event_active_nolock_). That fires the
+	// callback inside the same event_process_active drain that scheduled
+	// it, BEFORE any pending bufferevent EV_WRITE has a chance to flush.
+	// For wakes triggered from inside ctrl request handlers (signal,
+	// container lifecycle endpoints, ...), that delays the queued response
+	// to the calling container by however long _pv_run_state_cb takes —
+	// observed as ~+1-2 s per signalling container while the next group's
+	// volume-mount runs.
+	//
+	// A 1 µs timeout puts the event in the timer heap instead. It is then
+	// activated by timeout_process() AFTER evsel->dispatch() has had a
+	// chance to flush ready fds, so the request response goes out first
+	// and the wake's heavy work runs after.
+	struct timeval when = { 0, 1 };
+	event_base_once(base, -1, EV_TIMEOUT, cb, NULL, &when);
+
+	pv_log(TRACE, "add event: type='one shot' cb=%p", (void *)cb);
 }
 
 struct event_base *pv_event_get_base()

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -859,7 +859,53 @@ pv_state_func_t *const state_table[MAX_STATES] = {
 
 static pv_state_t state = PV_STATE_INIT;
 
+// Invariant: at most one _pv_run_state_cb is pending at any time, either as an
+// immediate one-shot (when wake_pending is true) or as the persistent
+// safety-net timer (wait_timer_ev). pv_wake_state_machine() cancels the timer
+// and schedules the one-shot; _pv_run_state_cb clears wake_pending on entry
+// and _next_state re-arms the timer when returning to WAIT / BLOCK_REBOOT.
+static bool wake_pending = false;
+static struct event *wait_timer_ev = NULL;
+
 static void _next_state(pv_state_t next_state);
+static void _pv_run_state_cb(evutil_socket_t fd, short events, void *arg);
+
+static void _cancel_wait_timer(void)
+{
+	if (wait_timer_ev)
+		event_del(wait_timer_ev);
+}
+
+static void _arm_wait_timer(int secs, event_callback_fn cb)
+{
+	struct event_base *base = pv_event_get_base();
+	if (!base)
+		return;
+
+	if (!wait_timer_ev) {
+		wait_timer_ev =
+			event_new(base, -1, EV_PERSIST, cb, NULL);
+		if (!wait_timer_ev) {
+			pv_log(ERROR, "could not create wait safety-net timer");
+			return;
+		}
+	}
+
+	struct timeval tv = { secs, 0 };
+	event_add(wait_timer_ev, &tv);
+}
+
+void pv_wake_state_machine(void)
+{
+	if (wake_pending)
+		return;
+
+	wake_pending = true;
+	_cancel_wait_timer();
+	pv_event_one_shot(_pv_run_state_cb);
+
+	pv_log(TRACE, "state machine wake scheduled");
+}
 
 static void _pv_run_state_cb(evutil_socket_t fd, short events, void *arg)
 {
@@ -867,6 +913,8 @@ static void _pv_run_state_cb(evutil_socket_t fd, short events, void *arg)
 	struct pantavisor *pv = pv_get_instance();
 	if (!pv)
 		return;
+
+	wake_pending = false;
 
 	pv_wdt_kick();
 
@@ -902,14 +950,23 @@ static void _next_state(pv_state_t next_state)
 	if (!pv)
 		return;
 
+	pv_state_t prev_state = state;
 	state = next_state;
 
-	if (state == PV_STATE_WAIT)
-		pv_event_timeout(WAIT_INTERVAL, _pv_run_state_cb);
-	else if (state == PV_STATE_BLOCK_REBOOT)
-		pv_event_timeout(BLOCK_INTERVAL, _pv_run_state_cb);
-	else
-		pv_event_one_shot(_pv_run_state_cb);
+	if (state != PV_STATE_WAIT && state != PV_STATE_BLOCK_REBOOT) {
+		pv_wake_state_machine();
+		return;
+	}
+
+	int interval = (state == PV_STATE_WAIT) ? WAIT_INTERVAL : BLOCK_INTERVAL;
+
+	// First entry into WAIT / BLOCK_REBOOT: run the handler immediately so
+	// container group progression and command handling do not pay a full
+	// interval of latency before the first evaluation.
+	if (prev_state != state)
+		pv_wake_state_machine();
+
+	_arm_wait_timer(interval, _pv_run_state_cb);
 }
 
 int pv_start()

--- a/pantavisor.h
+++ b/pantavisor.h
@@ -68,6 +68,13 @@ void pv_issue_nonreboot(void);
 void pv_issue_reboot(void);
 void pv_issue_poweroff(void);
 
+// Wake the main state machine to run as soon as possible. Idempotent: if a
+// tick is already pending (either as a one-shot or as the safety-net timer),
+// later calls are cheap no-ops. Call this from anywhere that produces a
+// state-machine-relevant event (platform status change, ctrl command, update
+// progress) to avoid waiting for the WAIT_INTERVAL safety-net tick.
+void pv_wake_state_machine(void);
+
 struct pantavisor *pv_get_instance(void);
 
 #endif

--- a/platforms.c
+++ b/platforms.c
@@ -40,6 +40,7 @@
 
 #include <sched.h>
 
+#include "pantavisor.h"
 #include "platforms.h"
 #include "volumes.h"
 #include "paths.h"
@@ -230,6 +231,14 @@ static void pv_platform_set_status(struct pv_platform *p, plat_status_t status)
 	pv_platform_on_status_goal_reached(p);
 
 	pv_group_eval_status(p->group);
+
+	// Status transitions that can change a group's goal state drive the
+	// main loop forward — wake it instead of waiting for the next
+	// WAIT_INTERVAL tick. STARTED / READY achieve start goals; STOPPED
+	// surfaces crashes and auto-recovery decisions.
+	if (status == PLAT_STARTED || status == PLAT_READY ||
+	    status == PLAT_STOPPED)
+		pv_wake_state_machine();
 }
 
 struct pv_platform *pv_platform_add(struct pv_state *s, char *name)

--- a/platforms.h
+++ b/platforms.h
@@ -210,6 +210,7 @@ void pv_platform_set_mounted(struct pv_platform *p);
 void pv_platform_set_blocked(struct pv_platform *p);
 void pv_platform_set_recovering(struct pv_platform *p);
 int pv_platform_set_ready(struct pv_platform *p);
+void pv_platform_set_updated(struct pv_platform *p);
 
 bool pv_platform_is_installed(struct pv_platform *p);
 bool pv_platform_is_blocked(struct pv_platform *p);

--- a/update/update.c
+++ b/update/update.c
@@ -282,6 +282,7 @@ void pv_update_start_install(const char *rev, const char *progress_hub,
 	pv_log(DEBUG, "starting update");
 
 	pv_logserver_start_update(rev);
+	u->logserver_started = true;
 
 	if (pv_storage_install_state_json(state, rev)) {
 		pv_update_progress_set(&u->progress,
@@ -550,6 +551,7 @@ void pv_update_run(const char *rev)
 	pv_log(DEBUG, "loading rev '%s' to be run", rev);
 
 	pv_logserver_start_update(rev);
+	u->logserver_started = true;
 
 	json = pv_storage_get_state_json(rev);
 	if (!json) {
@@ -642,7 +644,6 @@ int pv_update_resume(void (*report_cb)(const char *, const char *))
 	if (!u)
 		return -1;
 
-	pv_logserver_start_update(rev);
 	pv->update = u;
 
 	pv_log(DEBUG, "checking existing progress data from disk");
@@ -694,6 +695,13 @@ int pv_update_resume(void (*report_cb)(const char *, const char *))
 		pv_update_finish();
 		return 0;
 	}
+
+	// Defer logserver tracking until we're sure we'll actually run this
+	// update (past the DONE/FAILED/ROLLEDBACK early-returns above). Those
+	// branches otherwise incur a ~5 s wait in pv_logserver_stop_update
+	// while it polls for an update-logs file that was never produced.
+	pv_logserver_start_update(rev);
+	u->logserver_started = true;
 out:
 	if (!u)
 		return -1;
@@ -886,7 +894,8 @@ void pv_update_finish()
 	if (pv_update_is_failed())
 		pv_bootloader_fail_update();
 
-	pv_logserver_stop_update(u->rev);
+	if (u->logserver_started)
+		pv_logserver_stop_update(u->rev);
 
 	pv_update_progress_reload_logs(&u->progress);
 

--- a/update/update_struct.h
+++ b/update/update_struct.h
@@ -22,6 +22,7 @@
 #ifndef PV_UPDATE_STRUCT_H
 #define PV_UPDATE_STRUCT_H
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 #include "state.h"
@@ -97,6 +98,11 @@ struct pv_update {
 	int object_list_retries;
 	pv_system_transition_t transition;
 	void (*report_cb)(const char *, const char *);
+	// True after pv_logserver_start_update was called for this update.
+	// pv_update_finish uses this to skip the ~5s wait-for-logs path in
+	// pv_logserver_stop_update when no logs were ever tracked (e.g. the
+	// factory/DONE early-return branches of pv_update_resume).
+	bool logserver_started;
 };
 
 #endif


### PR DESCRIPTION
## Summary

Four fixes for a ~9 s boot-time regression since 1.28, plus one correctness wart:

1. **Polling tax on state transitions** — group boundaries and crash → retry waited up to 2 s for the next WAIT tick. Added `pv_wake_state_machine()`; wake on platform STARTED/READY/STOPPED and on entry into WAIT/BLOCK from any other state.
2. **Factory-boot logs-wait stall** — `pv_update_finish` polled 5 s for a logs file on short-circuit paths that never produced one. Track with `logserver_started`, skip on those paths.
3. **Oneshot fires before response flush** — `event_base_once({0, 0})` ran wake callbacks before evhttp flushed responses. Use a 1 µs timer so wakes fire after `evsel->dispatch()`.

Plus: `pv_platform_set_updated` missing declaration in `platforms.h` caused `-Werror=implicit-function-declaration`.

Per-commit rationale lives in the commit messages.

## Commits

| # | SHA | Purpose |
|---|---|---|
| 1 | `5df1b81` | fix: declare pv_platform_set_updated in platforms.h |
| 2 | `485ff69` | perf: add pv_wake_state_machine() and remove first-tick WAIT delay |
| 3 | `7d7e10e` | perf: wake state machine on platform STARTED/READY/STOPPED transitions |
| 4 | `bd1b4ea` | perf: skip 5s logs-wait on update paths that never produced logs |
| 5 | `313a9f1` | perf: defer pv_event_one_shot via 1 µs timer to flush pending fd writes first |

## Test plan

- [x] Build passes on scarthgap (`bitbake pantavisor-bsp` + `-c compile -f pantavisor` with `-Werror`).
- [x] On-device deploy to a quad-core opi3 dev device: commits cleanly, inter-group gaps collapse to 0 s, startup timings recovered to pre-regression parity.
- [x] `TESTPLAN-auto-recovery.md` — 7/8 PASS, T6 BLOCKED (appengine rev 0 never enters TESTING; `pv_state_is_stability_pending` verified by inspection). Retry delays land at configured intervals with no `+~2 s` WAIT-tick drift.
- [x] `TESTPLAN-container-control.md` — 8/9 PASS (T9 lenient stop falls through on a fixture that traps SIGTERM but LXC halts with SIGPWR — pre-existing, unrelated).
- [x] `TESTPLAN-pvctrl.md` — 31/31 functional PASS, T26 `poweroff` SKIPPED (destructive). Ctrl command dispatch RTT: start 88 ms, restart 90 ms, daemon stop/start 83 ms — consistent with the 1 µs defer fix.

## Companion PR

- [pantavisor/meta-pantavisor#279 — split `mdev.sh` LXC mount hook into optional `pantavisor-hooks-mdev` package](https://github.com/pantavisor/meta-pantavisor/pull/279).

## Follow-ups (separate PRs)

- **Wake on ctrl command arrival** in `ctrl/ctrl_cmd.c` so pv-ctrl requests don't wait up to 2 s for the next tick when the current state is in WAIT.
- **Wake on pantahub / update events** to surface update progress transitions without polling.
- **Audit remaining time-based timers** (`timer_commit`, `timer_rollback_remote`, per-platform `timer_status_goal`, auto-recovery retry) and make each its own libevent timer rather than piggy-backing on the WAIT tick.
- **`pvctl_utils.c::open_socket` retry granularity**: `sleep(2) × 5` is independently bad polling for cold sockets. Not causative for this PR's regressions but worth replacing with a 50 ms fine-grained poll.
