### PR TITLE
fix(update): keep pv_try set across failing tryboot reboot

### DIFF
--- a/update/update.c
+++ b/update/update.c
@@ -886,12 +886,16 @@ void pv_update_finish()
 	pv_log(DEBUG, "finishing update");
 
 	/*
-	 * Clear pv_try when the update reaches a final state.
-	 * This must happen here — not earlier — so the rolled-back
-	 * revision has a chance to detect and handle the rollback
-	 * (report to cloud, cleanup) before pv_try is removed.
+	 * Clear pv_try only on the rolled-back boot, after ERROR has been
+	 * recorded for the tried revision. Never clear it on the failing
+	 * revision itself: the bootloader still needs pv_try across the
+	 * upcoming reboot so it can drive the tryboot->fallback logic and
+	 * so the rolled-back revision can detect that it came up as a
+	 * rollback. pv_bootloader_trying_update() distinguishes the two:
+	 * it is true on the failing tryboot (pv_rev == pv_try) and false
+	 * on the rolled-back boot (pv_rev = old, pv_try = failed rev).
 	 */
-	if (pv_update_is_failed())
+	if (pv_update_is_failed() && !pv_bootloader_trying_update())
 		pv_bootloader_fail_update();
 
 	if (u->logserver_started)


### PR DESCRIPTION
## Summary

`pv_update_finish()` unconditionally cleared `pv_try` whenever the update was in a failed state. It runs on both:

1. The **failing tryboot revision** — via `pv_shutdown()` → `pv_update_finish()` just before the reboot that is supposed to trigger the bootloader's tryboot→fallback logic.
2. The **rolled-back boot** — via `pv_update_resume()` early-return paths after recording ERROR on disk.

Because (1) happened too, `pv_try` was wiped from the bootloader env **before** the reboot that needed it. Net effect on u-boot / ubootab / rpiab: after a failed tryboot, the next reboot saw no `pv_try`, looked like a normal boot of `pv_rev`, and no tryboot/fallback signalling reached the rolled-back revision.

The fix gates the clear on `!pv_bootloader_trying_update()`:

- **Failing tryboot boot**: `pv_rev == pv_try` → `trying_update() == true` → **do not clear**. The comment in `_pv_rollback()` (\`pantavisor.c\`) that says \"Do NOT clear pv_try here\" is now actually respected end-to-end.
- **Rolled-back boot**: `pv_rev = old, pv_try = failed rev` → `trying_update() == false` → clear after ERROR is recorded, as intended.

## Test plan

- [ ] Build and deploy a BSP image; install a revision that fails its status goal after the tryboot reboot; verify device rolls back to previous revision and `fw_printenv pv_try` is empty on the rolled-back boot.
- [ ] Inspect `/storage/boot/uboot.txt` immediately before the tryboot reboot and confirm `pv_try=<new-rev>` is still present (was being wiped before this fix).
- [ ] Verify that a successful tryboot still commits normally (`pv_rev` updated, `pv_try` cleared via the commit path in `pv_bootloader_pre_commit_update`).
- [ ] Verify a double-fault path: trigger a second unexpected reboot on the failing revision before pantavisor's shutdown completes; confirm `pv_try` survives and the bootloader still falls back on the next boot.