### PR TITLE
feat(disks): support name aliases for volume->disk resolution

### DIFF
--- a/disk/disk.c
+++ b/disk/disk.c
@@ -71,7 +71,96 @@ static void pv_disk_free(struct pv_disk *disk)
 	for (int i = 0; i < disk->init_order_count; i++)
 		free(disk->init_order[i]);
 
+	if (disk->aliases) {
+		for (int i = 0; i < disk->aliases_count; i++)
+			free(disk->aliases[i]);
+		free(disk->aliases);
+	}
+
 	free(disk);
+}
+
+bool pv_disk_has_name(const struct pv_disk *d, const char *name)
+{
+	if (!d || !name)
+		return false;
+	if (d->name && !strcmp(d->name, name))
+		return true;
+	for (int i = 0; i < d->aliases_count; i++) {
+		if (d->aliases[i] && !strcmp(d->aliases[i], name))
+			return true;
+	}
+	return false;
+}
+
+int pv_disk_list_validate(struct dl_list *disks)
+{
+	if (!disks)
+		return 0;
+
+	struct pv_disk *d, *tmp;
+	/* Every canonical name must be non-empty. Collect them first so
+	 * we can cross-check aliases against them in a second pass. */
+	dl_list_for_each_safe(d, tmp, disks, struct pv_disk, list)
+	{
+		if (!d->name || !d->name[0]) {
+			pv_log(ERROR, "disk list contains an unnamed disk");
+			return -1;
+		}
+	}
+
+	/* Check aliases:
+	 *   1. non-empty
+	 *   2. must not equal any canonical disk name (shadowing)
+	 *   3. must be unique across the whole list (no two disks share one)
+	 *
+	 * Alias equal to the owning disk's own ->name is accepted as a no-op
+	 * (harmless redundancy), but an alias equal to a *different* disk's
+	 * name is a hard conflict.
+	 */
+	dl_list_for_each_safe(d, tmp, disks, struct pv_disk, list)
+	{
+		for (int i = 0; i < d->aliases_count; i++) {
+			const char *a = d->aliases[i];
+			if (!a || !a[0]) {
+				pv_log(ERROR,
+				       "disk '%s' has empty alias at index %d",
+				       d->name, i);
+				return -1;
+			}
+
+			struct pv_disk *d2, *tmp2;
+			dl_list_for_each_safe(d2, tmp2, disks, struct pv_disk,
+					      list)
+			{
+				/* (2) alias shadowing another disk's name */
+				if (d2 != d && d2->name &&
+				    !strcmp(d2->name, a)) {
+					pv_log(ERROR,
+					       "disk '%s' alias '%s' conflicts with canonical name of disk '%s'",
+					       d->name, a, d2->name);
+					return -1;
+				}
+				/* (3) same alias on another disk */
+				if (d2 != d) {
+					for (int j = 0; j < d2->aliases_count;
+					     j++) {
+						if (d2->aliases[j] &&
+						    !strcmp(d2->aliases[j],
+							    a)) {
+							pv_log(ERROR,
+							       "alias '%s' is claimed by both disk '%s' and disk '%s'",
+							       a, d->name,
+							       d2->name);
+							return -1;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return 0;
 }
 
 void pv_disk_empty(struct dl_list *disks)
@@ -279,4 +368,3 @@ struct pv_disk *pv_disk_find(struct dl_list *disks, const char *name)
 
 	return NULL;
 }
-

--- a/disk/disk.h
+++ b/disk/disk.h
@@ -23,6 +23,7 @@
 #ifndef PV_DISK_H
 #define PV_DISK_H
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "utils/list.h"
@@ -82,6 +83,11 @@ struct pv_disk {
 	int dual_disks_count;
 	char *init_order[PV_DISK_DUAL_MAX_INIT_ORDER];
 	int init_order_count;
+	// name aliases: volumes may reference the disk by any of these in
+	// addition to ->name. Resolves at lookup time only; all downstream
+	// paths/logs use the canonical ->name of the resolved disk.
+	char **aliases;
+	int aliases_count;
 	// back-pointer to parent disk list (set by pv_disk_add)
 	struct dl_list *disk_list;
 	// pv_disk
@@ -123,7 +129,8 @@ static inline pv_disk_format_t pv_disk_str_to_format(const char *format_str)
 	return DISK_FORMAT_UNKNOWN;
 }
 
-static inline const char *pv_disk_dm_crypt_mode_to_str(pv_disk_dm_crypt_mode_t mode)
+static inline const char *
+pv_disk_dm_crypt_mode_to_str(pv_disk_dm_crypt_mode_t mode)
 {
 	switch (mode) {
 	case DISK_DM_CRYPT_MODE_UNKNOWN:
@@ -159,7 +166,8 @@ static inline const char *pv_disk_type_to_str(pv_disk_t type)
 	return "unknown";
 }
 
-static inline pv_disk_dm_crypt_mode_t pv_disk_dm_crypt_str_to_mode(const char *mode_str)
+static inline pv_disk_dm_crypt_mode_t
+pv_disk_dm_crypt_str_to_mode(const char *mode_str)
 {
 	if (mode_str) {
 		if (!strcmp(mode_str, "mainline"))
@@ -193,6 +201,19 @@ static inline pv_disk_t pv_disk_str_to_type(const char *type_str)
 
 struct pv_disk *pv_disk_find(struct dl_list *disks, const char *name);
 
+/* Returns true if `name` matches this disk's canonical ->name or any of
+ * its aliases. */
+bool pv_disk_has_name(const struct pv_disk *d, const char *name);
+
+/* Sanity-check the disk list as a whole. Returns 0 on success, -1 on
+ * conflict. The parser must call this once after all disks have been
+ * registered and refuse to boot if it fails. Checks:
+ *   - no alias shadows another disk's canonical name
+ *   - no alias is shared between two disks
+ *   - aliases array and name are non-empty strings
+ */
+int pv_disk_list_validate(struct dl_list *disks);
+
 /* Disks with names starting with '_' are internal — intended only as
  * sub-disk references for composite types (dual, future raid, etc.).
  * Volumes should not reference them directly. */
@@ -200,7 +221,6 @@ static inline bool pv_disk_is_internal(struct pv_disk *d)
 {
 	return d->name && d->name[0] == '_';
 }
-
 
 extern struct pv_disk_impl zram_impl;
 extern struct pv_disk_impl crypt_impl;

--- a/docs/overview/disks.md
+++ b/docs/overview/disks.md
@@ -362,6 +362,52 @@ volume 'docker--secrets' requires disk 'dm-secrets' which was not found
 This prevents silent fallthrough to another disk or diskless operation
 when a required disk is missing.
 
+### Aliases
+
+A disk may declare additional names via the `aliases` array. Volumes
+referring to any alias resolve to the same `pv_disk` as the canonical
+`name`. This is a lookup-time convenience — all downstream paths,
+mountpoints, and log lines continue to use the canonical `name`, so
+aliasing never produces a ghost mount or path ambiguity.
+
+```json
+"disks": [
+    {
+        "name": "dm-internal-secrets",
+        "type": "dm-crypt-versatile",
+        "path": "/storage/dm-crypt-files/dm-internal-secrets/versatile.img,2,versatile_key-internal_secrets",
+        "aliases": ["dm-versatile"]
+    }
+]
+```
+
+A container whose `run.json` storage section declares
+`"disk": "dm-versatile"` then resolves to `dm-internal-secrets`.
+
+When a volume resolves through an alias, pantavisor logs an INFO line
+naming both the alias used and the canonical disk:
+
+```
+volume 'docker--var-dmcrypt-volume' disk ref 'dm-versatile' resolved to 'dm-internal-secrets' via alias
+```
+
+Aliases are useful when a prebuilt container image references a disk
+name your device skel doesn't ship, and editing the upstream container
+is not an option.
+
+#### Validation
+
+Pantavisor refuses to boot the revision if any of these hold for the
+final merged disk list (across `disks`, `disks_v2`, and `disks_v3`):
+
+- a disk has an empty `name` or any empty alias string;
+- an alias matches another disk's canonical `name` (shadowing);
+- two disks declare the same alias.
+
+An alias equal to the disk's own `name` is accepted as a no-op. The
+strict missing-disk check above is **not weakened** by aliases — an
+unknown disk reference still fails the volume mount.
+
 ## Boot Sequence
 
 1. **Swap disks** — `pv_disk_mount_swap()` mounts all `swap-disk` type disks

--- a/docs/reference/pantavisor-state-format-v2.md
+++ b/docs/reference/pantavisor-state-format-v2.md
@@ -98,6 +98,7 @@ examples.
 | Key | Value Type | Default | Description |
 |:---|:---|:---:|:---|
 | `name` | string | **Mandatory** | Unique name used in `run.json` storage keys and mount paths. |
+| `aliases` | string array | empty | Additional names this disk answers to. Volumes referring to any alias resolve to this disk. Aliases must not shadow another disk's `name` or be claimed by more than one disk; conflicts make the state refuse to boot. See [Aliases](../overview/disks.md#aliases) in the overview. |
 | `type` | enum | **Mandatory** | `dm-crypt-caam`, `dm-crypt-dcp`, `dm-crypt-versatile`, `swap-disk`, `volume-disk`, `dual`, `directory`. |
 | `path` | string | **Mandatory** (crypt, swap, vol) | Device/image path. CAAM v2: `-v2 <img>,<size>,<key>`. DCP/versatile: `<img>,<size>,<key>`. |
 | `mode` | enum | **Mandatory** (crypt) | `mainline` or `nxp`. Selects key subsystem. |

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -249,8 +249,8 @@ static pv_disk_format_t parse_disks_get_format(const char *str,
 	return format;
 }
 
-static pv_disk_dm_crypt_mode_t parse_disks_dm_crypt_get_mode(const char *str,
-				jsmntok_t *diskv, int diskc)
+static pv_disk_dm_crypt_mode_t
+parse_disks_dm_crypt_get_mode(const char *str, jsmntok_t *diskv, int diskc)
 {
 	char *mode_str = pv_json_get_value(str, "mode", diskv, diskc);
 	pv_disk_dm_crypt_mode_t mode = pv_disk_dm_crypt_str_to_mode(mode_str);
@@ -338,10 +338,12 @@ static int parse_disks_ex(struct pv_state *s, char *value, bool lenient)
 
 		if (d->type == DISK_UNKNOWN) {
 			if (lenient) {
-				pv_log(WARN, "disk '%s' has unknown type, skipping",
+				pv_log(WARN,
+				       "disk '%s' has unknown type, skipping",
 				       d->name ? d->name : "(null)");
 				dl_list_del(&d->list);
-				t = t + (jsmnutil_object_key_count(str, diskv) * 2);
+				t = t +
+				    (jsmnutil_object_key_count(str, diskv) * 2);
 				free(d->name);
 				free(d->path);
 				free(d->mount_target);
@@ -369,7 +371,8 @@ static int parse_disks_ex(struct pv_state *s, char *value, bool lenient)
 		d->format = parse_disks_get_format(str, diskv, diskc);
 		if ((d->type == DISK_SWAP || d->type == DISK_VOLUME) &&
 		    d->format == DISK_FORMAT_UNKNOWN) {
-			pv_log(WARN, "new disk format = UNKNOWN - likely that mount fails");
+			pv_log(WARN,
+			       "new disk format = UNKNOWN - likely that mount fails");
 		}
 
 		d->def = parse_disks_get_default(str, diskv, diskc);
@@ -377,20 +380,68 @@ static int parse_disks_ex(struct pv_state *s, char *value, bool lenient)
 			str, "migrate_keyblob", diskv, diskc);
 		d->mounted = false;
 
+		/* Optional name aliases — lets volumes refer to this disk
+		 * by a synonym. Collisions are rejected later by
+		 * pv_disk_list_validate(). */
+		char *aliases_str =
+			pv_json_get_value(str, "aliases", diskv, diskc);
+		if (aliases_str) {
+			jsmntok_t *atokv = NULL;
+			int atokc;
+			if (jsmnutil_parse_json(aliases_str, &atokv, &atokc) >
+			    0) {
+				int acount = jsmnutil_array_count(aliases_str,
+								  atokv);
+				if (acount > 0) {
+					d->aliases =
+						calloc(acount, sizeof(char *));
+					if (d->aliases) {
+						int aremain = acount;
+						jsmntok_t *at = atokv + 1;
+						for (int i = 0; i < acount;
+						     i++) {
+							char *entry =
+								pv_json_array_get_one_str(
+									aliases_str,
+									&aremain,
+									&at);
+							if (entry)
+								d->aliases
+									[d->aliases_count++] =
+									entry;
+						}
+					}
+				}
+				free(atokv);
+			}
+			free(aliases_str);
+		}
+
 		// parse dual mode arrays
 		if (d->type == DISK_DUAL) {
-			char *disks_str = pv_json_get_value(str, "disks", diskv, diskc);
+			char *disks_str =
+				pv_json_get_value(str, "disks", diskv, diskc);
 			if (disks_str) {
 				jsmntok_t *dtokv = NULL;
 				int dtokc;
-				if (jsmnutil_parse_json(disks_str, &dtokv, &dtokc) > 0) {
-					int dcount = jsmnutil_array_count(disks_str, dtokv);
+				if (jsmnutil_parse_json(disks_str, &dtokv,
+							&dtokc) > 0) {
+					int dcount = jsmnutil_array_count(
+						disks_str, dtokv);
 					int dremain = dcount;
 					jsmntok_t *dt = dtokv + 1;
-					for (int i = 0; i < dcount && i < PV_DISK_DUAL_MAX_DISKS; i++) {
-						char *entry = pv_json_array_get_one_str(disks_str, &dremain, &dt);
+					for (int i = 0;
+					     i < dcount &&
+					     i < PV_DISK_DUAL_MAX_DISKS;
+					     i++) {
+						char *entry =
+							pv_json_array_get_one_str(
+								disks_str,
+								&dremain, &dt);
 						if (entry) {
-							d->dual_disks[d->dual_disks_count++] = entry;
+							d->dual_disks
+								[d->dual_disks_count++] =
+								entry;
 						}
 					}
 					free(dtokv);
@@ -398,18 +449,29 @@ static int parse_disks_ex(struct pv_state *s, char *value, bool lenient)
 				free(disks_str);
 			}
 
-			char *order_str = pv_json_get_value(str, "init_order", diskv, diskc);
+			char *order_str = pv_json_get_value(str, "init_order",
+							    diskv, diskc);
 			if (order_str) {
 				jsmntok_t *otokv = NULL;
 				int otokc;
-				if (jsmnutil_parse_json(order_str, &otokv, &otokc) > 0) {
-					int ocount = jsmnutil_array_count(order_str, otokv);
+				if (jsmnutil_parse_json(order_str, &otokv,
+							&otokc) > 0) {
+					int ocount = jsmnutil_array_count(
+						order_str, otokv);
 					int oremain = ocount;
 					jsmntok_t *ot = otokv + 1;
-					for (int i = 0; i < ocount && i < PV_DISK_DUAL_MAX_INIT_ORDER; i++) {
-						char *entry = pv_json_array_get_one_str(order_str, &oremain, &ot);
+					for (int i = 0;
+					     i < ocount &&
+					     i < PV_DISK_DUAL_MAX_INIT_ORDER;
+					     i++) {
+						char *entry =
+							pv_json_array_get_one_str(
+								order_str,
+								&oremain, &ot);
 						if (entry) {
-							d->init_order[d->init_order_count++] = entry;
+							d->init_order
+								[d->init_order_count++] =
+								entry;
 						}
 					}
 					free(otokv);
@@ -1755,6 +1817,15 @@ static struct pv_state *system1_parse_disks(struct pv_state *this,
 		value = NULL;
 	}
 
+	/* All disks from disks.json / disks_v3.json have been parsed —
+	 * enforce alias/name uniqueness before any volume tries to
+	 * resolve against this list. */
+	if (this && pv_disk_list_validate(&this->disks)) {
+		pv_log(ERROR, "disk alias validation failed");
+		this = NULL;
+		goto out;
+	}
+
 out:
 	if (tokv)
 		free(tokv);
@@ -2084,6 +2155,15 @@ static struct pv_state *parse_device(struct pv_state *this, char *buf)
 		}
 		free(value);
 		value = NULL;
+	}
+
+	/* Validate disk aliases after disks / disks_v2 / disks_v3 are all
+	 * in. Volumes parsed below will resolve against this set — bail
+	 * out now if any alias shadows or clashes. */
+	if (pv_disk_list_validate(&this->disks)) {
+		pv_log(ERROR, "disk alias validation failed in device.json");
+		this = NULL;
+		goto out;
 	}
 
 	value = pv_json_get_value(buf, "volumes", tokv, tokc);

--- a/volumes.c
+++ b/volumes.c
@@ -129,8 +129,16 @@ struct pv_volume *pv_volume_add_with_disk(struct pv_state *s, char *name,
 	dl_list_for_each_safe(d, tmp, disks, struct pv_disk, list)
 	{
 		// if no disk name requested: use the default
-		if ((!disk && d->def) || (disk && !strcmp(d->name, disk))) {
+		if (!disk && d->def) {
 			v->disk = d;
+			break;
+		}
+		if (disk && pv_disk_has_name(d, disk)) {
+			v->disk = d;
+			if (strcmp(d->name, disk))
+				pv_log(INFO,
+				       "volume '%s' disk ref '%s' resolved to '%s' via alias",
+				       name, disk, d->name);
 			break;
 		}
 	}


### PR DESCRIPTION
## Summary

Add an optional `aliases` array to each disk entry in `device.json` /
`disks_v3.json`. Volumes may reference a disk by any of its aliases in
addition to its canonical `->name`.

Motivation: a container's prebuilt `run.json` can declare
`disk: "dm-versatile"` while the device's skel only provisioned a disk
named `dm-internal-secrets` (type `dm-crypt-versatile`). Before this
change the strict mount check (introduced in \`5bd686c8\`) would
correctly fail to boot such a revision. After this change, operators
can add `"aliases": ["dm-versatile"]` to `dm-internal-secrets` and the
container resolves without having to re-publish the upstream image or
edit its run.json.

Resolution is **lookup-only**: all downstream paths, logs and internal
state use the canonical `->name` of the resolved disk, so there is no
path ambiguity and no ghost mount.

## Design

- `struct pv_disk` gains `char **aliases; int aliases_count;`.
- `pv_disk_has_name(d, name)` — returns true for canonical-name match
  or any alias match.
- `pv_volume_add_with_disk()` uses the helper. When a match comes via
  alias, an INFO log line names both the alias used and the canonical
  disk.
- The strict mount check from \`5bd686c8\` is **untouched** — aliases
  widen resolution, they don't weaken failure. Unknown disk refs still
  fail.

## Guardrails

`pv_disk_list_validate()` is called after disks / disks_v2 / disks_v3
have all been parsed, before any volume resolves, from both:

- `system1_parse_disks` (standalone `disks_v3.json` files)
- `system1_parse_device` (`device.json` blob)

It refuses to boot the revision if:

- any canonical disk `->name` is empty
- any alias string is empty
- an alias shadows another disk's canonical name
- an alias is claimed by more than one disk

Alias equal to the owning disk's own `->name` is accepted as a no-op.

## Example

\`\`\`json
{
  "disks": [
    {
      "name": "dm-internal-secrets",
      "path": "...",
      "type": "dm-crypt-versatile",
      "aliases": ["dm-versatile"]
    }
  ]
}
\`\`\`

A container whose run.json declares \`"disk": "dm-versatile"\` now
resolves to the same \`pv_disk\` as \`dm-internal-secrets\`.

## Test plan

- [ ] Build with workspace overlay and boot on a device where a
      container references a non-existent disk name resolved via alias
- [ ] Confirm INFO log line appears on resolution (\`... resolved to
      '<canonical>' via alias\`)
- [ ] Negative: add an alias that matches another disk's canonical
      name → device.json parse fails with \`alias '<x>' conflicts with
      canonical name of disk '<y>'\`
- [ ] Negative: add the same alias to two disks → parse fails with
      \`alias '<x>' is claimed by both disk '<a>' and disk '<b>'\`
- [ ] Regression: volume referencing an unknown disk (no alias match
      anywhere) still returns -1 from \`pv_volume_mount\` per
      \`5bd686c8\`