### PR TITLE
fix(logger): parse off_t xattr via intmax_t temporary

### DIFF
--- a/ph_logger.c
+++ b/ph_logger.c
@@ -28,6 +28,7 @@
 #include <sys/un.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <trest.h>
 #include <thttp.h>
 #include <sys/epoll.h>
@@ -305,9 +306,11 @@ static off_t _load_log_file_pos(const char *path)
 		pv_log(DEBUG, "log file is persistent. Trying to get xattr...",
 		       path);
 		if (getxattr(path, PH_LOGGER_POS_XATTR, dst, MAX_XATTR_SIZE) >
-		    0)
-			sscanf(dst, "%jd", &pos);
-		else {
+		    0) {
+			intmax_t parsed = 0;
+			if (sscanf(dst, "%jd", &parsed) == 1)
+				pos = (off_t)parsed;
+		} else {
 			if (errno == ENODATA)
 				// if xattr does not yet exist for that path, we save it with pos 0
 				_save_log_file_pos(pos, path);

--- a/pvlogger.c
+++ b/pvlogger.c
@@ -179,7 +179,9 @@ static int get_logger_xattr(struct log *log)
 	if (getxattr(fname, PV_LOGGER_POS_XATTR, buf, 32) < 0) {
 		pv_log(DEBUG, "Attribute %s not present", PV_LOGGER_POS_XATTR);
 	} else {
-		sscanf(buf, "%jd", &stored_pos);
+		intmax_t parsed = 0;
+		if (sscanf(buf, "%jd", &parsed) == 1)
+			stored_pos = (off_t)parsed;
 	}
 	return stored_pos;
 }
@@ -415,9 +417,11 @@ pv_new_log(bool islxc, struct pv_logger_config *logger_config, const char *name)
 		if (!strncmp(trunc_val, "true", strlen("true"))) {
 			trunc_val = pv_log_get_config_item(logger_config,
 							   "maxsize");
-			if (trunc_val)
-				sscanf(trunc_val, "%jd",
-				       &log_info->truncate_size);
+			if (trunc_val) {
+				intmax_t parsed = 0;
+				if (sscanf(trunc_val, "%jd", &parsed) == 1)
+					log_info->truncate_size = (off_t)parsed;
+			}
 		}
 	}
 	dl_list_init(&log_info->next);


### PR DESCRIPTION
## Summary

Three `sscanf(..., "%jd", &off_t_var)` call sites are undefined behaviour on platforms where `off_t` is not the same type as `intmax_t`.

On 32-bit glibc builds (e.g. Yocto `cortexa7t2hf-neon-poky-linux-gnueabi`, which doesn't enable `_FILE_OFFSET_BITS=64`) `off_t` is `long` while `intmax_t` is `long long`. With gcc's `-Werror=format=` this now fails the build outright:

```
pvlogger.c:182: error: format '%jd' expects argument of type 'intmax_t *', but argument 3 has type 'off_t *' {aka 'long int *'}
pvlogger.c:419: error: format '%jd' expects argument of type 'intmax_t *', but argument 3 has type 'off_t *' {aka 'long int *'}
ph_logger.c:309: error: format '%jd' expects argument of type 'intmax_t *', but argument 3 has type 'off_t *' {aka 'long int *'}
```

64-bit builds compiled by coincidence (both `intmax_t` and `off_t` alias `long`), but the UB was silent there.

## Fix

Parse into a local `intmax_t` and cast the result to `off_t`. Matching formatter side (e.g. `pvlogger.c:104` / `ph_logger.c:280`) was already correct — it casts `(intmax_t)pos` before `%jd`. This aligns the scanner side with the same pattern. Added `<inttypes.h>` to `ph_logger.c` for `intmax_t`.

## Test plan

- [x] Builds green on 32-bit ARM Yocto (kirkstone, `sunxi-nanopi-r1`, `cortexa7t2hf-neon`) — previously failed at `do_compile`, now succeeds
- [ ] No regression on 64-bit builds (expected: identical codegen semantics since `(off_t)(intmax_t)v == v` for any representable `off_t`)
- [ ] xattr round-trip still reads correct position after container restart