### PR TITLE
fix(event): event_del before event_free; ignore-then-close in platforms

### DIFF
--- a/event/event_socket.c
+++ b/event/event_socket.c
@@ -61,6 +61,15 @@ void pv_event_socket_ignore(struct pv_event_socket *listener)
 
 	pv_log(DEBUG, "stop listening event to socket fd %d", listener->fd);
 
+	/* event_del removes the fd from the epoll set while it is still
+	 * open; without it, callers that close(fd) before pv_event_socket_ignore
+	 * leak the registration into the epoll set. The kernel later reuses
+	 * the fd number for an unrelated file, libevent keeps firing the
+	 * stale EV_PERSIST callback on every iteration (level-triggered
+	 * EPOLLHUP / EPOLLERR for regular files), and pv-main-loop spins
+	 * at full CPU. event_free alone does not guarantee EPOLL_CTL_DEL
+	 * because the underlying fd may already be closed by then. */
+	event_del(listener->ev);
 	event_free(listener->ev);
 	listener->ev = NULL;
 }

--- a/platforms.c
+++ b/platforms.c
@@ -1014,9 +1014,15 @@ static void _read_platform_pipefd_cb(int fd, short event, void *arg)
 	while (read(p->pipefd[0], &p->init_pid, sizeof(pid_t)) < 0 &&
 	       errno == EINTR)
 		;
+	/* Stop libevent listening before closing the fd. Otherwise EPOLL_CTL_DEL
+	 * cannot be issued on a still-valid fd, the registration leaks into the
+	 * epoll set, the kernel reuses the fd number for an unrelated file
+	 * (squashfs loop, socketpair, pipe), and the stale EV_PERSIST entry
+	 * keeps firing EPOLLHUP/EPOLLERR every iteration — pv-main-loop pegs
+	 * at ~25% CPU per leaked listener. */
+	pv_event_socket_ignore(&p->pipefd_listener);
 	close(p->pipefd[0]);
 	p->pipefd[0] = -1;
-	pv_event_socket_ignore(&p->pipefd_listener);
 
 	if (p->init_pid <= 0) {
 		pv_log(WARN, "could not start platform '%s'", p->name);


### PR DESCRIPTION
## Summary

Fixes a stale fd registration leak in pv-main-loop's libevent base that
pegs ~25% of one core per leaked fd in the epoll set. The leak happens
on **every** container start (MGMT and non-MGMT alike); the live count
varies because some leaks self-cure when the reused-file owner later
closes. On a steady-state Pi 5 with 5 containers running, 3 leaks were
present in the epoll set, driving pv-main-loop to ~25% CPU.

Regressed in `009d9e2f` ("perf: make lxc container start non-blocking",
2025-10-29) — the commit that introduced async listening on `pipefd[0]`
to receive the LXC container's init PID. Tags affected: **024, 025,
026, 028-rc3**.

## Root cause

`pv_event_socket_ignore` was calling `event_free()` without a preceding
`event_del()`, AND `_read_platform_pipefd_cb` in `platforms.c` was doing
`close(p->pipefd[0])` BEFORE `pv_event_socket_ignore`. After close,
`EPOLL_CTL_DEL` on the closed fd fails with `EBADF`, the EV_PERSIST
registration leaks into the epoll set, the kernel reuses the fd number
for an unrelated file (squashfs loop backing, logserver socketpair, lxc
log pipe), and the stale entry keeps firing `EPOLLHUP/EPOLLERR` every
iteration. `pv-main-loop` runs ~140 `epoll_pwait`/sec doing no useful
work.

## Verification on Pi 5 (asacasa/labslave_rpi5)

5 containers running (core-image-base, os, pv-llama, pvr-sdk,
pvwificonnect, tailscale, pv-perf). Strace before and after:

**Before** (broken):
```
epoll_pwait(6, [{events=EPOLLHUP, data={u32=36}},
                {events=EPOLLHUP, data={u32=62}},
                {events=EPOLLHUP, data={u32=68}}], 32, 1996, ...) = 3
epoll_pwait(6, [...same 3 EPOLLHUP...], 32, 1995, ...) = 3
... (140/sec, fd 62 → /storage/trails/X/tailscale/root.squashfs)
```
- pv-main-loop CPU: **25%**
- vol/5s = 0–6, nonvol/5s = 250–346 (CPU-bound spin)

**After** (this fix):
```
epoll_pwait(6, [], 32, 1096, NULL, 8) = 0
```
- pv-main-loop CPU: **0%**
- vol/5s = 24, nonvol/5s = 0 (healthy event-driven sleep)

## Soak test — container restart loop

5 cycles of `pvcontrol containers stop tailscale` / `start tailscale`
(5 new listener registrations + cleanups in series):

| cycle | vol/3s | nonvol/3s |
|---|---|---|
| 1 | 13 | 2 |
| 2 | 15 | 9 |
| 3 | 8 | 3 |
| 4 | 5 | 2 |
| 5 | 24 | 3 |

Final pv-main-loop CPU: **0%**. Final `epoll_pwait` shows only
legitimate events (EPOLLIN/EPOLLOUT on real fds + timeout) — zero
EPOLLHUP phantoms accumulated across the 5 cycles. No leak under
restart pressure.

## Side effects of the bug (beyond CPU)

1. **Cumulative leak per container start** — auto-recovery + OTA
   restarts grow the live leak count over time (until self-cure).
2. **Tail latency on real events** — pv-ctrl HTTP, state-machine timers,
   ph-logger upload all gain ~7 ms per iteration.
3. **Watchdog starvation risk** — `pv_wdt_kick` runs from the state
   machine; on small boards with many container restarts, kicks can
   drift past the timeout and the SoC hardware-resets.
4. **`struct event` memory leak** — small (~64 B per leak) but
   unbounded across restarts.
5. **Misleading diagnostics** — anyone inspecting `/proc/$PID/fd/` sees
   apparent files in epoll (squashfs, log pipe) and is sent down the
   wrong investigation path.

## Fix

Two-part fix; either alone closes the bug for new code paths but both
together are needed to avoid regressions if a future caller forgets
the order:

- `event/event_socket.c`: call `event_del(listener->ev)` before
  `event_free(listener->ev)` so the kernel removes the fd from the
  epoll set while it is still open.
- `platforms.c`: call `pv_event_socket_ignore` **before**
  `close(pipefd[0])` so the `EPOLL_CTL_DEL` syscall sees a still-valid
  fd.

## Test plan

- [x] Build BSP, deploy to Pi 5
- [x] Confirm pv-main-loop CPU drops from 25% to 0%
- [x] Confirm vol/nonvol ctxt-switch ratio inverts (0:300 → 24:0 per 5s)
- [x] Confirm `epoll_pwait` blocks on full timeout instead of returning immediately with EPOLLHUP×3
- [x] Soak with 5x container restart cycles — leak count stays at 0, pv-main-loop stays at 0% CPU