### PR TITLE
feat(pvtx): improve CLI help message and error reporting

### DIFF
--- a/pvtx/pvtx.c
+++ b/pvtx/pvtx.c
@@ -22,7 +22,6 @@
 
 #include "pvtx_txn.h"
 #include "pvtx_error.h"
-#include "utils/fs.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -53,20 +52,10 @@ struct commands {
 };
 
 #define PVTX_DIR_VAR "PVTXDIR"
-#define LOCAL_ERR(msg) local_err(__FILE__, __LINE__, msg)
 
 static struct commands normal = {
-	.names =
-		(const char *[]){
-			"begin",
-			"add",
-			"remove",
-			"abort",
-			"commit",
-			"show",
-			"deploy",
-			"help",
-		},
+	.names = (const char *[]){ "begin", "add", "remove", "abort", "commit",
+				   "show", "deploy", "help", "--help" },
 	.fn =
 		(const func[]){
 			cmd_begin,
@@ -77,8 +66,9 @@ static struct commands normal = {
 			cmd_show,
 			cmd_deploy,
 			cmd_help,
+			cmd_help,
 		},
-	.size = 8,
+	.size = 9,
 };
 
 static struct commands queue = {
@@ -99,13 +89,6 @@ static struct commands queue = {
 	.size = 4,
 };
 
-static void local_err(const char *file, int line, const char *msg)
-{
-	char bname[NAME_MAX] = { 0 };
-	pv_fs_basename(file, bname);
-	fprintf(stderr, "ERROR: %s\n(%s:%d)\n", msg, bname, line);
-}
-
 static int cmd_begin(int argc, char **argv)
 {
 	struct pv_pvtx_error err = { 0 };
@@ -122,14 +105,15 @@ static int cmd_begin(int argc, char **argv)
 
 	int ret = pv_pvtx_txn_begin(from, obj_path, &err);
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "begin");
 
 	return ret;
 }
 static int cmd_add(int argc, char **argv)
 {
 	if (argc < 3) {
-		LOCAL_ERR("missing argument, files or - is needed");
+		pv_pvtx_error_print_raw(
+			"add", "missing argument, file or - is needed");
 		return -1;
 	}
 
@@ -142,14 +126,14 @@ static int cmd_add(int argc, char **argv)
 		ret = pv_pvtx_txn_add_from_disk(argv[2], &err);
 
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "add");
 
 	return ret;
 }
 static int cmd_remove(int argc, char **argv)
 {
 	if (argc < 3) {
-		LOCAL_ERR("must remove a part, missing parameter");
+		pv_pvtx_error_print_raw("remove", "must supply a part name");
 		return 4;
 	}
 
@@ -157,7 +141,7 @@ static int cmd_remove(int argc, char **argv)
 	int ret = pv_pvtx_txn_remove(argv[2], &err);
 
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "remove");
 
 	return ret;
 }
@@ -166,7 +150,7 @@ static int cmd_abort(int argc, char **argv)
 	struct pv_pvtx_error err = { 0 };
 	int ret = pv_pvtx_txn_abort(&err);
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "abort");
 	return ret;
 }
 static int cmd_commit(int argc, char **argv)
@@ -174,10 +158,10 @@ static int cmd_commit(int argc, char **argv)
 	struct pv_pvtx_error err = { 0 };
 	char *rev = pv_pvtx_txn_commit(&err);
 	if (!rev) {
-		fprintf(stderr, "ERROR: %s\n", err.str);
-		free(rev);
+		pv_pvtx_error_print(&err, "commit");
 	} else {
 		printf("%s\n", rev);
+		free(rev);
 	};
 
 	return err.code;
@@ -187,7 +171,7 @@ static int cmd_show(int argc, char **argv)
 	struct pv_pvtx_error err = { 0 };
 	char *json = pv_pvtx_txn_get_json(&err);
 	if (!json) {
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "show");
 		return err.code;
 	}
 
@@ -199,7 +183,7 @@ static int cmd_show(int argc, char **argv)
 static int cmd_deploy(int argc, char **argv)
 {
 	if (argc < 3) {
-		LOCAL_ERR("missing deploy folder");
+		pv_pvtx_error_print_raw("deploy", "missing deploy folder");
 		return 1;
 	}
 
@@ -207,7 +191,7 @@ static int cmd_deploy(int argc, char **argv)
 	int ret = pv_pvtx_txn_deploy(argv[2], &err);
 
 	if (ret != 0) {
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "deploy");
 	}
 
 	return ret;
@@ -216,64 +200,133 @@ static int cmd_deploy(int argc, char **argv)
 static int cmd_help(int argc, char **argv)
 {
 	printf("Usage: %s COMMAND [SUB-COMMAND] args...\n\n", argv[0]);
+	printf("pvtx manages Pantavisor revision transactions. A transaction\n");
+	printf("starts with 'begin', is built up with 'add'/'remove', and is\n");
+	printf("finalized with either 'commit' (remote) or 'deploy' (local).\n\n");
+
 	printf("Commands:\n");
 
 	printf("  %-30s", "begin <base> [object]");
-	printf("Creates a new transaction.\n");
+	printf("Start a new transaction based on an existing revision.\n");
 	printf("%-32s%s\n", " ",
-	       "The first argument <base> could be a real revision,");
+	       "<base> can be \"current\" (copy state from the running Pantavisor");
 	printf("%-32s%s\n", " ",
-	       "\"current\" (use current rev) or \"empty\" (empty revision).");
+	       "via pv-ctrl), \"empty\" (start from a blank revision), or a path");
+	printf("%-32s%s\n", " ", "to a revision directory or state JSON file.");
 	printf("%-32s%s\n", " ",
-	       "Transactions created without an object_path are called remote");
+	       "If [object] is given, the transaction is local: objects are saved");
 	printf("%-32s%s\n", " ",
-	       "and its objects are sent directly to the pv-ctrl socket.");
-	printf("  %-30s", "add <file> or -");
-	printf("Adds a json or tarball to the current transaction.\n");
+	       "to that directory and finalized with 'deploy'. Without [object],");
 	printf("%-32s%s\n", " ",
-	       "Alternatively '-' could be used to read from stdin.");
+	       "the transaction is remote: objects are streamed to pv-ctrl and");
+	printf("%-32s%s\n", " ", "finalized with 'commit'.");
+
+	printf("  %-30s", "add <file | ->");
+	printf("Add a package to the current transaction.\n");
+	printf("%-32s%s\n", " ",
+	       "<file> can be a state JSON file or a gzip tarball containing a");
+	printf("%-32s%s\n", " ",
+	       "\"json\" descriptor and an \"objects/\" directory with content");
+	printf("%-32s%s\n", " ",
+	       "files named by their SHA-256 hash. Use '-' to read a tarball");
+	printf("%-32s%s\n", " ",
+	       "from stdin. For remote transactions, objects are uploaded to");
+	printf("%-32s%s\n", " ",
+	       "pv-ctrl directly; for local ones, saved to the object dir.");
+
 	printf("  %-30s", "remove <part>");
-	printf("Remove the given part from the revision.\n");
+	printf("Remove a named part (container/component) from the current\n");
+	printf("%-32s%s\n", " ", "transaction's state JSON.");
+
 	printf("  %-30s", "abort");
-	printf("Abort the current transaction.\n");
+	printf("Discard the current transaction, deleting the in-progress\n");
+	printf("%-32s%s\n", " ", "state JSON and transaction status file.");
+
 	printf("  %-30s", "commit");
-	printf("Commit transaction, valid only for remote transactions.\n");
+	printf("Finalize a remote transaction by sending the state JSON to\n");
+	printf("%-32s%s\n", " ",
+	       "Pantavisor via the pv-ctrl socket. Generates and prints a");
+	printf("%-32s%s\n", " ",
+	       "revision name (locals/pvtx-<timestamp>-<hash>-<rand>).");
+	printf("%-32s%s\n", " ",
+	       "Only valid for remote transactions (begun without [object]).");
+
 	printf("  %-30s", "show");
-	printf("Show the current state json.\n");
+	printf("Print the in-progress state JSON of the current transaction.\n");
+
 	printf("  %-30s", "deploy <directory>");
-	printf("Deploy the current transaction in the given directory.\n");
-	printf("  %-30s", "help");
-	printf("Show this help and ends.\n");
+	printf("Finalize a local transaction by writing the revision layout\n");
+	printf("%-32s%s\n", " ",
+	       "to <directory>. Creates .pvr/json, .pvr/config, hard-links");
+	printf("%-32s%s\n", " ",
+	       "objects from the object dir, and sets up .pv/ BSP links.");
+	printf("%-32s%s\n", " ",
+	       "Performs a safe atomic-like swap: the old directory is kept");
+	printf("%-32s%s\n", " ", "as <directory>.bak until deploy succeeds.");
+	printf("%-32s%s\n", " ",
+	       "Only valid for local transactions (begun with [object]).");
+
+	printf("  %-30s", "help | --help");
+	printf("Show this help message.\n");
+
 	printf("  %-30s", "queue <sub-command>");
-	printf("This command uses the queue mode and requires a sub-command.\n");
+	printf("Operate in queue mode, which records an ordered sequence of\n");
 	printf("%-32s%s\n", " ",
-	       "Queues creates a series of steps to be executed in the same order");
-	printf("%-32s%s\n", " ", "in which they were created.");
+	       "add/remove steps and replays them atomically in one 'process'");
+	printf("%-32s%s\n", " ",
+	       "call. Useful for batching multiple package updates together.");
 
-	printf("Queue Sub-commands:\n");
-	printf("  %-30s", "new <queue> [object]");
-	printf("Creates a new queue at queue and save objects at object.\n");
+	printf("\nQueue Sub-commands:\n");
+
+	printf("  %-30s", "new <queue> <object>");
+	printf("Initialize a new queue. <queue> is the directory where step\n");
+	printf("%-32s%s\n", " ",
+	       "files are stored in order; <object> is the directory where");
+	printf("%-32s%s\n", " ", "unpacked content objects will be saved.");
+
 	printf("  %-30s", "remove <part>");
-	printf("Add a remove instruction for the given part in the current queue.\n");
-	printf("  %-30s", "unpack <tarball> or -");
-	printf("Unpack the given tarball from file or from stdin (if - is used).\n");
-	printf("  %-30s", "process [base] [queue] [obj]");
-	printf("Process the current queue.\n");
+	printf("Schedule a remove step for <part> in the current queue.\n");
 	printf("%-32s%s\n", " ",
-	       "base : use a specific revision, \"current\" or \"empty\" as base");
-	printf("%-32s%s\n", " ",
-	       "queue: define the queue path. Implicit call to queue new");
-	printf("%-32s%s\n", " ",
-	       "obj  : define the object path. Needed if the queue argument is used.");
+	       "Creates a numbered .remove marker that 'queue process' will");
+	printf("%-32s%s\n", " ", "apply in sequence.");
 
-	printf("Environment Variables:\n");
+	printf("  %-30s", "unpack <tarball|->");
+	printf("Stage a package into the current queue. Extracts the state\n");
+	printf("%-32s%s\n", " ",
+	       "JSON descriptor and saves objects to the object directory.");
+	printf("%-32s%s\n", " ",
+	       "Each call adds a numbered step entry. Use '-' for stdin.");
+
+	printf("  %-30s", "process [base [queue obj]]");
+	printf("Replay all queued steps in order to build a final revision.\n");
+	printf("%-32s%s\n", " ",
+	       "Applies add directories and .remove markers alphabetically.");
+	printf("%-32s%s\n", " ",
+	       "base : revision to start from (\"current\", \"empty\", or path).");
+	printf("%-32s%s\n", " ",
+	       "queue: queue directory path; implicitly calls 'queue new'");
+	printf("%-32s%s\n", " ",
+	       "       when provided (requires obj to be set as well).");
+	printf("%-32s%s\n", " ",
+	       "obj  : object directory path; required when queue is given.");
+	printf("%-32s%s\n", " ",
+	       "When called with no arguments, resumes the active queue and");
+	printf("%-32s%s\n", " ", "active transaction.");
+
+	printf("\nEnvironment Variables:\n");
 	printf("  %-30s", "PVTXDIR");
-	printf("Temporary directory where PVTX store transaction related data\n");
+	printf("Directory where pvtx stores transaction state (status file\n");
+	printf("%-32s%s\n", " ",
+	       "and current.json). Default (root): /var/cache/pvtx");
+	printf("%-32s%s\n", " ",
+	       "Default (user): ~/.local/share/pvtx");
 	printf("  %-30s", "PVTX_OBJECT_BUF_SIZE");
-	printf("Size of the buffer used to save objects. Min 512B max 10485760B (10M)\n");
+	printf("I/O buffer size for reading/writing object files.\n");
+	printf("%-32s%s\n", " ",
+	       "Min 512B, max 10485760B (10M). Default: 512B.");
 	printf("  %-30s", "PVTX_CTRL_BUF_SIZE");
-	printf("Size of the buffer used to get and post data to pv-ctrl.\n");
-	printf("%-32s%s\n", " ", "Min 16384B (16K) max 10485760B (10M)\n");
+	printf("I/O buffer size for communicating with pv-ctrl socket.\n");
+	printf("%-32s%s\n", " ", "Min 16384B (16K), max 10485760B (10M).\n");
 
 	return 0;
 }
@@ -281,10 +334,12 @@ static int cmd_help(int argc, char **argv)
 static int cmd_queue_new(int argc, char **argv)
 {
 	if (argc < 4) {
-		LOCAL_ERR("queue argument is required");
+		pv_pvtx_error_print_raw("queue new",
+					"queue argument is required");
 		return 1;
 	} else if (argc < 5) {
-		LOCAL_ERR("objects argument is required");
+		pv_pvtx_error_print_raw("queue new",
+					"objects argument is required");
 		return 1;
 	}
 
@@ -292,28 +347,31 @@ static int cmd_queue_new(int argc, char **argv)
 
 	int ret = pv_pvtx_queue_new(argv[3], argv[4], &err);
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "queue new");
 
 	return ret;
 }
 static int cmd_queue_remove(int argc, char **argv)
 {
 	if (argc < 4) {
-		LOCAL_ERR("missing argument 'part'");
+		pv_pvtx_error_print_raw("queue remove",
+					"missing argument 'part'");
 		return 1;
 	}
 
 	struct pv_pvtx_error err = { 0 };
 	int ret = pv_pvtx_queue_remove(argv[3], &err);
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "queue remove");
 
 	return ret;
 }
 static int cmd_queue_unpack(int argc, char **argv)
 {
 	if (argc < 4) {
-		LOCAL_ERR("missing argument, file or - is required");
+		pv_pvtx_error_print_raw(
+			"queue unpack",
+			"missing argument, file or - is required");
 		return 1;
 	}
 
@@ -326,7 +384,7 @@ static int cmd_queue_unpack(int argc, char **argv)
 		ret = pv_pvtx_queue_unpack_from_disk(argv[3], &err);
 
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "queue unpack");
 
 	return ret;
 }
@@ -348,7 +406,7 @@ static int cmd_queue_process(int argc, char **argv)
 	int ret = pv_pvtx_queue_process(var[0], var[1], var[2], &err);
 
 	if (ret != 0)
-		fprintf(stderr, "ERROR: %s\n", err.str);
+		pv_pvtx_error_print(&err, "queue process");
 
 	return ret;
 }
@@ -364,7 +422,6 @@ static int pv_pvtx_process_args(int argc, char **argv)
 	struct commands *cmd = &normal;
 
 	if (!strlen(op)) {
-		LOCAL_ERR("empty command");
 		cmd_help(argc, argv);
 		exit(1);
 	}
@@ -383,10 +440,10 @@ static int pv_pvtx_process_args(int argc, char **argv)
 		return err;
 	}
 
-	char e[256] = { 0 };
-	snprintf(e, 256, "command not found: %s", op);
-
-	LOCAL_ERR(e);
+	pv_pvtx_error_print_raw("command process",
+				"sub command not found: %s\nplease use 'help' "
+				"to find the right sub command",
+				op);
 
 	return -1;
 }

--- a/pvtx/pvtx_ctrl.c
+++ b/pvtx/pvtx_ctrl.c
@@ -80,12 +80,12 @@ int socket_wait(struct pv_pvtx_ctrl *ctrl, int events)
 	int res = poll(fds, 1, 10000);
 
 	if (res < 0) {
-		PVTX_ERROR_SET(&ctrl->error, errno, "poll failed: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(&ctrl->error, errno, "poll failed: %s",
+				  strerror(errno));
 		return -1;
 	} else if (res == 0) {
-		PVTX_ERROR_SET(&ctrl->error, -1,
-			       "couldn't get server response, timeout! (10s)");
+		pv_pvtx_error_set(&ctrl->error, -1,
+				  "pv-ctrl did not respond within 10 seconds");
 		return -1;
 	}
 
@@ -98,7 +98,7 @@ struct pv_pvtx_buffer *get_buffer(struct pv_pvtx_error *err)
 		pv_pvtx_buffer_from_env(PVTX_CTRL_BUFF_ENV, PVTX_CTRL_BUFF_MIN,
 					PVTX_CTRL_BUFF_MAX, 512);
 	if (!buf && err)
-		PVTX_ERROR_SET(err, -1, "couldn't get buffer");
+		pv_pvtx_error_set(err, -1, "couldn't get buffer");
 
 	return buf;
 }
@@ -140,9 +140,10 @@ void pv_pvtx_ctrl_free(struct pv_pvtx_ctrl *ctrl)
 	free(ctrl);
 }
 
-static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path)
+static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path,
+			struct pv_pvtx_error *err)
 {
-	pv_pvtx_error_clear(&ctrl->error);
+	pv_pvtx_error_clear(err);
 
 	if (!path) {
 		// checking both paths
@@ -151,8 +152,10 @@ static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path)
 		else if (pv_fs_path_exist(PVTX_CTRL_CONTAINER_SOCK))
 			path = PVTX_CTRL_CONTAINER_SOCK;
 		else {
-			PVTX_ERROR_SET(&ctrl->error, -1,
-				       "couldn't locate socket");
+			pv_pvtx_error_set(
+				err, -1,
+				"pv-ctrl socket not found (tried /pv/pv-ctrl and "
+				"/pantavisor/pv-ctrl)");
 			return -1;
 		}
 	}
@@ -172,8 +175,9 @@ static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path)
 			AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
 
 		if (ctrl->sock < 0) {
-			PVTX_ERROR_SET(&ctrl->error, errno,
-				       "couldn't open socket");
+			pv_pvtx_error_set(err, errno,
+					  "failed to create client socket: %s",
+					  strerror(errno));
 			return -1;
 		}
 
@@ -189,21 +193,24 @@ static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path)
 	} while (!ok && retries > 0);
 
 	if (!ok || ctrl->sock < 0) {
-		PVTX_ERROR_SET(&ctrl->error, -1,
-			       "couldn't connect, all atteps failed");
+		pv_pvtx_error_set(
+			err, -1,
+			"failed to connect to pv-ctrl (%s) after 5 attempts: %s",
+			path, strerror(errno));
 		return -1;
 	}
 
 	return 0;
 }
 
-struct pv_pvtx_ctrl *pv_pvtx_ctrl_new(const char *path)
+struct pv_pvtx_ctrl *pv_pvtx_ctrl_new(const char *path,
+				      struct pv_pvtx_error *err)
 {
 	struct pv_pvtx_ctrl *ctrl = calloc(1, sizeof(struct pv_pvtx_ctrl));
 	if (!ctrl)
 		return NULL;
 
-	if (connect_sock(ctrl, path) != 0) {
+	if (connect_sock(ctrl, path, err) != 0) {
 		free(ctrl);
 		return NULL;
 	}
@@ -220,8 +227,8 @@ static int send_header(struct pv_pvtx_ctrl *ctrl,
 
 	char *head_str = header_to_str(head);
 	if (!head_str) {
-		PVTX_ERROR_SET(&ctrl->error, -1,
-			       "couldn't allocate header string");
+		pv_pvtx_error_set(&ctrl->error, -1,
+				  "couldn't allocate header string");
 		return -1;
 	}
 	pv_fs_file_write_nointr(ctrl->sock, head_str, strlen(head_str));
@@ -252,8 +259,8 @@ static void check_error(struct pv_pvtx_buffer *buf, struct pv_pvtx_error *err)
 
 	const char *ptr = strchr(buf->data, ' ');
 	if (!ptr) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't parse header, error check failed");
+		pv_pvtx_error_set(err, -1,
+				  "couldn't parse header, error check failed");
 		return;
 	}
 
@@ -267,7 +274,7 @@ static void check_error(struct pv_pvtx_buffer *buf, struct pv_pvtx_error *err)
 
 	char *end = strstr(buf->data, "\r\n");
 	if (!end) {
-		PVTX_ERROR_SET(err, -1, "couldn't parse header");
+		pv_pvtx_error_set(err, -1, "couldn't parse header");
 		return;
 	}
 
@@ -278,12 +285,12 @@ static void check_error(struct pv_pvtx_buffer *buf, struct pv_pvtx_error *err)
 
 	char *error_str = NULL;
 	if (asprintf(&error_str, "%s\nResponse: %s", base_err, ptr) == -1) {
-		PVTX_ERROR_SET(err, -1, "couldn't get the complete err: %s",
-			       base_err);
+		pv_pvtx_error_set(err, -1, "couldn't get the complete err: %s",
+				  base_err);
 		return;
 	}
 
-	PVTX_ERROR_SET(err, -code, error_str);
+	pv_pvtx_error_set(err, -code, error_str);
 	free(error_str);
 }
 
@@ -329,8 +336,8 @@ static struct pv_pvtx_buffer *read_data(struct pv_pvtx_ctrl *ctrl)
 		return NULL;
 
 	if (!(revents & POLLIN)) {
-		PVTX_ERROR_SET(&ctrl->error, errno, "poll error: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(&ctrl->error, errno, "poll error: %s",
+				  strerror(errno));
 		goto out;
 	}
 
@@ -347,14 +354,14 @@ static struct pv_pvtx_buffer *read_data(struct pv_pvtx_ctrl *ctrl)
 	if (!pos)
 		goto out;
 
-	size_t header_size = pos + 4 - (char*)buf->data;
+	size_t header_size = pos + 4 - (char *)buf->data;
 	size_t body_read = cur_read - header_size;
 	size_t total = len + header_size;
 
 	if (cur_read < total) {
 		if (pv_pvtx_buffer_realloc(buf, total + 1) != 0) {
-			PVTX_ERROR_SET(&ctrl->error, -1,
-				       "couldn't reallocate buffer");
+			pv_pvtx_error_set(&ctrl->error, -1,
+					  "couldn't reallocate buffer");
 			goto out;
 		}
 
@@ -434,7 +441,7 @@ int pv_pvtx_ctrl_obj_put(struct pv_pvtx_ctrl *ctrl,
 	struct pv_pvtx_buffer *buf = get_buffer(&ctrl->error);
 
 	if (!buf) {
-		PVTX_ERROR_SET(&ctrl->error, -1, "couldn't allocate buffer");
+		pv_pvtx_error_set(&ctrl->error, -1, "couldn't allocate buffer");
 		return -1;
 	}
 
@@ -448,8 +455,8 @@ int pv_pvtx_ctrl_obj_put(struct pv_pvtx_ctrl *ctrl,
 			return -1;
 
 		if (!(revents & POLLOUT)) {
-			PVTX_ERROR_SET(&ctrl->error, errno, "poll error: %s",
-				       strerror(errno));
+			pv_pvtx_error_set(&ctrl->error, errno, "poll error: %s",
+					  strerror(errno));
 			return -1;
 		}
 

--- a/pvtx/pvtx_ctrl.h
+++ b/pvtx/pvtx_ctrl.h
@@ -34,7 +34,8 @@ struct pv_pvtx_ctrl {
 	struct pv_pvtx_error error;
 };
 
-struct pv_pvtx_ctrl *pv_pvtx_ctrl_new(const char *path);
+struct pv_pvtx_ctrl *pv_pvtx_ctrl_new(const char *path,
+				      struct pv_pvtx_error *err);
 void pv_pvtx_ctrl_free(struct pv_pvtx_ctrl *ctrl);
 char *pv_pvtx_ctrl_steps_get(struct pv_pvtx_ctrl *ctrl, const char *rev,
 			     size_t *size);

--- a/pvtx/pvtx_error.c
+++ b/pvtx/pvtx_error.c
@@ -1,30 +1,24 @@
 #include "pvtx_error.h"
-#include "utils/fs.h"
 
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <linux/limits.h>
 
-void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *file,
-		       int line, const char *tmpl, ...)
+static void set_error(struct pv_pvtx_error *err, int code, const char *tmpl, va_list list)
 {
 	pv_pvtx_error_clear(err);
+	vsnprintf(err->str, PV_PVTX_ERROR_MAX_LEN, tmpl, list);
+	err->code = code;
+}
 
+void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *tmpl,
+		       ...)
+{
 	va_list list;
 	va_start(list, tmpl);
-	int len = vsnprintf(err->str, PV_PVTX_ERROR_MAX_LEN, tmpl, list);
+	set_error(err, code, tmpl, list);
 	va_end(list);
-
-	if (file && len < PV_PVTX_ERROR_MAX_LEN) {
-		char bname[NAME_MAX] = { 0 };
-		pv_fs_basename(file, bname);
-
-		snprintf(err->str + len, PV_PVTX_ERROR_MAX_LEN - len,
-			 "\n(%s:%d)", bname, line);
-	}
-
-	err->code = code;
 }
 
 void pv_pvtx_error_clear(struct pv_pvtx_error *err)
@@ -32,8 +26,7 @@ void pv_pvtx_error_clear(struct pv_pvtx_error *err)
 	memset(err, 0, sizeof(struct pv_pvtx_error));
 }
 
-void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *file,
-			   int line, const char *tmpl, ...)
+void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *tmpl, ...)
 {
 	char old_buf[PV_PVTX_ERROR_MAX_LEN] = { 0 };
 	memccpy(old_buf, err->str, '\0', PV_PVTX_ERROR_MAX_LEN);
@@ -44,6 +37,21 @@ void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *file,
 	vsnprintf(new_buf, PV_PVTX_ERROR_MAX_LEN, tmpl, list);
 	va_end(list);
 
-	pv_pvtx_error_set(err, err->code, file, line, "%s: %s", new_buf,
-			  old_buf);
+	pv_pvtx_error_set(err, err->code, "%s;\n%s", new_buf, old_buf);
+}
+
+void pv_pvtx_error_print(struct pv_pvtx_error *err, const char *name)
+{
+	fprintf(stderr, "ERROR: %s: %s\n", name, err->str);
+}
+
+void pv_pvtx_error_print_raw(const char *name, const char *tmpl, ...)
+{
+	struct pv_pvtx_error err = {0};
+	va_list list;
+	va_start(list, tmpl);
+	set_error(&err, -1, tmpl, list);
+	va_end(list);
+
+	pv_pvtx_error_print(&err, name);
 }

--- a/pvtx/pvtx_error.h
+++ b/pvtx/pvtx_error.h
@@ -29,17 +29,12 @@ struct pv_pvtx_error {
 	char str[PV_PVTX_ERROR_MAX_LEN];
 };
 
-#define PVTX_ERROR_SET(err, code, tmpl, ...)                                   \
-	pv_pvtx_error_set(err, code, __FILE__, __LINE__, tmpl, ##__VA_ARGS__)
-
-#define PVTX_ERROR_PREPEND(err, tmpl, ...)                                     \
-	pv_pvtx_error_prepend(err, __FILE__, __LINE__, tmpl, ##__VA_ARGS__)
-
-void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *file,
-		       int line, const char *tmpl, ...);
+void pv_pvtx_error_set(struct pv_pvtx_error *err, int code, const char *tmpl,
+		       ...);
 void pv_pvtx_error_clear(struct pv_pvtx_error *err);
 
-void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *file,
-			   int line, const char *tmpl, ...);
+void pv_pvtx_error_prepend(struct pv_pvtx_error *err, const char *tmpl, ...);
+void pv_pvtx_error_print(struct pv_pvtx_error *err, const char *name);
+void pv_pvtx_error_print_raw(const char *name, const char *tmpl, ...);
 
 #endif

--- a/pvtx/pvtx_state.c
+++ b/pvtx/pvtx_state.c
@@ -305,9 +305,9 @@ static int get_all_patterns(struct pv_pvtx_state *st,
 			int name_len = 0;
 			const char *name =
 				token_to_str(st, keys->data.i[i], &name_len);
-			PVTX_ERROR_SET(err, -1,
-				       "couldn't decrypt %.*s signature",
-				       name_len, name);
+			pv_pvtx_error_set(err, -1,
+					  "couldn't decrypt %.*s signature",
+					  name_len, name);
 
 			return -1;
 		}
@@ -343,7 +343,7 @@ struct pv_pvtx_state *pv_pvtx_state_from_str(const char *str, size_t len,
 	priv->tok.data.t = pv_pvtx_jsmn_parse_data(str, len, &priv->tok.size);
 	if (!priv->tok.data.t) {
 		if (err)
-			PVTX_ERROR_SET(err, -1, "couldn't parse json data");
+			pv_pvtx_error_set(err, -1, "couldn't parse json data");
 		goto error;
 	}
 	priv->tok.has_str = false;

--- a/pvtx/pvtx_tar.c
+++ b/pvtx/pvtx_tar.c
@@ -117,7 +117,8 @@ int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con)
 	pv_pvtx_error_clear(&tar->err);
 
 	if (read_remaining_bytes(tar, con) != 0) {
-		PVTX_ERROR_SET(&tar->err, -1, "couldn't read remaining bytes");
+		pv_pvtx_error_set(&tar->err, -1,
+				  "couldn't read remaining bytes");
 		return -1;
 	}
 
@@ -125,12 +126,12 @@ int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con)
 	ssize_t size = read_nointr(tar->priv, &meta, PVTX_TAR_BLOCK_SIZE);
 
 	if (size < PVTX_TAR_BLOCK_SIZE) {
-		PVTX_ERROR_SET(&tar->err, -1, "couldn't read header");
+		pv_pvtx_error_set(&tar->err, -1, "couldn't read header");
 		return -1;
 	}
 
 	if (strncmp(meta.magic, "ustar", strlen("ustar"))) {
-		PVTX_ERROR_SET(&tar->err, -1, "ustar not found");
+		pv_pvtx_error_set(&tar->err, -1, "ustar not found");
 		return -1;
 	}
 
@@ -138,9 +139,8 @@ int pv_pvtx_tar_next(struct pv_pvtx_tar *tar, struct pv_pvtx_tar_content *con)
 	get_name(tar, &meta, con->name);
 
 	con->size = strtoll(meta.size, NULL, 8);
-	con->cap = con->size == 0
-			   ? 0
-			   : (con->size | (PVTX_TAR_BLOCK_SIZE - 1)) + 1;
+	con->cap = con->size == 0 ? 0 :
+				    (con->size | (PVTX_TAR_BLOCK_SIZE - 1)) + 1;
 	if (!con->priv)
 		con->priv = tar->priv;
 	con->read = 0;
@@ -210,9 +210,9 @@ static enum pv_pvtx_tar_type imp_from_file(int fd, struct pv_pvtx_error *err)
 		char *e = NULL;
 		if (errno == ESPIPE) {
 			e = "type cannot be obtained from a no seekable fd: %s";
-			PVTX_ERROR_SET(err, errno, e, strerror(errno));
+			pv_pvtx_error_set(err, errno, e, strerror(errno));
 		} else {
-			PVTX_ERROR_SET(err, errno, "%s", strerror(errno));
+			pv_pvtx_error_set(err, errno, "%s", strerror(errno));
 		}
 		return type;
 	}
@@ -238,10 +238,10 @@ enum pv_pvtx_tar_type pv_pvtx_tar_type_get(const char *path,
 	pv_pvtx_error_clear(err);
 	int fd = open(path, O_RDONLY);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "imposible to check the file type, "
-			       "couldn't open file %s",
-			       path);
+		pv_pvtx_error_set(err, -1,
+				  "imposible to check the file type, "
+				  "couldn't open file %s",
+				  path);
 		return PVTX_TAR_UNKNOWN;
 	}
 
@@ -260,14 +260,14 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_fd(int fd, enum pv_pvtx_tar_type type,
 
 	struct pv_pvtx_tar *tar = calloc(1, sizeof(struct pv_pvtx_tar));
 	if (!tar) {
-		PVTX_ERROR_SET(err, errno, "couldn't allocate tar object");
+		pv_pvtx_error_set(err, errno, "couldn't allocate tar object");
 		return NULL;
 	}
 
 	tar->priv = calloc(1, sizeof(struct pv_pvtx_tar_priv));
 	if (!tar->priv) {
-		PVTX_ERROR_SET(&tar->err, -1,
-			       "couldn't allocate implementation");
+		pv_pvtx_error_set(&tar->err, -1,
+				  "couldn't allocate implementation");
 		goto err;
 	}
 
@@ -296,8 +296,8 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_fd(int fd, enum pv_pvtx_tar_type type,
 
 	priv->imp_data = priv->imp->from_fd(fd);
 	if (!priv->imp_data) {
-		PVTX_ERROR_SET(err, errno,
-			       "couldn't initialize format implementation");
+		pv_pvtx_error_set(err, errno,
+				  "couldn't initialize format implementation");
 		goto err;
 	}
 
@@ -317,10 +317,10 @@ struct pv_pvtx_tar *pv_pvtx_tar_from_path(const char *path,
 	errno = 0;
 	int fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't create struct pv_pvtx_tar, "
-			       " open file %s error: %s",
-			       path, strerror(errno));
+		pv_pvtx_error_set(err, -1,
+				  "couldn't create struct pv_pvtx_tar, "
+				  " open file %s error: %s",
+				  path, strerror(errno));
 		return NULL;
 	}
 

--- a/pvtx/pvtx_txn.c
+++ b/pvtx/pvtx_txn.c
@@ -47,10 +47,13 @@
 #include <linux/limits.h>
 #include <sys/random.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 #define PVTX_TXN_PATH "PVTXDIR"
 #define PVTX_TXN_PREFIX_PATH "PREFIX"
-#define PVTX_TXN_DEFAULT_PATH "/var/pvr-sdk/pvtx"
+#define PVTX_TXN_DEFAULT_PATH_ROOT "/var/cache/pvtx"
+#define PVTX_TXN_DEFAULT_PATH_USER ".local/share/pvtx"
 #define PVTX_TXN_FILE ".status"
 #define PVTX_TXN_JSON "current.json"
 #define PVTX_TXN_DST_CONFIG ".pvr/config"
@@ -98,11 +101,30 @@ static const char *get_pvtxdir(void)
 		return pvtxdir_cache;
 	}
 
-	char *pfx = getenv(PVTX_TXN_PREFIX_PATH);
-	if (pfx)
-		pv_fs_path_concat(pvtxdir_cache, 2, pfx, PVTX_TXN_DEFAULT_PATH);
-	else
-		memccpy(pvtxdir_cache, PVTX_TXN_DEFAULT_PATH, '\0', PATH_MAX);
+	if (getuid() == 0) {
+		char *pfx = getenv(PVTX_TXN_PREFIX_PATH);
+		if (pfx)
+			pv_fs_path_concat(pvtxdir_cache, 2, pfx,
+					  PVTX_TXN_DEFAULT_PATH_ROOT);
+		else
+			memccpy(pvtxdir_cache, PVTX_TXN_DEFAULT_PATH_ROOT,
+				'\0', PATH_MAX);
+	} else {
+		char *home = getenv("HOME");
+		if (!home) {
+			struct passwd *pw = getpwuid(getuid());
+			if (pw)
+				home = pw->pw_dir;
+		}
+		if (home)
+			pv_fs_path_concat(pvtxdir_cache, 2, home,
+					  PVTX_TXN_DEFAULT_PATH_USER);
+		else
+			memccpy(pvtxdir_cache, PVTX_TXN_DEFAULT_PATH_ROOT,
+				'\0', PATH_MAX);
+	}
+
+	pv_fs_mkdir_p(pvtxdir_cache, 0755);
 
 	return pvtxdir_cache;
 }
@@ -202,20 +224,20 @@ static int write_object_from_content(const char *path,
 	char tmp[PATH_MAX] = { 0 };
 	int fd = pv_fs_file_tmp(path, tmp);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't create temp file for %s, object %s "
-			       "will not be written",
-			       path, con->name);
+		pv_pvtx_error_set(err, -1,
+				  "couldn't create temp file for %s, object %s "
+				  "will not be written",
+				  path, con->name);
 		return -1;
 	}
 
 	int ret = -1;
 	struct pv_pvtx_buffer *buf = get_buffer();
 	if (!buf) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't allocate buffer, object %s "
-			       "will not be written",
-			       con->name);
+		pv_pvtx_error_set(err, -1,
+				  "couldn't allocate buffer, object %s "
+				  "will not be written",
+				  con->name);
 		goto out;
 	}
 
@@ -234,10 +256,10 @@ static int write_object_from_content(const char *path,
 	}
 
 	if (rename(tmp, path) != 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't move temp file, object %s"
-			       "will not be written",
-			       con->name);
+		pv_pvtx_error_set(err, -1,
+				  "couldn't move temp file, object %s"
+				  "will not be written",
+				  con->name);
 
 		remove(tmp);
 		goto out;
@@ -278,18 +300,27 @@ static int init_state_json(const char *from, struct pv_pvtx_error *err)
 	char *json = NULL;
 	size_t json_len = 0;
 	struct pv_pvtx_state *st = NULL;
-	const char *err_msg = "couldn't initialize json with %s: %s";
 
 	pv_pvtx_error_clear(err);
 
 	if (!strncmp(from, "current", strlen("current"))) {
-		struct pv_pvtx_ctrl *ctrl = pv_pvtx_ctrl_new(NULL);
+		struct pv_pvtx_ctrl *ctrl = pv_pvtx_ctrl_new(NULL, err);
 		if (!ctrl) {
-			PVTX_ERROR_SET(err, -1, err_msg, from,
-				       "pv-ctrl connection error");
+			pv_pvtx_error_prepend(
+				err,
+				"failed to connect to pv-ctrl to read the "
+				"current revision state;\nmake sure Pantavisor "
+				"is running and the pv-ctrl socket is available\n"
+				"or check the 'help' command if you are looking "
+				"other ways to start a transaction");
 			goto out;
 		}
 		json = pv_pvtx_ctrl_steps_get(ctrl, "current", &json_len);
+		if (!json)
+			pv_pvtx_error_set(
+				err, -1,
+				"connected to pv-ctrl but failed to "
+				"retrieve the current revision state");
 		pv_pvtx_ctrl_free(ctrl);
 		goto out;
 
@@ -299,15 +330,18 @@ static int init_state_json(const char *from, struct pv_pvtx_error *err)
 	} else {
 		char *loc = find_json(from);
 		if (!loc) {
-			PVTX_ERROR_SET(err, -1, err_msg, from,
-				       "trail location error");
+			pv_pvtx_error_set(
+				err, -1,
+				"no state JSON found at '%s'; expected "
+				"a revision directory or a json file",
+				from);
 			goto out;
 		}
 
 		st = pv_pvtx_state_from_file(loc, err);
 
 		if (!st)
-			PVTX_ERROR_PREPEND(err, "error loding %s", loc);
+			pv_pvtx_error_prepend(err, "error loading '%s'", loc);
 
 		free(loc);
 
@@ -320,9 +354,10 @@ out:
 	if (json) {
 		pv_fs_file_write_no_sync(get_json_path(), json, json_len);
 		free(json);
-	} else {
-		PVTX_ERROR_SET(err, -1, err_msg, from,
-			       "error creating state json");
+	} else if (err->code == 0) {
+		pv_pvtx_error_set(
+			err, -1,
+			"failed to initialize revision state from '%s'", from);
 	}
 
 	return err->code;
@@ -347,19 +382,19 @@ static int save_state_json(struct pv_pvtx_state *st, struct pv_pvtx_error *err)
 	char tmp[PATH_MAX] = { 0 };
 	int fd = pv_fs_file_tmp(get_json_path(), tmp);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, fd, "error creating temp file");
+		pv_pvtx_error_set(err, fd, "error creating temp file");
 		goto out;
 	}
 	close(fd);
 
 	if (pv_fs_file_write_no_sync(tmp, st->json, st->len) != 0) {
-		PVTX_ERROR_SET(err, -1, "error writing temp file");
+		pv_pvtx_error_set(err, -1, "error writing temp file");
 		goto out;
 	}
 
 	if (rename(tmp, get_json_path()) != 0) {
 		remove(tmp);
-		PVTX_ERROR_SET(err, -1, "rename error %s", strerror(errno));
+		pv_pvtx_error_set(err, -1, "rename error %s", strerror(errno));
 	}
 out:
 	return err->code;
@@ -372,18 +407,18 @@ static int add_json(const char *json, size_t size, struct pv_pvtx_error *err)
 	struct pv_pvtx_state *cur =
 		pv_pvtx_state_from_file(get_json_path(), err);
 	if (!cur) {
-		PVTX_ERROR_PREPEND(err, "couldn't load current state json");
+		pv_pvtx_error_prepend(err, "couldn't load current state json");
 		return -1;
 	}
 
 	struct pv_pvtx_state *st = pv_pvtx_state_from_str(json, size, err);
 	if (!st) {
-		PVTX_ERROR_PREPEND(err, "couldn't load incoming json");
+		pv_pvtx_error_prepend(err, "couldn't load incoming json");
 		goto out;
 	}
 
 	if (pv_pvtx_state_add(cur, st) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't merge incoming json");
+		pv_pvtx_error_set(err, -1, "couldn't merge incoming json");
 		goto out;
 	}
 
@@ -449,11 +484,11 @@ static int add_object_local(struct pv_pvtx_tar_content *con,
 static int add_object_remote(struct pv_pvtx_tar_content *con,
 			     struct pv_pvtx_error *err)
 {
-	struct pv_pvtx_ctrl *ctrl = pv_pvtx_ctrl_new(NULL);
+	struct pv_pvtx_ctrl *ctrl = pv_pvtx_ctrl_new(NULL, err);
 	if (!ctrl) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't send object %s, allocation failed",
-			       con->name);
+		pv_pvtx_error_prepend(
+			err, "couldn't send object %s, allocation failed",
+			con->name);
 		return -1;
 	}
 
@@ -474,16 +509,16 @@ static int add_tar(struct pv_pvtx_tar *tar, struct pv_pvtx_error *err)
 
 	struct pvtx_txn *txn = pvtx_load();
 	if (!txn) {
-		PVTX_ERROR_SET(err, -1, "couldn't load current transaction");
+		pv_pvtx_error_set(err, -1, "couldn't load current transaction");
 		return -1;
 	}
 
 	char tmp[PATH_MAX] = { 0 };
 	int fd = pv_fs_file_tmp(get_json_path(), tmp);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, fd,
-			       "couldn't get tmp file for pkg json "
-			       "process aborted");
+		pv_pvtx_error_set(err, fd,
+				  "couldn't get tmp file for pkg json "
+				  "process aborted");
 		goto out;
 	}
 	close(fd);
@@ -703,9 +738,10 @@ static int create_link(const char *deploy_path, const char *file,
 	if (pv_fs_path_exist(link_path))
 		remove(link_path);
 
-	if (stat(bsp_file,&st)) {
-		printf("WARN: cannot bsp file does not exist. continuing anyway ... (%s)\n", bsp_file);
-	        return 0;
+	if (stat(bsp_file, &st)) {
+		printf("WARN: cannot bsp file does not exist. continuing anyway ... (%s)\n",
+		       bsp_file);
+		return 0;
 	}
 
 	return link(bsp_file, link_path);
@@ -792,19 +828,23 @@ static int create_fs(const char *obj_path, const char *deploy_path,
 	pv_fs_mkbasedir_p(js_dst, 0755);
 	int ret = pv_fs_file_copy_no_sync(get_json_path(), js_dst, 0600);
 	if (ret != 0) {
-		PVTX_ERROR_SET(err, ret, "couldn't write state json: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(err, ret,
+				  "couldn't write state.json to '%s': %s",
+				  js_dst, strerror(errno));
 		return ret;
 	}
 
 	if (create_from_json(deploy_path, obj_path) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't create objects from json: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(err, -1,
+				  "couldn't hard-link objects into '%s': %s",
+				  deploy_path, strerror(errno));
 		return err->code;
 	}
 
 	if (create_bsp_link(deploy_path) != 0)
-		PVTX_ERROR_SET(err, -1, "couldn't link bsp to .pv/");
+		pv_pvtx_error_set(err, -1,
+				  "couldn't create BSP symlink in '%s/.pv/'",
+				  deploy_path);
 
 	return err->code;
 }
@@ -817,7 +857,7 @@ static int add_json_from_disk(const char *path, struct pv_pvtx_error *err)
 	char *json = pv_fs_file_read(path, &size);
 
 	if (!json) {
-		PVTX_ERROR_SET(err, -1, "couldn't load json from %s", path);
+		pv_pvtx_error_set(err, -1, "couldn't load json from %s", path);
 		return err->code;
 	}
 
@@ -888,9 +928,9 @@ static int move_objects(const char *dirname, const char *queue,
 		pv_fs_path_concat(dst, 2, obj_path, entry->d_name);
 
 		if (rename(src, dst) != 0) {
-			PVTX_ERROR_SET(err, -1,
-				       "couldn't move %s to object dir (%s)",
-				       src, obj_path);
+			pv_pvtx_error_set(err, -1,
+					  "couldn't move %s to object dir (%s)",
+					  src, obj_path);
 			goto out;
 		}
 	}
@@ -909,13 +949,14 @@ static int process_add_directory(struct pv_pvtx_state *st, const char *dirname,
 
 	struct pv_pvtx_state *new = pv_pvtx_state_from_file(js, err);
 	if (!new) {
-		PVTX_ERROR_PREPEND(err, "couldn't add %s", js);
+		pv_pvtx_error_prepend(err, "couldn't add %s", js);
 		return err->code;
 	}
 
 	if (pv_pvtx_state_add(st, new) != 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't add json, operation add failed");
+		pv_pvtx_error_set(err, -1,
+				  "couldn't apply queued add step from '%s'",
+				  js);
 		goto out;
 	}
 
@@ -945,7 +986,7 @@ static int queue_add_tar(struct pv_pvtx_tar *tar, const char *name,
 
 	struct pvtx_queue *q = pvtx_load();
 	if (!q) {
-		PVTX_ERROR_SET(err, -1, "couldn't load current queue");
+		pv_pvtx_error_set(err, -1, "couldn't load current queue");
 		return err->code;
 	}
 
@@ -954,7 +995,7 @@ static int queue_add_tar(struct pv_pvtx_tar *tar, const char *name,
 	char tmp[PATH_MAX] = { 0 };
 	int fd = pv_fs_file_tmp(q->queue, tmp);
 	if (fd < 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't create json temp file");
+		pv_pvtx_error_set(err, -1, "couldn't create json temp file");
 		goto out;
 	}
 	close(fd);
@@ -967,22 +1008,22 @@ static int queue_add_tar(struct pv_pvtx_tar *tar, const char *name,
 			ret = add_object_local(&con, q->txn.obj, err);
 
 		if (ret != 0) {
-			PVTX_ERROR_SET(err, ret, "couldn't save obejct: %s",
-				       con.name);
+			pv_pvtx_error_set(err, ret, "couldn't save object: %s",
+					  con.name);
 			goto out;
 		}
 	}
 
 	char fname[PATH_MAX] = { 0 };
 	if (get_queue_json_path(name ? name : "package", fname) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't create json path");
+		pv_pvtx_error_set(err, -1, "couldn't create json path");
 		goto out;
 	}
 
 	if (rename(tmp, fname) != 0) {
 		remove(tmp);
-		PVTX_ERROR_SET(err, -1, "couldn't add tar: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(err, -1, "couldn't add tar: %s",
+				  strerror(errno));
 		goto out;
 	}
 out:
@@ -1010,8 +1051,10 @@ int pv_pvtx_txn_begin(const char *from, const char *obj_path,
 	struct pvtx_queue *q = NULL;
 	struct pvtx_txn *txn = pvtx_load();
 	if (txn && txn->status == PVTX_TXN_STATUS_ACTIVE) {
-		PVTX_ERROR_SET(err, -1,
-			       "there is a previous transaction active.");
+		pv_pvtx_error_set(err, -1,
+				  "a transaction is already in progress\n"
+				  "run 'pvtx abort' to discard it or "
+				  "'pvtx commit'/'pvtx deploy' to finalize it");
 		goto out;
 	}
 
@@ -1021,7 +1064,7 @@ int pv_pvtx_txn_begin(const char *from, const char *obj_path,
 		if (!txn) {
 			txn = calloc(1, sizeof(struct pvtx_txn));
 			if (!txn) {
-				PVTX_ERROR_SET(
+				pv_pvtx_error_set(
 					err, -1,
 					"couldn't create new transaction");
 				goto out;
@@ -1043,7 +1086,8 @@ int pv_pvtx_txn_begin(const char *from, const char *obj_path,
 	} else {
 		q = pvtx_load();
 		if (!q) {
-			PVTX_ERROR_SET(err, -1, "couldn't load current config");
+			pv_pvtx_error_set(err, -1,
+					  "couldn't load current config");
 			goto out;
 		}
 
@@ -1053,7 +1097,7 @@ int pv_pvtx_txn_begin(const char *from, const char *obj_path,
 	}
 
 	if (init_state_json(from, err) != 0) {
-		PVTX_ERROR_PREPEND(err, "couldn't init transaction");
+		pv_pvtx_error_prepend(err, "could not start transaction");
 		goto out;
 	}
 
@@ -1072,7 +1116,7 @@ int pv_pvtx_txn_add_from_disk(const char *path, struct pv_pvtx_error *err)
 	pv_pvtx_error_clear(err);
 
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(
+		pv_pvtx_error_set(
 			err, 1,
 			"no active transaction. Start a transaction first.");
 		return err->code;
@@ -1099,7 +1143,7 @@ int pv_pvtx_txn_add_tar_from_fd(int fd, struct pv_pvtx_error *err)
 	pv_pvtx_error_clear(err);
 
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(
+		pv_pvtx_error_set(
 			err, 1,
 			"no active transaction. Start a transaction first.");
 		return err->code;
@@ -1121,13 +1165,14 @@ int pv_pvtx_txn_abort(struct pv_pvtx_error *err)
 		return 0;
 
 	if (unlink(get_json_path()) != 0)
-		PVTX_ERROR_SET(err, -1, "couldn't delete current json file");
+		pv_pvtx_error_set(err, -1, "couldn't delete current json file");
 
 	char path[PATH_MAX] = { 0 };
 	get_data_file(path);
 
 	if (unlink(path) != 0)
-		PVTX_ERROR_SET(err, -1, "couldn't delete current status file");
+		pv_pvtx_error_set(err, -1,
+				  "couldn't delete current status file");
 
 	return err->code;
 }
@@ -1135,26 +1180,29 @@ int pv_pvtx_txn_abort(struct pv_pvtx_error *err)
 char *pv_pvtx_txn_commit(struct pv_pvtx_error *err)
 {
 	char *json = NULL;
+	char *rev = NULL;
 	struct pv_pvtx_ctrl *ctrl = NULL;
 	struct pvtx_txn *txn = pvtx_load();
 
 	if (!txn || txn->status != PVTX_TXN_STATUS_ACTIVE) {
-		PVTX_ERROR_SET(
+		pv_pvtx_error_set(
 			err, 11,
 			"no active transaction. Start a transaction first.");
 		goto out;
 	}
 
 	if (txn->is_local) {
-		PVTX_ERROR_SET(err, 12,
-			       "this is a local transaction, only can "
-			       "be deployed with pvtx deploy");
+		pv_pvtx_error_set(err, 12,
+				  "this is a local transaction; use "
+				  "'pvtx deploy <dir>' to finalize it");
 		goto out;
 	}
 
-	ctrl = pv_pvtx_ctrl_new(NULL);
+	ctrl = pv_pvtx_ctrl_new(NULL, err);
 	if (!ctrl) {
-		PVTX_ERROR_SET(err, -1, "couldn't communicate with pv-ctrl");
+		pv_pvtx_error_prepend(
+			err, "failed to connect to pv-ctrl to submit the "
+			     "revision; make sure Pantavisor is running");
 		goto out;
 	}
 
@@ -1162,19 +1210,23 @@ char *pv_pvtx_txn_commit(struct pv_pvtx_error *err)
 	json = pv_fs_file_read(get_json_path(), &json_len);
 
 	if (!json) {
-		PVTX_ERROR_SET(err, -1, "couldn't load state json");
+		pv_pvtx_error_set(err, -1, "couldn't load state json");
 		goto out;
 	}
 
-	char *rev = get_rev_name(json, json_len);
+	rev = get_rev_name(json, json_len);
 
 	if (!rev) {
-		PVTX_ERROR_SET(err, -1, "couldn't build revision string");
+		pv_pvtx_error_set(err, -1, "couldn't build revision string");
 		goto out;
 	}
 
 	if (pv_pvtx_ctrl_steps_put(ctrl, json, json_len, rev) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't set rev %s", rev);
+		pv_pvtx_error_set(
+			err, -1,
+			"failed to upload revision '%s' to Pantavisor "
+			"via pv-ctrl",
+			rev);
 		goto out;
 	}
 
@@ -1195,7 +1247,7 @@ out:
 char *pv_pvtx_txn_get_json(struct pv_pvtx_error *err)
 {
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(
+		pv_pvtx_error_set(
 			err, 11,
 			"no active transaction. Start a transaction first.");
 		return NULL;
@@ -1204,8 +1256,8 @@ char *pv_pvtx_txn_get_json(struct pv_pvtx_error *err)
 	errno = 0;
 	char *json = pv_fs_file_read(get_json_path(), NULL);
 	if (!json) {
-		PVTX_ERROR_SET(err, -1, "couldn't get state json: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(err, -1, "couldn't get state json: %s",
+				  strerror(errno));
 		return NULL;
 	}
 
@@ -1215,28 +1267,32 @@ char *pv_pvtx_txn_get_json(struct pv_pvtx_error *err)
 int pv_pvtx_txn_deploy(const char *path, struct pv_pvtx_error *err)
 {
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(err, 11, "no active transaction");
+		pv_pvtx_error_set(
+			err, 11,
+			"no active transaction; run 'pvtx begin' first");
 		return 11;
 	}
 
 	struct pvtx_txn *txn = pvtx_load();
 
 	if (!txn || !txn->is_local) {
-		PVTX_ERROR_SET(err, -1,
-			       "this not a local transaction. Only "
-			       "local transaction can be deployed");
+		pv_pvtx_error_set(err, -1,
+				  "this is a remote transaction; use "
+				  "'pvtx commit' to finalize it");
 		goto out;
 	}
 
 	char tmpdir[PATH_MAX] = { 0 };
 	if (pv_fs_path_tmpdir(path, tmpdir) != 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't set up temp dir; deploy failed");
+		pv_pvtx_error_set(err, -1,
+				  "couldn't set up temp directory at '%s': %s",
+				  path, strerror(errno));
 		goto out;
 	}
 
 	if (init_config(path, tmpdir, txn->obj) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't initialize config");
+		pv_pvtx_error_set(err, -1, "couldn't initialize config at '%s'",
+				  path);
 		goto out;
 	}
 
@@ -1247,18 +1303,17 @@ int pv_pvtx_txn_deploy(const char *path, struct pv_pvtx_error *err)
 	snprintf(bakdir, PATH_MAX, "%s.bak", path);
 
 	if (pv_fs_rename_safe_noatomic(path, bakdir) != 0) {
-		PVTX_ERROR_SET(
-			err, -1,
-			"couldn't backup directory %s -> %s, deploy failed: %s",
-			path, bakdir, strerror(errno));
+		pv_pvtx_error_set(err, -1, "couldn't back up '%s' to '%s': %s",
+				  path, bakdir, strerror(errno));
 		pv_fs_path_remove_recursive_no_sync(tmpdir);
 		goto out;
 	}
 
 	if (pv_fs_rename_safe_noatomic(tmpdir, path) != 0) {
 		rename(bakdir, path);
-		PVTX_ERROR_SET(err, -1, "couldn't deploy current rev: %s",
-			       strerror(errno));
+		pv_pvtx_error_set(err, -1,
+				  "couldn't swap in new revision directory: %s",
+				  strerror(errno));
 		pv_fs_path_remove_recursive_no_sync(tmpdir);
 		goto out;
 	}
@@ -1281,7 +1336,7 @@ out:
 int pv_pvtx_txn_remove(const char *part, struct pv_pvtx_error *err)
 {
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(
+		pv_pvtx_error_set(
 			err, 3,
 			"no active transaction. Start a transaction first.");
 		return 3;
@@ -1290,12 +1345,12 @@ int pv_pvtx_txn_remove(const char *part, struct pv_pvtx_error *err)
 	struct pv_pvtx_state *st =
 		pv_pvtx_state_from_file(get_json_path(), err);
 	if (!st) {
-		PVTX_ERROR_PREPEND(err, "couldn't load state json");
+		pv_pvtx_error_prepend(err, "couldn't load state json");
 		return -1;
 	}
 
 	if (pv_pvtx_state_remove(st, part) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't remove part %s", part);
+		pv_pvtx_error_set(err, -1, "couldn't remove part %s", part);
 		goto out;
 	}
 
@@ -1310,9 +1365,9 @@ int pv_pvtx_queue_new(const char *queue_path, const char *obj_path,
 		      struct pv_pvtx_error *err)
 {
 	if (is_active_txn()) {
-		PVTX_ERROR_SET(err, 12,
-			       "active transaction; finish your work "
-			       "with 'deploy', 'commit' or 'abort' first");
+		pv_pvtx_error_set(err, 12,
+				  "active transaction; finish your work "
+				  "with 'deploy', 'commit' or 'abort' first");
 		return 12;
 	}
 
@@ -1332,8 +1387,9 @@ int pv_pvtx_queue_new(const char *queue_path, const char *obj_path,
 	memccpy(q.txn.obj, obj_path, '\0', PATH_MAX);
 
 	if (pvtx_save(&q, sizeof(struct pvtx_queue)) != 0) {
-		PVTX_ERROR_SET(err, -1,
-			       "couldn't create queue, save operation failed");
+		pv_pvtx_error_set(
+			err, -1,
+			"couldn't create queue, save operation failed");
 		return -1;
 	}
 
@@ -1348,25 +1404,25 @@ int pv_pvtx_queue_remove(const char *part, struct pv_pvtx_error *err)
 	char *enc = NULL;
 
 	if (!q || !pv_fs_path_exist(q->queue)) {
-		PVTX_ERROR_SET(err, 1, "queue %s does not exist",
-			       q ? q->queue : "");
+		pv_pvtx_error_set(err, 1, "queue %s does not exist",
+				  q ? q->queue : "");
 		goto out;
 	}
 
 	enc = url_encode(part);
 	if (!enc) {
-		PVTX_ERROR_SET(err, -1, "couldn't encode name");
+		pv_pvtx_error_set(err, -1, "couldn't encode name");
 		goto out;
 	}
 
 	char fname[PATH_MAX] = { 0 };
 	if (get_queue_remove_file(enc, fname) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't create .remove file name");
+		pv_pvtx_error_set(err, -1, "couldn't create .remove file name");
 		goto out;
 	}
 
 	if (pv_fs_file_write_no_sync(fname, NULL, 0) != 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't create file %s", fname);
+		pv_pvtx_error_set(err, -1, "couldn't create file %s", fname);
 		goto out;
 	}
 
@@ -1385,8 +1441,8 @@ int pv_pvtx_queue_unpack_from_disk(const char *part, struct pv_pvtx_error *err)
 {
 	struct pvtx_queue *q = pvtx_load();
 	if (!q || !pv_fs_path_exist(q->queue)) {
-		PVTX_ERROR_SET(err, 1, "queue %s does not exist",
-			       q ? q->queue : "");
+		pv_pvtx_error_set(err, 1, "queue %s does not exist",
+				  q ? q->queue : "");
 		if (q)
 			free(q);
 		return 1;
@@ -1404,13 +1460,13 @@ int pv_pvtx_queue_unpack_from_disk(const char *part, struct pv_pvtx_error *err)
 
 		char fname[PATH_MAX] = { 0 };
 		if (get_queue_json_path(part, fname) != 0) {
-			PVTX_ERROR_SET(err, -1, "couldn't create json path");
+			pv_pvtx_error_set(err, -1, "couldn't create json path");
 			return -1;
 		}
 
 		if (pv_fs_file_copy_no_sync(part, fname, 0644) != 0) {
-			PVTX_ERROR_SET(err, -1, "couldn't copy %s to %s", part,
-				       fname);
+			pv_pvtx_error_set(err, -1, "couldn't copy %s to %s",
+					  part, fname);
 			return -1;
 		}
 		pv_pvtx_error_clear(err);
@@ -1434,8 +1490,8 @@ int pv_pvtx_queue_unpack_tar_from_fd(int fd, struct pv_pvtx_error *err)
 {
 	struct pvtx_queue *q = pvtx_load();
 	if (!q || !pv_fs_path_exist(q->queue)) {
-		PVTX_ERROR_SET(err, 1, "queue %s does not exist",
-			       q ? q->queue : "");
+		pv_pvtx_error_set(err, 1, "queue %s does not exist",
+				  q ? q->queue : "");
 		if (q)
 			free(q);
 
@@ -1471,12 +1527,13 @@ int pv_pvtx_queue_process(const char *from, const char *queue_path,
 	struct pvtx_queue *q = pvtx_load();
 
 	if (!q) {
-		PVTX_ERROR_SET(err, -1, "couldn't load current config");
+		pv_pvtx_error_set(err, -1, "couldn't load current config");
 		return err->code;
 	}
 
 	if (!pv_fs_path_exist(q->queue)) {
-		PVTX_ERROR_SET(err, -1, "queue %s does not exist");
+		pv_pvtx_error_set(err, -1, "queue '%s' does not exist",
+				  q->queue);
 		goto out;
 	}
 
@@ -1484,20 +1541,21 @@ int pv_pvtx_queue_process(const char *from, const char *queue_path,
 		goto out;
 
 	if (!is_active_txn()) {
-		PVTX_ERROR_SET(err, 3, "no active transaction");
+		pv_pvtx_error_set(err, 3, "no active transaction");
 		goto out;
 	}
 
 	int len = scandir(q->queue, &entry, NULL, alphasort);
 	if (len < 0) {
-		PVTX_ERROR_SET(err, -1, "couldn't scan directory %s", q->queue);
+		pv_pvtx_error_set(err, -1, "couldn't scan directory %s",
+				  q->queue);
 		goto out;
 	}
 
 	st = pv_pvtx_state_from_file(get_json_path(), err);
 	if (!st) {
-		PVTX_ERROR_PREPEND(err, "couldn't process queue, "
-					"error loading current state json");
+		pv_pvtx_error_prepend(err, "couldn't process queue, "
+					   "error loading current state json");
 		goto out;
 	}
 
@@ -1511,8 +1569,8 @@ int pv_pvtx_queue_process(const char *from, const char *queue_path,
 		char *ext = strrchr(fn, '.');
 		if (ext && !strncmp(ext, ".remove", strlen(ext))) {
 			if (process_remove_file(st, fn) != 0) {
-				PVTX_ERROR_SET(err, -1, "couldn't remove %s",
-					       fn);
+				pv_pvtx_error_set(err, -1, "couldn't remove %s",
+						  fn);
 				free(fn);
 				goto out;
 			}


### PR DESCRIPTION
## Summary

Improve the `pvtx` CLI user experience in two areas:

**Help message** (`pvtx.c`): rewrote the help output to clearly describe what each command does, including the local vs. remote transaction distinction, which arguments are required vs. optional, and how to finalize a transaction with `commit` or `deploy`. Also fixed `queue new` incorrectly showing `[object]` as optional when the code requires it.

**Error messages** (`pvtx_txn.c`, `pvtx_ctrl.c`): made errors actionable and free of internal implementation details:

- Socket errors now name the paths that were checked and suggest verifying Pantavisor is running.
- `begin` with the default `current` base no longer exposes the internal string "current" in the error output.
- Wrong transaction type errors (local vs. remote) now tell the user which command to use instead.
- Fixed a missing format argument in `queue process` (`"queue %s does not exist"` had no corresponding value).
- Fixed typos: "atteps", "loding", "this not a local transaction", "only can be deployed".

Some examples of new error text:

* Trying to initialize transaction with pv-ctrl without the socket present 
```
$ pvtx-static begin current
./pvtx begin current
$ ./pvtx begin current
ERROR: begin: could not start transaction;
failed to connect to pv-ctrl to read the current revision state;
make sure Pantavisor is running and the pv-ctrl socket is available
or check the 'help' command if you are looking other ways to start a transaction;
pv-ctrl socket not found (tried /pv/pv-ctrl and /pantavisor/pv-ctrl)
```
* Trying to commit a local transaction
```
$ pvtx commit
ERROR: commit: failed to connect to pv-ctrl to submit the revision; make sure Pantavisor is running;
pv-ctrl socket not found (tried /pv/pv-ctrl and /pantavisor/pv-ctrl)
```
* Starting a transaction when another is active:
```
$ pvtx begin
ERROR: begin: a transaction is already in progress
run 'pvtx abort' to discard it or 'pvtx commit'/'pvtx deploy' to finalize it
```
* Starting a new transaction with a wrong path
```
$ pvtx begin /path/no/exits
ERROR: begin: could not start transaction;
no state JSON found at '/path/no/exits'; expected a revision directory or a json file
``` 

New help text:
```
$ pvtx-static help
Usage: ./pvtx COMMAND [SUB-COMMAND] args...

pvtx manages Pantavisor revision transactions. A transaction
starts with 'begin', is built up with 'add'/'remove', and is
finalized with either 'commit' (remote) or 'deploy' (local).

Commands:
  begin <base> [object]         Start a new transaction based on an existing revision.
                                <base> can be "current" (copy state from the running Pantavisor
                                via pv-ctrl), "empty" (start from a blank revision), or a path
                                to a revision directory or state JSON file.
                                If [object] is given, the transaction is local: objects are saved
                                to that directory and finalized with 'deploy'. Without [object],
                                the transaction is remote: objects are streamed to pv-ctrl and
                                finalized with 'commit'.
  add <file | ->                Add a package to the current transaction.
                                <file> can be a state JSON file or a gzip tarball containing a
                                "json" descriptor and an "objects/" directory with content
                                files named by their SHA-256 hash. Use '-' to read a tarball
                                from stdin. For remote transactions, objects are uploaded to
                                pv-ctrl directly; for local ones, saved to the object dir.
  remove <part>                 Remove a named part (container/component) from the current
                                transaction's state JSON.
  abort                         Discard the current transaction, deleting the in-progress
                                state JSON and transaction status file.
  commit                        Finalize a remote transaction by sending the state JSON to
                                Pantavisor via the pv-ctrl socket. Generates and prints a
                                revision name (locals/pvtx-<timestamp>-<hash>-<rand>).
                                Only valid for remote transactions (begun without [object]).
  show                          Print the in-progress state JSON of the current transaction.
  deploy <directory>            Finalize a local transaction by writing the revision layout
                                to <directory>. Creates .pvr/json, .pvr/config, hard-links
                                objects from the object dir, and sets up .pv/ BSP links.
                                Performs a safe atomic-like swap: the old directory is kept
                                as <directory>.bak until deploy succeeds.
                                Only valid for local transactions (begun with [object]).
  help | --help                 Show this help message.
  queue <sub-command>           Operate in queue mode, which records an ordered sequence of
                                add/remove steps and replays them atomically in one 'process'
                                call. Useful for batching multiple package updates together.

Queue Sub-commands:
  new <queue> <object>          Initialize a new queue. <queue> is the directory where step
                                files are stored in order; <object> is the directory where
                                unpacked content objects will be saved.
  remove <part>                 Schedule a remove step for <part> in the current queue.
                                Creates a numbered .remove marker that 'queue process' will
                                apply in sequence.
  unpack <tarball|->            Stage a package into the current queue. Extracts the state
                                JSON descriptor and saves objects to the object directory.
                                Each call adds a numbered step entry. Use '-' for stdin.
  process [base [queue obj]]    Replay all queued steps in order to build a final revision.
                                Applies add directories and .remove markers alphabetically.
                                base : revision to start from ("current", "empty", or path).
                                queue: queue directory path; implicitly calls 'queue new'
                                       when provided (requires obj to be set as well).
                                obj  : object directory path; required when queue is given.
                                When called with no arguments, resumes the active queue and
                                active transaction.

Environment Variables:
  PVTXDIR                       Directory where pvtx stores transaction state (status file
                                and current.json). Default: /var/pvr-sdk/pvtx
  PVTX_OBJECT_BUF_SIZE          I/O buffer size for reading/writing object files.
                                Min 512B, max 10485760B (10M). Default: 512B.
  PVTX_CTRL_BUF_SIZE            I/O buffer size for communicating with pv-ctrl socket.
                                Min 16384B (16K), max 10485760B (10M).
```