### PR TITLE
fix(update): rollback local revs when Hub turns unstable mid-testing

### DIFF
--- a/pantahub/pantahub.c
+++ b/pantahub/pantahub.c
@@ -952,6 +952,11 @@ bool pv_pantahub_is_online()
 	return pv_pantahub_proto_is_online();
 }
 
+bool pv_pantahub_was_ever_online()
+{
+	return pv_pantahub_proto_was_ever_online();
+}
+
 bool pv_pantahub_got_any_failure()
 {
 	return pv_pantahub_proto_got_any_failure();

--- a/pantahub/pantahub.h
+++ b/pantahub/pantahub.h
@@ -62,6 +62,7 @@ void pv_pantahub_evaluate_state(void);
 bool pv_pantahub_is_reporting(void);
 
 bool pv_pantahub_is_online(void);
+bool pv_pantahub_was_ever_online(void);
 bool pv_pantahub_got_any_failure(void);
 
 bool pv_pantahub_is_progress_queue_empty(void);

--- a/pantahub/pantahub_proto.c
+++ b/pantahub/pantahub_proto.c
@@ -76,6 +76,7 @@ typedef enum {
 struct pv_pantahub_session {
 	char *token;
 	bool online;
+	bool was_ever_online;
 	short failed_requests;
 	bool any_failed_request;
 
@@ -99,6 +100,7 @@ void pv_pantahub_proto_init()
 {
 	session.token = NULL;
 	session.online = false;
+	session.was_ever_online = false;
 	session.failed_requests = UNRESPONSIVE_REQUESTS_MAX;
 	session.any_failed_request = false;
 
@@ -263,6 +265,11 @@ bool pv_pantahub_proto_is_online()
 	return session.online;
 }
 
+bool pv_pantahub_proto_was_ever_online()
+{
+	return session.was_ever_online;
+}
+
 bool pv_pantahub_proto_got_any_failure()
 {
 	return session.any_failed_request;
@@ -387,8 +394,10 @@ static void _recv_post_auth_cb(struct evhttp_request *req, void *ctx)
 	}
 
 	session.token = pv_pantahub_msg_parse_session_token(body);
-	if (session.token)
+	if (session.token) {
 		pv_log(DEBUG, "got new token");
+		session.was_ever_online = true;
+	}
 
 out:
 	if (body)

--- a/pantahub/pantahub_proto.h
+++ b/pantahub/pantahub_proto.h
@@ -31,6 +31,7 @@ void pv_pantahub_proto_reset_fail(void);
 void pv_pantahub_proto_reset_trails_status(void);
 
 bool pv_pantahub_proto_is_online(void);
+bool pv_pantahub_proto_was_ever_online(void);
 bool pv_pantahub_proto_got_any_failure(void);
 
 bool pv_pantahub_proto_is_any_progress_request_pending(void);

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -200,7 +200,8 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 		// after a reboot...
 		json = pv_storage_get_state_json(pv_bootloader_get_rev());
 		if (!json) {
-			pv_log(ERROR, "get_state_json returned NULL for rev '%s'",
+			pv_log(ERROR,
+			       "get_state_json returned NULL for rev '%s'",
 			       pv_bootloader_get_rev());
 			pv_update_set_error_no_state_json();
 			goto out;
@@ -443,6 +444,18 @@ static pv_state_t pv_wait_network(struct pantavisor *pv)
 	ph_logger_toggle(pv->state->rev);
 	// new ph client state machine
 	pv_pantahub_start();
+
+	// rollback local revisions during TESTING only if the Hub was reachable
+	// at some point during this boot and then turned unstable. Devices that
+	// have never seen the Hub (e.g. PV_CONTROL_REMOTE_ALWAYS=1 with no
+	// network yet) keep committing locally and are not penalized.
+	if (pv_update_is_testing() && pv_pantahub_was_ever_online() &&
+	    pv_pantahub_got_any_failure()) {
+		pv_log(ERROR,
+		       "Hub was reachable earlier this boot but became unstable during testing. Rolling back...");
+		pv_update_set_error_hub_unstable();
+		return PV_STATE_ROLLBACK;
+	}
 
 	// we don't want to rollback local revisions because of failing Hub comms
 	// which could happen when PV_CONTROL_REMOTE_ALWAYS=1
@@ -883,8 +896,7 @@ static void _arm_wait_timer(int secs, event_callback_fn cb)
 		return;
 
 	if (!wait_timer_ev) {
-		wait_timer_ev =
-			event_new(base, -1, EV_PERSIST, cb, NULL);
+		wait_timer_ev = event_new(base, -1, EV_PERSIST, cb, NULL);
 		if (!wait_timer_ev) {
 			pv_log(ERROR, "could not create wait safety-net timer");
 			return;
@@ -958,7 +970,8 @@ static void _next_state(pv_state_t next_state)
 		return;
 	}
 
-	int interval = (state == PV_STATE_WAIT) ? WAIT_INTERVAL : BLOCK_INTERVAL;
+	int interval =
+		(state == PV_STATE_WAIT) ? WAIT_INTERVAL : BLOCK_INTERVAL;
 
 	// First entry into WAIT / BLOCK_REBOOT: run the handler immediately so
 	// container group progression and command handling do not pay a full


### PR DESCRIPTION
## Summary

Under `PV_CONTROL_REMOTE_ALWAYS=1`, a device with a local revision that successfully talks to the Hub and then loses Hub reachability during TESTING would silently commit to DONE. This happens because the early `pv_update_is_local() goto out` bypass in `pv_wait_network()` skips the existing `is_testing && got_any_failure` rollback branch entirely for local revs.

This change introduces a per-boot, in-memory \"Hub was reachable at some point this boot\" flag and uses it to gate a rollback during TESTING, applied **before** the local bypass.

## Behavior

| Mode | Local rev | Hub history this boot | Behavior |
|---|---|---|---|
| `REMOTE=1` only | yes | n/a | unchanged (`remote_mode=false`, `pv_wait_network` not called) |
| `REMOTE_ALWAYS=1` | yes | never online | unchanged — commits on goal achievement (no first-boot regression) |
| `REMOTE_ALWAYS=1` | yes | was online, then unstable in TESTING | **new** — rolls back |
| any | no (remote rev) | was online, then unstable in TESTING | rolls back via the new branch (also via the existing one, unchanged) |

## Implementation

- `session.was_ever_online` (bool) added to `struct pv_pantahub_session` in `pantahub_proto.c`. Initialized to false in `pv_pantahub_proto_init()`. Set to true inside `_recv_post_auth_cb()` when a session token is parsed (i.e. first successful auth). Never cleared until pantavisor restarts.
- `pv_pantahub_proto_was_ever_online()` getter exposed via `pantahub_proto.h`, wrapped as `pv_pantahub_was_ever_online()` in `pantahub.{c,h}`.
- `pv_wait_network()` in `pantavisor.c`: new branch hoisted above the local bypass, gated on `pv_pantahub_was_ever_online() && pv_pantahub_got_any_failure()` during TESTING. Existing branches preserved as a safety net.

## Test plan

- [ ] PV_CONTROL_REMOTE_ALWAYS=1, factory-style local revision, no network ever — boots, reaches DONE, commits.
- [ ] PV_CONTROL_REMOTE_ALWAYS=1, local revision, brought online (auth succeeds) then network cut during TESTING — observe \"Hub was reachable earlier this boot but became unstable during testing. Rolling back...\" and a rollback.
- [ ] PV_CONTROL_REMOTE_ALWAYS=1, local revision, fully online during TESTING — commits to DONE as before.
- [ ] PV_CONTROL_REMOTE=1 only, local revision — unchanged path, commits regardless of Hub state.
- [ ] Remote (Hub-pulled) revision — existing INPROGRESS-without-reporting and TESTING-with-failure paths still trigger rollback (regression).