### PR TITLE
feat(ipam): isolate pools by default at L3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ add_executable(pantavisor
 			grub.c
 			init.c
 			init.h
+			ipam.c
+			ipam.h
 			jsons.c
 			jsons.h
 			log.c

--- a/ipam.c
+++ b/ipam.c
@@ -1,0 +1,696 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/sockios.h>
+
+#include "ipam.h"
+#include "config.h"
+#include "utils/str.h"
+
+#define MODULE_NAME "ipam"
+#define pv_log(level, msg, ...)                                                \
+	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
+	     ##__VA_ARGS__)
+#include "log.h"
+
+// Global IPAM state
+static struct pv_ipam ipam_state = { .initialized = false };
+
+int pv_ipam_init(void)
+{
+	if (ipam_state.initialized)
+		return 0;
+
+	dl_list_init(&ipam_state.pools);
+	ipam_state.initialized = true;
+
+	pv_log(INFO, "IPAM subsystem initialized");
+	return 0;
+}
+
+void pv_ipam_free(void)
+{
+	struct pv_ip_pool *pool, *pool_tmp;
+	struct pv_ip_lease *lease, *lease_tmp;
+
+	dl_list_for_each_safe(pool, pool_tmp, &ipam_state.pools,
+			      struct pv_ip_pool, list)
+	{
+		dl_list_for_each_safe(lease, lease_tmp, &pool->leases,
+				      struct pv_ip_lease, list)
+		{
+			dl_list_del(&lease->list);
+			if (lease->container_name)
+				free(lease->container_name);
+			free(lease);
+		}
+		dl_list_del(&pool->list);
+		if (pool->name)
+			free(pool->name);
+		if (pool->bridge)
+			free(pool->bridge);
+		if (pool->parent)
+			free(pool->parent);
+		free(pool);
+	}
+
+	ipam_state.initialized = false;
+	pv_log(INFO, "IPAM subsystem freed");
+}
+
+struct pv_ipam *pv_ipam_get(void)
+{
+	return &ipam_state;
+}
+
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask)
+{
+	char *cidr_copy, *slash;
+	int prefix_len;
+	struct in_addr addr;
+
+	if (!cidr || !subnet || !mask)
+		return -1;
+
+	cidr_copy = strdup(cidr);
+	if (!cidr_copy)
+		return -1;
+
+	slash = strchr(cidr_copy, '/');
+	if (!slash) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*slash = '\0';
+	prefix_len = atoi(slash + 1);
+
+	if (prefix_len < 0 || prefix_len > 32) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	if (inet_pton(AF_INET, cidr_copy, &addr) != 1) {
+		free(cidr_copy);
+		return -1;
+	}
+
+	*subnet = addr.s_addr;
+
+	if (prefix_len == 0)
+		*mask = 0;
+	else
+		*mask = htonl(~((1 << (32 - prefix_len)) - 1));
+
+	free(cidr_copy);
+	return 0;
+}
+
+char *pv_ipam_ip_to_str(uint32_t ip)
+{
+	struct in_addr addr;
+	addr.s_addr = ip;
+	return strdup(inet_ntoa(addr));
+}
+
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask)
+{
+	return (ip & mask) == (subnet & mask);
+}
+
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat)
+{
+	struct pv_ip_pool *pool;
+	uint32_t subnet, mask;
+	struct in_addr gw_addr;
+
+	if (!name || !bridge_or_parent || !subnet_cidr || !gateway) {
+		pv_log(ERROR, "invalid pool parameters");
+		return NULL;
+	}
+
+	if (pv_ipam_parse_cidr(subnet_cidr, &subnet, &mask) < 0) {
+		pv_log(ERROR, "invalid subnet CIDR: %s", subnet_cidr);
+		return NULL;
+	}
+
+	if (inet_pton(AF_INET, gateway, &gw_addr) != 1) {
+		pv_log(ERROR, "invalid gateway IP: %s", gateway);
+		return NULL;
+	}
+
+	// Check if pool already exists
+	if (pv_ipam_find_pool(name)) {
+		pv_log(WARN, "pool '%s' already exists", name);
+		return NULL;
+	}
+
+	pool = calloc(1, sizeof(struct pv_ip_pool));
+	if (!pool)
+		return NULL;
+
+	pool->name = strdup(name);
+	pool->type = type;
+	pool->subnet = subnet;
+	pool->mask = mask;
+	pool->gateway = gw_addr.s_addr;
+	pool->nat = nat;
+	pool->bridge_created = false;
+
+	if (type == POOL_TYPE_BRIDGE)
+		pool->bridge = strdup(bridge_or_parent);
+	else
+		pool->parent = strdup(bridge_or_parent);
+
+	// Start allocating from gateway + 1
+	pool->next_ip = ntohl(gw_addr.s_addr) + 1;
+
+	dl_list_init(&pool->leases);
+	dl_list_init(&pool->list);
+	dl_list_add_tail(&ipam_state.pools, &pool->list);
+
+	pv_log(INFO, "added pool '%s': type=%s, subnet=%s, gateway=%s, nat=%s",
+	       name, type == POOL_TYPE_BRIDGE ? "bridge" : "macvlan",
+	       subnet_cidr, gateway, nat ? "yes" : "no");
+
+	return pool;
+}
+
+struct pv_ip_pool *pv_ipam_find_pool(const char *name)
+{
+	struct pv_ip_pool *pool;
+
+	if (!name)
+		return NULL;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (strcmp(pool->name, name) == 0)
+			return pool;
+	}
+
+	return NULL;
+}
+
+static bool is_ip_available(struct pv_ip_pool *pool, uint32_t ip)
+{
+	struct pv_ip_lease *lease;
+
+	// Check if IP is the gateway
+	if (ip == pool->gateway)
+		return false;
+
+	// Check if IP is in existing leases
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (lease->ip == ip)
+			return false;
+	}
+
+	return true;
+}
+
+char *pv_ipam_allocate(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *existing;
+	uint32_t ip, ip_net;
+	uint32_t broadcast, max_ip;
+	char *result;
+	int prefix_len;
+	uint32_t mask_host;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return NULL;
+	}
+
+	// Check if container already has a lease
+	existing = pv_ipam_get_lease(pool_name, container_name);
+	if (existing) {
+		// Reuse existing lease
+		char *ip_str = pv_ipam_ip_to_str(existing->ip);
+		mask_host = ntohl(pool->mask);
+		prefix_len = __builtin_popcount(mask_host);
+		result = malloc(strlen(ip_str) + 4);
+		sprintf(result, "%s/%d", ip_str, prefix_len);
+		free(ip_str);
+		pv_log(DEBUG, "reusing existing lease for %s: %s",
+		       container_name, result);
+		return result;
+	}
+
+	// Calculate broadcast address
+	broadcast = pool->subnet | ~pool->mask;
+	max_ip = ntohl(broadcast) - 1; // Last usable IP
+
+	// Find next available IP
+	ip = pool->next_ip;
+	while (ip <= max_ip) {
+		ip_net = htonl(ip);
+		if (is_ip_available(pool, ip_net)) {
+			// Found available IP
+			lease = calloc(1, sizeof(struct pv_ip_lease));
+			if (!lease)
+				return NULL;
+
+			lease->container_name = strdup(container_name);
+			lease->ip = ip_net;
+			lease->in_use = true;
+			dl_list_init(&lease->list);
+			dl_list_add_tail(&pool->leases, &lease->list);
+
+			// Update next_ip cursor
+			pool->next_ip = ip + 1;
+
+			// Format result as CIDR
+			char *ip_str = pv_ipam_ip_to_str(ip_net);
+			mask_host = ntohl(pool->mask);
+			prefix_len = __builtin_popcount(mask_host);
+			result = malloc(strlen(ip_str) + 4);
+			sprintf(result, "%s/%d", ip_str, prefix_len);
+			free(ip_str);
+
+			pv_log(INFO, "allocated %s to %s from pool %s", result,
+			       container_name, pool_name);
+			return result;
+		}
+		ip++;
+	}
+
+	pv_log(ERROR, "no available IPs in pool '%s'", pool_name);
+	return NULL;
+}
+
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+	uint32_t ip, mask;
+	struct in_addr addr;
+	char *ip_only, *slash;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool) {
+		pv_log(ERROR, "pool '%s' not found", pool_name);
+		return -1;
+	}
+
+	// Parse IP from CIDR
+	ip_only = strdup(ip_cidr);
+	slash = strchr(ip_only, '/');
+	if (slash)
+		*slash = '\0';
+
+	if (inet_pton(AF_INET, ip_only, &addr) != 1) {
+		pv_log(ERROR, "invalid IP: %s", ip_only);
+		free(ip_only);
+		return -1;
+	}
+	ip = addr.s_addr;
+	free(ip_only);
+
+	// Check if IP is in pool subnet
+	if (!pv_ipam_ip_in_subnet(ip, pool->subnet, pool->mask)) {
+		pv_log(ERROR, "IP %s not in pool '%s' subnet", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Check if IP is available
+	if (!is_ip_available(pool, ip)) {
+		pv_log(ERROR, "IP %s already in use in pool '%s'", ip_cidr,
+		       pool_name);
+		return -1;
+	}
+
+	// Create lease
+	lease = calloc(1, sizeof(struct pv_ip_lease));
+	if (!lease)
+		return -1;
+
+	lease->container_name = strdup(container_name);
+	lease->ip = ip;
+	lease->in_use = true;
+	dl_list_init(&lease->list);
+	dl_list_add_tail(&pool->leases, &lease->list);
+
+	pv_log(INFO, "reserved %s for %s in pool %s", ip_cidr, container_name,
+	       pool_name);
+	return 0;
+}
+
+void pv_ipam_release(const char *pool_name, const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease, *tmp;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return;
+
+	dl_list_for_each_safe(lease, tmp, &pool->leases, struct pv_ip_lease,
+			      list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0) {
+			char *ip_str = pv_ipam_ip_to_str(lease->ip);
+			pv_log(INFO, "released %s from %s in pool %s", ip_str,
+			       container_name, pool_name);
+			free(ip_str);
+
+			dl_list_del(&lease->list);
+			free(lease->container_name);
+			free(lease);
+			return;
+		}
+	}
+}
+
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name)
+{
+	struct pv_ip_pool *pool;
+	struct pv_ip_lease *lease;
+
+	pool = pv_ipam_find_pool(pool_name);
+	if (!pool)
+		return NULL;
+
+	dl_list_for_each(lease, &pool->leases, struct pv_ip_lease, list)
+	{
+		if (strcmp(lease->container_name, container_name) == 0)
+			return lease;
+	}
+
+	return NULL;
+}
+
+char *pv_ipam_generate_mac(uint32_t ip_net)
+{
+	char *mac;
+	uint32_t ip;
+
+	if (!ip_net)
+		return NULL;
+
+	// Convert from network byte order to host byte order
+	ip = ntohl(ip_net);
+
+	// Format: 02:00:XX:XX:XX:XX where XX:XX:XX:XX is the IP address octets
+	// 02 = locally administered, unicast
+	// Using IP ensures uniqueness within pool (IPs are unique)
+	// Example: IP 10.0.5.2 → MAC 02:00:0a:00:05:02
+	mac = malloc(18);
+	if (!mac)
+		return NULL;
+
+	snprintf(mac, 18, "02:00:%02x:%02x:%02x:%02x", (ip >> 24) & 0xff,
+		 (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
+
+	return mac;
+}
+
+static int setup_bridge(struct pv_ip_pool *pool)
+{
+	int fd, sockfd, ret = 0;
+	struct ifreq ifr;
+	struct sockaddr_in sai;
+	char *gateway_str;
+	uint32_t mask_host;
+	int prefix_len;
+
+	if (!pool || pool->type != POOL_TYPE_BRIDGE || !pool->bridge)
+		return -1;
+
+	if (pool->bridge_created)
+		return 0;
+
+	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	if (fd < 0) {
+		pv_log(ERROR, "unable to create socket: %s", strerror(errno));
+		return -1;
+	}
+
+	// Create bridge
+	ret = ioctl(fd, SIOCBRADDBR, pool->bridge);
+	if (ret < 0 && errno != EEXIST) {
+		pv_log(ERROR, "unable to create bridge %s: %s", pool->bridge,
+		       strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	// Configure bridge IP
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd < 0) {
+		pv_log(ERROR, "unable to create dgram socket: %s",
+		       strerror(errno));
+		return -1;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, pool->bridge, IFNAMSIZ - 1);
+
+	// Set IP address
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->gateway;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFADDR, &ifr);
+	if (ret < 0) {
+		gateway_str = pv_ipam_ip_to_str(pool->gateway);
+		pv_log(ERROR, "unable to set IP %s on %s: %s", gateway_str,
+		       pool->bridge, strerror(errno));
+		free(gateway_str);
+		close(sockfd);
+		return -1;
+	}
+
+	// Set netmask
+	memset(&sai, 0, sizeof(sai));
+	sai.sin_family = AF_INET;
+	sai.sin_addr.s_addr = pool->mask;
+	memcpy(&ifr.ifr_addr, &sai, sizeof(sai));
+
+	ret = ioctl(sockfd, SIOCSIFNETMASK, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to set netmask on %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	// Bring interface up
+	ret = ioctl(sockfd, SIOCGIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to get flags for %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+	ret = ioctl(sockfd, SIOCSIFFLAGS, &ifr);
+	if (ret < 0) {
+		pv_log(ERROR, "unable to bring up %s: %s", pool->bridge,
+		       strerror(errno));
+		close(sockfd);
+		return -1;
+	}
+
+	close(sockfd);
+
+	pool->bridge_created = true;
+
+	gateway_str = pv_ipam_ip_to_str(pool->gateway);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+	pv_log(INFO, "created bridge %s with IP %s/%d", pool->bridge,
+	       gateway_str, prefix_len);
+	free(gateway_str);
+
+	return 0;
+}
+
+static int setup_nat(struct pv_ip_pool *pool)
+{
+	char cmd[512];
+	char *subnet_str;
+	uint32_t mask_host;
+	int prefix_len;
+	int ret;
+
+	if (!pool || !pool->nat)
+		return 0;
+
+	subnet_str = pv_ipam_ip_to_str(pool->subnet);
+	mask_host = ntohl(pool->mask);
+	prefix_len = __builtin_popcount(mask_host);
+
+	// Enable IP forwarding
+	ret = system("echo 1 > /proc/sys/net/ipv4/ip_forward");
+	if (ret != 0) {
+		pv_log(WARN, "failed to enable IP forwarding");
+	}
+
+	// Try iptables first, fall back to nftables
+	snprintf(
+		cmd, sizeof(cmd),
+		"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
+		"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
+		subnet_str, prefix_len, pool->bridge, subnet_str, prefix_len,
+		pool->bridge);
+
+	ret = system(cmd);
+	if (ret != 0) {
+		// Try nftables
+		snprintf(
+			cmd, sizeof(cmd),
+			"nft add table nat 2>/dev/null; "
+			"nft add chain nat postrouting { type nat hook postrouting priority 100 \\; } 2>/dev/null; "
+			"nft add rule nat postrouting ip saddr %s/%d oifname != \"%s\" masquerade 2>/dev/null",
+			subnet_str, prefix_len, pool->bridge);
+		ret = system(cmd);
+		if (ret != 0) {
+			pv_log(WARN, "failed to setup NAT for pool %s",
+			       pool->name);
+		} else {
+			pv_log(INFO, "setup NAT (nftables) for pool %s",
+			       pool->name);
+		}
+	} else {
+		pv_log(INFO, "setup NAT (iptables) for pool %s", pool->name);
+	}
+
+	free(subnet_str);
+	return 0;
+}
+
+int pv_ipam_setup_bridges(void)
+{
+	struct pv_ip_pool *pool;
+	int ret = 0;
+
+	dl_list_for_each(pool, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (pool->type == POOL_TYPE_BRIDGE) {
+			if (setup_bridge(pool) < 0)
+				ret = -1;
+			if (pool->nat)
+				setup_nat(pool);
+		}
+	}
+
+	return ret;
+}
+
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode)
+{
+	struct pv_platform_network *net;
+
+	net = calloc(1, sizeof(struct pv_platform_network));
+	if (!net)
+		return NULL;
+
+	net->mode = mode;
+	dl_list_init(&net->interfaces);
+
+	return net;
+}
+
+void pv_platform_network_free(struct pv_platform_network *net)
+{
+	struct pv_platform_network_iface *iface, *tmp;
+
+	if (!net)
+		return;
+
+	dl_list_for_each_safe(iface, tmp, &net->interfaces,
+			      struct pv_platform_network_iface, list)
+	{
+		dl_list_del(&iface->list);
+		if (iface->name)
+			free(iface->name);
+		if (iface->pool)
+			free(iface->pool);
+		if (iface->ipv4_address)
+			free(iface->ipv4_address);
+		if (iface->ipv4_gateway)
+			free(iface->ipv4_gateway);
+		if (iface->bridge)
+			free(iface->bridge);
+		if (iface->veth_host)
+			free(iface->veth_host);
+		if (iface->mac_address)
+			free(iface->mac_address);
+		if (iface->static_ip)
+			free(iface->static_ip);
+		if (iface->static_mac)
+			free(iface->static_mac);
+		free(iface);
+	}
+
+	if (net->hostname)
+		free(net->hostname);
+	free(net);
+}
+
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool)
+{
+	struct pv_platform_network_iface *iface;
+
+	if (!net || !name || !pool)
+		return NULL;
+
+	iface = calloc(1, sizeof(struct pv_platform_network_iface));
+	if (!iface)
+		return NULL;
+
+	iface->name = strdup(name);
+	iface->pool = strdup(pool);
+	dl_list_init(&iface->list);
+	dl_list_add_tail(&net->interfaces, &iface->list);
+
+	return iface;
+}

--- a/ipam.c
+++ b/ipam.c
@@ -622,6 +622,118 @@ static int setup_nat(struct pv_ip_pool *pool)
 	return 0;
 }
 
+// Isolate pools from each other at L3. Same-bridge (same-pool) traffic is
+// L2-bridged and never hits FORWARD. External egress (container -> uplink)
+// targets the uplink iface (not another pool bridge) and falls through to
+// POSTROUTING MASQUERADE. NAT return traffic is preserved via the
+// conntrack-ESTABLISHED,RELATED accept installed at the top of the chain
+// before any DROP rule. Cross-pool routed traffic (bridge A -> bridge B)
+// matches the per-pair DROP and is dropped.
+static int setup_isolation(void)
+{
+	char cmd[1024];
+	int ret;
+	int pairs = 0;
+	struct pv_ip_pool *a, *b;
+
+	// If fewer than two bridge pools exist, nothing to isolate.
+	int bridge_pools = 0;
+	dl_list_for_each(a, &ipam_state.pools, struct pv_ip_pool, list)
+	{
+		if (a->type == POOL_TYPE_BRIDGE)
+			bridge_pools++;
+	}
+	if (bridge_pools < 2)
+		return 0;
+
+	bool have_nft = system("command -v nft >/dev/null 2>&1") == 0;
+	bool have_iptables = system("command -v iptables >/dev/null 2>&1") == 0;
+
+	ret = -1;
+	if (have_nft) {
+		// Ensure filter table + forward chain + conntrack-accept rule
+		// exist. Use `add` with 2>/dev/null so re-running is idempotent.
+		ret = system(
+			"nft add table inet pv_ipam 2>/dev/null; "
+			"nft add chain inet pv_ipam forward { type filter hook forward priority 0 \\; } 2>/dev/null; "
+			"nft add rule inet pv_ipam forward ct state related,established accept 2>/dev/null");
+
+		if (ret == 0) {
+			dl_list_for_each(a, &ipam_state.pools,
+					 struct pv_ip_pool, list)
+			{
+				if (a->type != POOL_TYPE_BRIDGE)
+					continue;
+				dl_list_for_each(b, &ipam_state.pools,
+						 struct pv_ip_pool, list)
+				{
+					if (b->type != POOL_TYPE_BRIDGE)
+						continue;
+					if (a == b)
+						continue;
+					snprintf(
+						cmd, sizeof(cmd),
+						"nft add rule inet pv_ipam forward iifname \"%s\" oifname \"%s\" drop 2>/dev/null",
+						a->bridge, b->bridge);
+					if (system(cmd) == 0)
+						pairs++;
+				}
+			}
+			pv_log(INFO,
+			       "pool isolation (nftables): %d cross-pool drop rule(s) installed",
+			       pairs);
+			return 0;
+		}
+	}
+
+	if (ret != 0 && have_iptables) {
+		// Insert the conntrack-accept prelude at the top of FORWARD so
+		// NAT return flows pass before we start dropping cross-bridge
+		// traffic. Use -C / -I pattern for idempotency.
+		ret = system(
+			"iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || "
+			"iptables -I FORWARD 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null");
+
+		if (ret == 0) {
+			dl_list_for_each(a, &ipam_state.pools,
+					 struct pv_ip_pool, list)
+			{
+				if (a->type != POOL_TYPE_BRIDGE)
+					continue;
+				dl_list_for_each(b, &ipam_state.pools,
+						 struct pv_ip_pool, list)
+				{
+					if (b->type != POOL_TYPE_BRIDGE)
+						continue;
+					if (a == b)
+						continue;
+					snprintf(
+						cmd, sizeof(cmd),
+						"iptables -C FORWARD -i %s -o %s -j DROP 2>/dev/null || "
+						"iptables -A FORWARD -i %s -o %s -j DROP 2>/dev/null",
+						a->bridge, b->bridge, a->bridge,
+						b->bridge);
+					if (system(cmd) == 0)
+						pairs++;
+				}
+			}
+			pv_log(INFO,
+			       "pool isolation (iptables): %d cross-pool drop rule(s) installed",
+			       pairs);
+			return 0;
+		}
+	}
+
+	if (!have_nft && !have_iptables) {
+		pv_log(WARN,
+		       "neither nftables (nft) nor iptables available; pools are NOT isolated");
+	} else {
+		pv_log(WARN,
+		       "failed to install pool isolation rules; pools are NOT isolated");
+	}
+	return -1;
+}
+
 int pv_ipam_setup_bridges(void)
 {
 	struct pv_ip_pool *pool;
@@ -636,6 +748,8 @@ int pv_ipam_setup_bridges(void)
 				setup_nat(pool);
 		}
 	}
+
+	setup_isolation();
 
 	return ret;
 }

--- a/ipam.c
+++ b/ipam.c
@@ -572,17 +572,14 @@ static int setup_nat(struct pv_ip_pool *pool)
 		pv_log(WARN, "failed to enable IP forwarding");
 	}
 
-	// Try iptables first, fall back to nftables
-	snprintf(
-		cmd, sizeof(cmd),
-		"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
-		"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
-		subnet_str, prefix_len, pool->bridge, subnet_str, prefix_len,
-		pool->bridge);
+	// Prefer nftables (default on modern distros and kernel-native since
+	// 3.13); fall back to iptables if nft is missing or fails (e.g. a BSP
+	// with only the legacy tools, or kernel without nf_tables).
+	bool have_nft = system("command -v nft >/dev/null 2>&1") == 0;
+	bool have_iptables = system("command -v iptables >/dev/null 2>&1") == 0;
 
-	ret = system(cmd);
-	if (ret != 0) {
-		// Try nftables
+	ret = -1;
+	if (have_nft) {
 		snprintf(
 			cmd, sizeof(cmd),
 			"nft add table nat 2>/dev/null; "
@@ -590,15 +587,35 @@ static int setup_nat(struct pv_ip_pool *pool)
 			"nft add rule nat postrouting ip saddr %s/%d oifname != \"%s\" masquerade 2>/dev/null",
 			subnet_str, prefix_len, pool->bridge);
 		ret = system(cmd);
-		if (ret != 0) {
-			pv_log(WARN, "failed to setup NAT for pool %s",
-			       pool->name);
-		} else {
+		if (ret == 0) {
 			pv_log(INFO, "setup NAT (nftables) for pool %s",
 			       pool->name);
 		}
-	} else {
-		pv_log(INFO, "setup NAT (iptables) for pool %s", pool->name);
+	}
+
+	if (ret != 0 && have_iptables) {
+		snprintf(
+			cmd, sizeof(cmd),
+			"iptables -t nat -C POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null || "
+			"iptables -t nat -A POSTROUTING -s %s/%d ! -o %s -j MASQUERADE 2>/dev/null",
+			subnet_str, prefix_len, pool->bridge, subnet_str,
+			prefix_len, pool->bridge);
+		ret = system(cmd);
+		if (ret == 0) {
+			pv_log(INFO, "setup NAT (iptables) for pool %s",
+			       pool->name);
+		}
+	}
+
+	if (ret != 0) {
+		if (!have_nft && !have_iptables) {
+			pv_log(WARN,
+			       "neither nftables (nft) nor iptables available; cannot setup NAT for pool %s",
+			       pool->name);
+		} else {
+			pv_log(WARN, "failed to setup NAT for pool %s",
+			       pool->name);
+		}
 	}
 
 	free(subnet_str);

--- a/ipam.h
+++ b/ipam.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PV_IPAM_H
+#define PV_IPAM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <netinet/in.h>
+
+#include "utils/list.h"
+
+// Pool types
+typedef enum { POOL_TYPE_BRIDGE, POOL_TYPE_MACVLAN } pv_pool_type_t;
+
+// IP lease - tracks allocated IPs
+struct pv_ip_lease {
+	char *container_name;
+	uint32_t ip; // Network byte order
+	bool in_use;
+	struct dl_list list; // pv_ip_lease
+};
+
+// IP pool - defines a network pool from device.json
+struct pv_ip_pool {
+	char *name; // Pool name (e.g., "internal")
+	pv_pool_type_t type; // bridge or macvlan
+	char *bridge; // Bridge interface name (for type=bridge)
+	char *parent; // Parent interface (for type=macvlan)
+	uint32_t subnet; // Subnet address (network byte order)
+	uint32_t mask; // Subnet mask (network byte order)
+	uint32_t gateway; // Gateway IP (network byte order)
+	bool nat; // Enable NAT
+	bool bridge_created; // Bridge already created
+	uint32_t next_ip; // Next IP to allocate (host byte order)
+	struct dl_list leases; // pv_ip_lease
+	struct dl_list list; // pv_ip_pool
+};
+
+// Platform network mode
+typedef enum {
+	NET_MODE_NONE, // No network config (use static lxc.container.conf)
+	NET_MODE_HOST, // Host namespace
+	NET_MODE_POOL // Pool-based dynamic
+} pv_net_mode_t;
+
+// Platform network interface config
+struct pv_platform_network_iface {
+	char *name; // Container-side interface (e.g., "eth0")
+	char *pool; // Pool name from device.json
+	char *ipv4_address; // Assigned IP in CIDR notation
+	char *ipv4_gateway; // Gateway IP
+	char *bridge; // Host bridge name
+	char *veth_host; // Host-side veth name
+	char *mac_address; // MAC address
+	char *static_ip; // Static IP override from run.json (optional)
+	char *static_mac; // Static MAC override from run.json (optional)
+	struct dl_list list; // pv_platform_network_iface
+};
+
+// Platform network config (from run.json)
+struct pv_platform_network {
+	pv_net_mode_t mode;
+	char *hostname;
+	struct dl_list interfaces; // pv_platform_network_iface
+};
+
+// Global IPAM state
+struct pv_ipam {
+	struct dl_list pools; // pv_ip_pool
+	bool initialized;
+};
+
+// Initialize IPAM subsystem
+int pv_ipam_init(void);
+
+// Cleanup IPAM subsystem
+void pv_ipam_free(void);
+
+// Get global IPAM instance
+struct pv_ipam *pv_ipam_get(void);
+
+// Add a pool from device.json
+struct pv_ip_pool *pv_ipam_add_pool(const char *name, pv_pool_type_t type,
+				    const char *bridge_or_parent,
+				    const char *subnet_cidr,
+				    const char *gateway, bool nat);
+
+// Find a pool by name
+struct pv_ip_pool *pv_ipam_find_pool(const char *name);
+
+// Allocate an IP from a pool for a container
+// Returns allocated IP in CIDR notation (e.g., "10.0.3.2/24") or NULL on failure
+char *pv_ipam_allocate(const char *pool_name, const char *container_name);
+
+// Reserve a specific IP in a pool (for static configs)
+// Returns 0 on success, -1 if IP already taken or not in pool
+int pv_ipam_reserve(const char *pool_name, const char *container_name,
+		    const char *ip_cidr);
+
+// Release an IP back to the pool
+void pv_ipam_release(const char *pool_name, const char *container_name);
+
+// Get the lease for a container in a pool
+struct pv_ip_lease *pv_ipam_get_lease(const char *pool_name,
+				      const char *container_name);
+
+// Setup bridges for all pools (called during init)
+int pv_ipam_setup_bridges(void);
+
+// Generate deterministic MAC address from container name
+// Returns MAC in format "02:pv:XX:XX:XX:XX"
+char *pv_ipam_generate_mac(uint32_t ip);
+
+// Parse CIDR notation (e.g., "10.0.3.0/24") into subnet and mask
+int pv_ipam_parse_cidr(const char *cidr, uint32_t *subnet, uint32_t *mask);
+
+// Format IP address to string
+char *pv_ipam_ip_to_str(uint32_t ip);
+
+// Check if IP is in subnet
+bool pv_ipam_ip_in_subnet(uint32_t ip, uint32_t subnet, uint32_t mask);
+
+// Create platform network config
+struct pv_platform_network *pv_platform_network_new(pv_net_mode_t mode);
+
+// Free platform network config
+void pv_platform_network_free(struct pv_platform_network *net);
+
+// Add interface to platform network
+struct pv_platform_network_iface *
+pv_platform_network_add_iface(struct pv_platform_network *net, const char *name,
+			      const char *pool);
+
+#endif // PV_IPAM_H

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -71,6 +71,7 @@
 #include "pantahub/pantahub.h"
 
 #include "parser/parser.h"
+#include "ipam.h"
 
 #include "utils/timer.h"
 #include "utils/fs.h"
@@ -180,6 +181,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_state_t next_state = PV_STATE_ROLLBACK;
 	char *json = NULL;
 
+	// Initialize IPAM subsystem
+	pv_ipam_init();
+
 	// resume update if we are booting up to test a new revision
 	if (pv_update_resume(pv_pantahub_queue_progress)) {
 		pv_log(ERROR, "update could not be resumed");
@@ -238,6 +242,9 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	pv_update_set_factory();
 
 	pv_state_load_done(pv->state);
+
+	// Setup IPAM network bridges (must happen after state parsing)
+	pv_ipam_setup_bridges();
 
 	// once state is verified, we can load credentials, in case they are stored in a volume
 	if (!pv_update_get_state()) {

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -52,6 +52,7 @@
 #include "state.h"
 #include "pvlogger.h"
 #include "paths.h"
+#include "ipam.h"
 
 #include "utils/str.h"
 #include "utils/fs.h"
@@ -1398,6 +1399,106 @@ static int do_action_for_auto_recovery(struct json_key_action *jka, char *value)
 	return 0;
 }
 
+static int do_action_for_network(struct json_key_action *jka, char *value)
+{
+	struct platform_bundle *bundle = (struct platform_bundle *)jka->opaque;
+	struct pv_platform *p = *bundle->platform;
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *mode_str = NULL;
+	char *pool = NULL;
+	char *hostname = NULL;
+	char *static_ip = NULL;
+	char *static_mac = NULL;
+	char *buf = jka->buf;
+	pv_net_mode_t mode = NET_MODE_NONE;
+
+	if (!p || !buf)
+		return -1;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "wrong format network");
+		return -1;
+	}
+
+	// Check for mode first
+	mode_str = pv_json_get_value(buf, "mode", tokv, tokc);
+	if (mode_str) {
+		if (strcmp(mode_str, "host") == 0) {
+			mode = NET_MODE_HOST;
+		} else if (strcmp(mode_str, "pool") == 0) {
+			mode = NET_MODE_POOL;
+		}
+		free(mode_str);
+	}
+
+	// Check for pool (shorthand for single interface)
+	pool = pv_json_get_value(buf, "pool", tokv, tokc);
+	if (pool) {
+		mode = NET_MODE_POOL;
+	}
+
+	hostname = pv_json_get_value(buf, "hostname", tokv, tokc);
+	static_ip = pv_json_get_value(buf, "ip", tokv, tokc);
+	static_mac = pv_json_get_value(buf, "mac", tokv, tokc);
+
+	// Create network config for the platform
+	if (mode != NET_MODE_NONE) {
+		p->network = pv_platform_network_new(mode);
+		if (!p->network) {
+			pv_log(ERROR, "failed to create network config for %s",
+			       p->name);
+			ret = -1;
+			goto out;
+		}
+
+		if (hostname) {
+			p->network->hostname = strdup(hostname);
+		}
+
+		// If pool specified, create default eth0 interface
+		if (mode == NET_MODE_POOL && pool) {
+			struct pv_platform_network_iface *iface;
+			iface = pv_platform_network_add_iface(p->network,
+							      "eth0", pool);
+			if (!iface) {
+				pv_log(ERROR, "failed to add interface for %s",
+				       p->name);
+				ret = -1;
+				goto out;
+			}
+			// Set static overrides if provided
+			if (static_ip) {
+				iface->static_ip = strdup(static_ip);
+			}
+			if (static_mac) {
+				iface->static_mac = strdup(static_mac);
+			}
+			pv_log(DEBUG,
+			       "platform '%s' network: pool=%s, hostname=%s, ip=%s, mac=%s",
+			       p->name, pool, hostname ? hostname : "(none)",
+			       static_ip ? static_ip : "(auto)",
+			       static_mac ? static_mac : "(auto)");
+		} else if (mode == NET_MODE_HOST) {
+			pv_log(DEBUG, "platform '%s' network: mode=host",
+			       p->name);
+		}
+	}
+
+out:
+	if (pool)
+		free(pool);
+	if (hostname)
+		free(hostname);
+	if (static_ip)
+		free(static_ip);
+	if (static_mac)
+		free(static_mac);
+	if (tokv)
+		free(tokv);
+	return ret;
+}
+
 static int do_action_for_one_volume(struct json_key_action *jka, char *value)
 { /*
 	 * Opaque will contain the platform
@@ -1597,6 +1698,8 @@ static int parse_platform(struct pv_state *s, char *buf, int n)
 			      do_action_for_roles_array, false),
 		ADD_JKA_ENTRY("auto_recovery", JSMN_OBJECT, &bundle,
 			      do_action_for_auto_recovery, false),
+		ADD_JKA_ENTRY("network", JSMN_OBJECT, &bundle,
+			      do_action_for_network, false),
 		ADD_JKA_ENTRY("config", JSMN_STRING, &config, NULL, true),
 		ADD_JKA_ENTRY("share", JSMN_STRING, &shares, NULL, true),
 		ADD_JKA_ENTRY("root-volume", JSMN_STRING, &bundle,
@@ -2032,6 +2135,160 @@ out:
 	return this;
 }
 
+static int parse_network_pools(struct pv_state *s, char *buf)
+{
+	int tokc, size, ret = 1;
+	char *str = NULL;
+	jsmntok_t *tokv, *t, *poolv = NULL;
+	jsmntok_t **k, **keys;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network pools");
+		goto out;
+	}
+
+	// Get pool names (keys)
+	keys = jsmnutil_get_object_keys(buf, tokv);
+	if (!keys) {
+		pv_log(DEBUG, "no network pools defined");
+		ret = 0;
+		goto out;
+	}
+
+	k = keys;
+	while (*k) {
+		char *name, *type_str, *bridge, *parent, *subnet, *gateway;
+		char *nat_str;
+		pv_pool_type_t type;
+		bool nat;
+		int n, poolc;
+
+		n = (*k)->end - (*k)->start;
+
+		// Get pool name
+		name = malloc(n + 1);
+		snprintf(name, n + 1, "%s", buf + (*k)->start);
+
+		// Get pool value
+		n = (*k + 1)->end - (*k + 1)->start;
+		str = malloc(n + 1);
+		snprintf(str, n + 1, "%s", buf + (*k + 1)->start);
+
+		if (jsmnutil_parse_json(str, &poolv, &poolc) <= 0) {
+			pv_log(ERROR, "invalid pool entry for '%s'", name);
+			free(name);
+			free(str);
+			str = NULL;
+			goto out;
+		}
+
+		// Parse pool fields
+		type_str = pv_json_get_value(str, "type", poolv, poolc);
+		bridge = pv_json_get_value(str, "bridge", poolv, poolc);
+		parent = pv_json_get_value(str, "parent", poolv, poolc);
+		subnet = pv_json_get_value(str, "subnet", poolv, poolc);
+		gateway = pv_json_get_value(str, "gateway", poolv, poolc);
+		nat_str = pv_json_get_value(str, "nat", poolv, poolc);
+
+		// Determine pool type
+		if (type_str && strcmp(type_str, "macvlan") == 0)
+			type = POOL_TYPE_MACVLAN;
+		else
+			type = POOL_TYPE_BRIDGE;
+
+		// Parse NAT flag
+		nat = (nat_str && strcmp(nat_str, "true") == 0);
+
+		// Validate required fields
+		if (!subnet || !gateway) {
+			pv_log(ERROR, "pool '%s' missing subnet or gateway",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_BRIDGE && !bridge) {
+			pv_log(ERROR, "bridge pool '%s' missing bridge name",
+			       name);
+			goto free_pool;
+		}
+
+		if (type == POOL_TYPE_MACVLAN && !parent) {
+			pv_log(ERROR,
+			       "macvlan pool '%s' missing parent interface",
+			       name);
+			goto free_pool;
+		}
+
+		// Add pool to IPAM
+		if (!pv_ipam_add_pool(name, type,
+				      type == POOL_TYPE_BRIDGE ? bridge :
+								 parent,
+				      subnet, gateway, nat)) {
+			pv_log(ERROR, "failed to add pool '%s'", name);
+		} else {
+			pv_log(DEBUG, "added network pool '%s'", name);
+		}
+
+	free_pool:
+		if (type_str)
+			free(type_str);
+		if (bridge)
+			free(bridge);
+		if (parent)
+			free(parent);
+		if (subnet)
+			free(subnet);
+		if (gateway)
+			free(gateway);
+		if (nat_str)
+			free(nat_str);
+		if (poolv) {
+			free(poolv);
+			poolv = NULL;
+		}
+		free(name);
+		free(str);
+		str = NULL;
+
+		k++;
+	}
+	jsmnutil_tokv_free(keys);
+	ret = 0;
+
+out:
+	if (str)
+		free(str);
+	if (poolv)
+		free(poolv);
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
+static int parse_network(struct pv_state *s, char *buf)
+{
+	int tokc, ret = 0;
+	jsmntok_t *tokv;
+	char *pools_str = NULL;
+
+	if (jsmnutil_parse_json(buf, &tokv, &tokc) < 0) {
+		pv_log(ERROR, "cannot parse network section");
+		return -1;
+	}
+
+	pools_str = pv_json_get_value(buf, "pools", tokv, tokc);
+	if (pools_str) {
+		ret = parse_network_pools(s, pools_str);
+		free(pools_str);
+	}
+
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}
+
 static struct pv_state *parse_device(struct pv_state *this, char *buf)
 {
 	int tokc;
@@ -2089,12 +2346,22 @@ static struct pv_state *parse_device(struct pv_state *this, char *buf)
 	value = pv_json_get_value(buf, "volumes", tokv, tokc);
 	if (!value) {
 		pv_log(WARN, "volumes not defined in device.json");
-		goto out;
+	} else {
+		if (!parse_storage(this, NULL, value)) {
+			pv_log(ERROR, "cannot parse storage in device.json");
+			this = NULL;
+			goto out;
+		}
+		free(value);
+		value = NULL;
 	}
-	if (!parse_storage(this, NULL, value)) {
-		pv_log(ERROR, "cannot parse storage in device.json");
-		this = NULL;
-		goto out;
+
+	// Parse network pools (optional)
+	value = pv_json_get_value(buf, "network", tokv, tokc);
+	if (value) {
+		if (parse_network(this, value)) {
+			pv_log(WARN, "failed to parse network in device.json");
+		}
 	}
 
 out:

--- a/platforms.c
+++ b/platforms.c
@@ -58,6 +58,7 @@
 #include "utils/pvsignals.h"
 #include "utils/tsh.h"
 #include "utils/system.h"
+#include "ipam.h"
 
 #define MODULE_NAME "platforms"
 #define pv_log(level, msg, ...)                                                \
@@ -371,6 +372,20 @@ void pv_platform_free(struct pv_platform *p)
 
 	pv_platform_empty_logger_list(p);
 	pv_platform_empty_logger_configs(p);
+
+	// Release IPAM allocations for this platform
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+
+	if (p->network)
+		pv_platform_network_free(p->network);
 
 	free(p);
 }
@@ -1120,7 +1135,97 @@ int pv_platform_start(struct pv_platform *p)
 	timer_start(&p->timer_status_goal,
 		    p->group->default_status_goal_timeout, 0, RELATIV_TIMER);
 
+	// Allocate IPAM network resources if platform uses pool-based networking
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (!iface->pool)
+				continue;
+
+			struct pv_ip_pool *pool =
+				pv_ipam_find_pool(iface->pool);
+			if (!pool) {
+				pv_log(ERROR,
+				       "platform '%s' references unknown pool '%s', refusing to start",
+				       p->name, iface->pool);
+				goto ipam_error;
+			}
+
+			// Allocate or reserve IP from pool
+			char *ip = NULL;
+			if (iface->static_ip) {
+				// Use static IP - reserve it in the pool
+				if (pv_ipam_reserve(iface->pool, p->name,
+						    iface->static_ip) == 0) {
+					ip = strdup(iface->static_ip);
+					pv_log(DEBUG,
+					       "platform '%s' using static IP %s",
+					       p->name, ip);
+				} else {
+					pv_log(ERROR,
+					       "failed to reserve static IP %s for platform '%s' (already in use or outside subnet), refusing to start",
+					       iface->static_ip, p->name);
+					goto ipam_error;
+				}
+			} else {
+				// Allocate IP dynamically
+				ip = pv_ipam_allocate(iface->pool, p->name);
+				if (!ip) {
+					pv_log(ERROR,
+					       "failed to allocate IP for platform '%s' from pool '%s' (pool exhausted), refusing to start",
+					       p->name, iface->pool);
+					goto ipam_error;
+				}
+			}
+
+			// Store allocated info in interface struct
+			iface->ipv4_address = ip;
+			iface->ipv4_gateway = pv_ipam_ip_to_str(pool->gateway);
+			iface->bridge = strdup(pool->bridge);
+
+			// Use static MAC if provided, otherwise generate from IP
+			if (iface->static_mac) {
+				iface->mac_address = strdup(iface->static_mac);
+			} else {
+				struct pv_ip_lease *lease =
+					pv_ipam_get_lease(iface->pool, p->name);
+				iface->mac_address =
+					lease ? pv_ipam_generate_mac(
+							lease->ip) :
+						NULL;
+			}
+
+			pv_log(INFO, "platform '%s' IP %s MAC %s on bridge %s",
+			       p->name, iface->ipv4_address,
+			       iface->mac_address ? iface->mac_address : "auto",
+			       iface->bridge);
+		}
+	}
+
 	pv_log(DEBUG, "starting platform '%s'", p->name);
+
+	goto ipam_ok;
+
+ipam_error:
+	// Release any IPAM leases allocated for this platform before failing
+	if (p->network && p->network->mode == NET_MODE_POOL) {
+		struct pv_platform_network_iface *iface;
+		dl_list_for_each(iface, &p->network->interfaces,
+				 struct pv_platform_network_iface, list)
+		{
+			if (iface->pool)
+				pv_ipam_release(iface->pool, p->name);
+		}
+	}
+	pv_log(ERROR,
+	       "platform '%s' failed IPAM network validation, triggering rollback if in try-boot",
+	       p->name);
+	pv_platform_stop(p);
+	return -1;
+
+ipam_ok:
 
 	if (ctrl->start(p, s->rev, path, p->log.lxc_pipe[1], p->pipefd[1])) {
 		pv_log(ERROR, "could not start platform '%s'", p->name);

--- a/platforms.h
+++ b/platforms.h
@@ -31,6 +31,7 @@
 #include "utils/timer.h"
 
 #include "event/event_socket.h"
+#include "ipam.h"
 
 typedef enum {
 	PLAT_NONE,
@@ -173,6 +174,7 @@ struct pv_platform {
 	struct dl_list drivers; // pv_platform_driver
 	struct dl_list services; // pv_platform_service
 	struct dl_list service_exports; // pv_platform_service_export
+	struct pv_platform_network *network; // dynamic IPAM network config
 	struct dl_list list; // pv_platform
 	struct dl_list logger_list; // pv_log_info
 	/*

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -47,6 +47,7 @@
 #include "paths.h"
 #include "utils/pvsignals.h"
 #include "utils/system.h"
+#include "ipam.h"
 
 #define PV_VLOG __vlog
 #include "utils/tsh.h"
@@ -226,6 +227,106 @@ static char *inschr(char *path, int n, char chr, char *seed)
 	*(path + pl + sl + 1) = 0;
 
 	return path;
+}
+
+static void pv_setup_lxc_network(struct lxc_container *c, struct pv_platform *p)
+{
+	struct pv_platform_network_iface *iface;
+	int idx = 0;
+	char key[64], value[256];
+
+	if (!p->network || p->network->mode != NET_MODE_POOL)
+		return;
+
+	// Set hostname if configured
+	if (p->network->hostname) {
+		c->set_config_item(c, "lxc.uts.name", p->network->hostname);
+		pv_log(DEBUG, "set container hostname to '%s'",
+		       p->network->hostname);
+	}
+
+	// Configure each network interface
+	dl_list_for_each(iface, &p->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (!iface->ipv4_address || !iface->bridge) {
+			pv_log(WARN, "skipping interface without IP or bridge");
+			continue;
+		}
+
+		// Set interface type to veth
+		snprintf(key, sizeof(key), "lxc.net.%d.type", idx);
+		c->set_config_item(c, key, "veth");
+
+		// Link to bridge
+		snprintf(key, sizeof(key), "lxc.net.%d.link", idx);
+		c->set_config_item(c, key, iface->bridge);
+
+		// Set container-side interface name
+		snprintf(key, sizeof(key), "lxc.net.%d.name", idx);
+		c->set_config_item(c, key, iface->name ? iface->name : "eth0");
+
+		// Set IPv4 address
+		snprintf(key, sizeof(key), "lxc.net.%d.ipv4.address", idx);
+		c->set_config_item(c, key, iface->ipv4_address);
+
+		// Set gateway
+		if (iface->ipv4_gateway) {
+			snprintf(key, sizeof(key), "lxc.net.%d.ipv4.gateway",
+				 idx);
+			c->set_config_item(c, key, iface->ipv4_gateway);
+		}
+
+		// Set MAC address if available
+		if (iface->mac_address) {
+			snprintf(key, sizeof(key), "lxc.net.%d.hwaddr", idx);
+			c->set_config_item(c, key, iface->mac_address);
+		}
+
+		// Bring interface up
+		snprintf(key, sizeof(key), "lxc.net.%d.flags", idx);
+		c->set_config_item(c, key, "up");
+
+		pv_log(INFO, "configured net.%d: type=veth link=%s ip=%s gw=%s",
+		       idx, iface->bridge, iface->ipv4_address,
+		       iface->ipv4_gateway ? iface->ipv4_gateway : "none");
+
+		idx++;
+	}
+
+	// If we configured any interfaces, we need to remove 'net' from namespace.keep
+	// The container will get its own network namespace
+	if (idx > 0) {
+		// Check current namespace.keep setting and remove 'net' if present
+		char ns_keep[256] = { 0 };
+		c->get_config_item(c, "lxc.namespace.keep", ns_keep,
+				   sizeof(ns_keep));
+
+		if (strlen(ns_keep) > 0) {
+			// Remove 'net' from the list (values separated by newlines)
+			char new_ns_keep[256] = { 0 };
+			char *saveptr = NULL;
+			char *tok = strtok_r(ns_keep, " \t\n", &saveptr);
+			while (tok) {
+				if (strcmp(tok, "net") != 0) {
+					if (strlen(new_ns_keep) > 0)
+						strcat(new_ns_keep, "\n");
+					strcat(new_ns_keep, tok);
+				}
+				tok = strtok_r(NULL, " \t\n", &saveptr);
+			}
+			// Clear and set each namespace individually
+			c->clear_config_item(c, "lxc.namespace.keep");
+			char *ns_saveptr = NULL;
+			char *ns = strtok_r(new_ns_keep, "\n", &ns_saveptr);
+			while (ns) {
+				c->set_config_item(c, "lxc.namespace.keep", ns);
+				ns = strtok_r(NULL, "\n", &ns_saveptr);
+			}
+			pv_log(DEBUG,
+			       "updated lxc.namespace.keep (removed 'net')");
+		}
+	}
 }
 
 static void pv_setup_lxc_container(struct lxc_container *c,
@@ -410,6 +511,9 @@ static void pv_setup_lxc_container(struct lxc_container *c,
 		c->set_config_item(c, "lxc.hook.mount", path);
 	}
 	closedir(d);
+
+	// Configure IPAM network if platform has pool-based networking
+	pv_setup_lxc_network(c, p);
 }
 
 static void pv_setup_default_log(struct pv_platform *p, struct lxc_container *c,

--- a/state.c
+++ b/state.c
@@ -42,6 +42,7 @@
 #include "jsons.h"
 #include "addons.h"
 #include "pantavisor.h"
+#include "ipam.h"
 #include "storage.h"
 #include "metadata.h"
 #include "update/update.h"
@@ -785,6 +786,18 @@ static bool pv_state_check_auto_recovery(struct pv_state *s,
 				    RELATIV_TIMER);
 			pv_platform_set_recovering(p);
 		} else {
+			// Release any IPAM leases before restarting
+			if (p->network && p->network->mode == NET_MODE_POOL) {
+				struct pv_platform_network_iface *iface;
+				dl_list_for_each(
+					iface, &p->network->interfaces,
+					struct pv_platform_network_iface, list)
+				{
+					if (iface->pool)
+						pv_ipam_release(iface->pool,
+								p->name);
+				}
+			}
 			pv_platform_set_installed(p);
 		}
 		return true;


### PR DESCRIPTION
Stacked on #613 (`feature/ipam`). Retarget to master once #613 lands.

## Summary

Makes IPAM pools **isolated from each other by default**. Same-pool traffic and external NAT egress keep working exactly as before; cross-pool traffic is dropped at the kernel FORWARD chain. The design intent is that cross-pool service access go through xconnect's service mesh, matching how UDS / D-Bus / DRM / Wayland mediation already works and how the in-flight TCP/HTTP plugins in #616 extend the model to IP services.

## Implementation

New `setup_isolation()` in `ipam.c`, invoked from `pv_ipam_setup_bridges()` after all per-pool bridges and NAT rules are installed.

- Probes `command -v nft` / `command -v iptables` with the same pattern already used by `setup_nat`; prefers nftables, falls back to iptables, emits a clear warning if neither is available.
- nftables path: creates an `inet pv_ipam` filter table and a `forward` chain (hook forward, priority 0), installs `ct state related,established accept` once, then adds `iifname <A> oifname <B> drop` for every ordered pair of distinct bridge pools.
- iptables path: `-C … || -I 1` the conntrack prelude, then `-C … || -A` each `-i A -o B -j DROP` pair.
- Operations are idempotent — re-running (e.g. after a reconfigure) is safe.
- Short-circuits when fewer than two bridge-type pools exist, so single-pool setups are unchanged.

Same-pool traffic is L2-bridged and never hits FORWARD, so isolation is free there. External egress targets the uplink iface (not another pool bridge) and falls through to `POSTROUTING` MASQUERADE.

## Test plan

Verified on docker-x86_64-scarthgap with the two-pool setup from TESTPLAN-ipam.md (meta-pantavisor PR below):

- [x] nft ruleset shows `table inet pv_ipam { chain forward { … ct state established,related accept ; iifname "pvbr0" oifname "pvbr1" drop ; iifname "pvbr1" oifname "pvbr0" drop } }`
- [x] internal → own gateway 10.0.5.1 — 0% loss
- [x] internal → 8.8.8.8 (NAT path) — 0% loss
- [x] internal → lab 10.0.6.2 — **100% loss** (isolated)
- [x] lab → internal 10.0.5.2 — **100% loss** (isolated, reverse)
- [x] lab → own gateway 10.0.6.1 — 0% loss
- [x] IPAM log: `pool isolation (nftables): 2 cross-pool drop rule(s) installed`

Companion PR in meta-pantavisor bumps SRCREV and adds Test 5 covering this end-to-end.

## Out of scope (follow-ups)

- No opt-out flag on individual pools. If a setup ever legitimately needs cross-pool routing, adding `isolated: false` to the pool schema is a small delta.
- Cross-pool service reachability via xconnect TCP/HTTP plugins — PR #616 + the Stage B follow-up.