### PR TITLE
fix(parser): correctly walk multi-element service-object arrays

### DIFF
--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -763,12 +763,28 @@ static int platform_services_add(struct pv_platform *p, plat_service_t type,
 	size = jsmnutil_array_count(buf, tokv);
 	if (size <= 0)
 		goto out;
+	/* Iterate the array of service objects directly off the parsed
+	 * jsmn token stream rather than via pv_json_array_get_one_str.
+	 * That helper advances *tok by exactly one token per call which
+	 * is fine for arrays of primitives but lands inside the previous
+	 * object on arrays of objects — second-and-later entries get
+	 * mis-parsed (the first key of the prior object surfaces as a
+	 * bogus element with no `name`, and platform validation then
+	 * fails with "required service '(null)' not found"). Walk the
+	 * subtree explicitly using start/end byte offsets, bounded by
+	 * tokv+tokc so we never read past the token array. */
 	t = tokv + 1;
-	for (int i = 0; i < size; i++) {
-		int svc_c;
-		char *svc_s = pv_json_array_get_one_str(buf, &size, &t);
+	jsmntok_t *tok_end = tokv + tokc;
+	for (int i = 0; i < size && t < tok_end; i++) {
+		int el_start = t->start;
+		int el_end = t->end;
+		int el_len = el_end - el_start;
+		char *svc_s = calloc(el_len + 1, 1);
 		if (!svc_s)
 			break;
+		memcpy(svc_s, buf + el_start, el_len);
+
+		int svc_c;
 		if (jsmnutil_parse_json(svc_s, &sv, &svc_c) > 0) {
 			char *n = pv_json_get_value(svc_s, "name", sv, svc_c);
 			char *t_s = pv_json_get_value(svc_s, "type", sv, svc_c);
@@ -796,6 +812,14 @@ static int platform_services_add(struct pv_platform *p, plat_service_t type,
 						svc_s, NULL, NULL, NULL);
 		}
 		free(svc_s);
+
+		/* Advance past the entire subtree of this element. Any
+		 * descendant token has start > el_start and start < el_end;
+		 * stop when we land on a token whose start is at or past
+		 * el_end (i.e. the next sibling). */
+		t++;
+		while (t < tok_end && t->start < el_end)
+			t++;
 	}
 	ret = 1;
 out:
@@ -868,11 +892,22 @@ static int parse_service_exports(struct pv_state *s, struct pv_platform *p,
 			goto out;
 		t = tokv + 1;
 	}
-	for (int i = 0; i < size; i++) {
-		int svc_c;
-		char *svc_s = pv_json_array_get_one_str(buf, &size, &t);
+	/* Walk the array of objects via byte offsets — same reasoning
+	 * as platform_services_add. The bound is the end of whichever
+	 * token array we just parsed: services_tokv if we used the
+	 * new {"services":[...]} format, otherwise tokv. */
+	jsmntok_t *tok_end =
+		services_tokv ? services_tokv + services_tokc : tokv + tokc;
+	for (int i = 0; i < size && t < tok_end; i++) {
+		int el_start = t->start;
+		int el_end = t->end;
+		int el_len = el_end - el_start;
+		char *svc_s = calloc(el_len + 1, 1);
 		if (!svc_s)
 			break;
+		memcpy(svc_s, buf + el_start, el_len);
+
+		int svc_c;
 		if (jsmnutil_parse_json(svc_s, &sv, &svc_c) > 0) {
 			char *n = pv_json_get_value(svc_s, "name", sv, svc_c);
 			char *t_s = pv_json_get_value(svc_s, "type", sv, svc_c);
@@ -889,6 +924,10 @@ static int parse_service_exports(struct pv_state *s, struct pv_platform *p,
 			free(sv);
 		}
 		free(svc_s);
+
+		t++;
+		while (t < tok_end && t->start < el_end)
+			t++;
 	}
 	ret = 1;
 out:


### PR DESCRIPTION
## Summary

Fixes a parser bug in \`platform_services_add\` and \`parse_service_exports\` that silently truncates and mis-parses multi-element \`PV_SERVICES_REQUIRED\` and \`services.json\` arrays.

## Root cause

Both functions used \`pv_json_array_get_one_str\` to walk an array of service objects. That helper has two issues that compound:

1. **Loop bound aliased with the helper's decrement counter.** The original code:
   \`\`\`c
   size = jsmnutil_array_count(...);
   for (int i = 0; i < size; i++) {
       char *svc_s = pv_json_array_get_one_str(buf, &size, &t);
       ...
   }
   \`\`\`
   \`pv_json_array_get_one_str\` decrements \`*size\` per call. Reading the same \`size\` as the loop bound exits the loop after \`ceil(N/2)\` entries — N=2 → 1 of 2 processed, etc.

2. **Token advance is one position, not one subtree.** The helper does \`(*tok)++\` after consuming an element. For arrays of primitives this is correct, but for arrays of objects it lands inside the previous object on the very next call. Subsequent iterations parse the *previous* element's first key as if it were the next array element. The result is service entries with NULL \`name\`, and platform validation then bails out with \`required service '(null)' not found\`.

## How it surfaces

Two requirements in an agent-app's \`PV_SERVICES_REQUIRED\`:

\`\`\`json
{
    \"PV_SERVICES_REQUIRED\": [
        { \"name\": \"log-feed\", \"target\": \"/run/pv/services/log-feed.sock\" },
        { \"name\": \"pv-llama\", \"target\": \"/run/pv/services/pv-llama.sock\" }
    ]
}
\`\`\`

\`/xconnect-graph\` returned only the \`log-feed\` link. Both services were declared and reachable; the parser dropped \`pv-llama\` on the floor before the graph builder ever saw it. \`pv-xconnect\` therefore never wired the consumer-side socket, and the consumer agent saw \`/run/pv/services/pv-llama.sock\` missing forever.

## Fix

Walk the array of object elements directly off the parsed jsmn token stream, using the array-element token's \`start\`/\`end\` byte offsets in the source buffer to copy each element and advance past its entire subtree. Iteration is bounded by \`tokv + tokc\` so the walker never reads past the parsed token array.

Other call sites of \`pv_json_array_get_one_str\` use the \`while ((str = get_one_str(...)))\` idiom over arrays of primitives, where one-token advance is correct. The helper is left unchanged to preserve that behaviour; we only replace the two object-array call sites.

## Verification on labslave_rpi5

Before fix:
\`\`\`
$ pvcontrol graph ls
[{\"consumer\":\"agentic-example-log-triage\",
  \"provider\":\"agentic-log-feed\",
  \"name\":\"log-feed\", ... }]
# pv-llama edge missing
\`\`\`

After fix:
\`\`\`
$ pvcontrol graph ls
[{\"consumer\":\"agentic-example-log-triage\",
  \"provider\":\"agentic-log-feed\",
  \"name\":\"log-feed\", \"target\":\"/run/pv/services/log-feed.sock\", ...},
 {\"consumer\":\"agentic-example-log-triage\",
  \"provider\":\"pv-llama\",
  \"name\":\"pv-llama\", \"target\":\"/run/pv/services/pv-llama.sock\", ...}]
\`\`\`

End-to-end: agent-app receives a log event from the log-feed feed, calls pv-llama via the consumer-side UDS, publishes a JSON verdict to its action sink. Confirmed live on the device.

## Test plan

- [x] On-device verification via \`agentic-example-log-triage\` with two required services
- [x] grep shows other \`pv_json_array_get_one_str\` call sites all iterate primitive arrays — those continue to work via the helper unchanged
- [ ] Unit test covering N=2 and N=3 service arrays (follow-up)