### PR TITLE
fix(update): drive update FSM on the unclaimed path

### DIFF
--- a/pantavisor.c
+++ b/pantavisor.c
@@ -200,7 +200,8 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 		// after a reboot...
 		json = pv_storage_get_state_json(pv_bootloader_get_rev());
 		if (!json) {
-			pv_log(ERROR, "get_state_json returned NULL for rev '%s'",
+			pv_log(ERROR,
+			       "get_state_json returned NULL for rev '%s'",
 			       pv_bootloader_get_rev());
 			pv_update_set_error_no_state_json();
 			goto out;
@@ -501,6 +502,15 @@ static pv_state_t _pv_wait(struct pantavisor *pv)
 			if (pv->unclaimed) {
 				// unclaimed wait operations
 				next_state = pv_wait_unclaimed(pv);
+				// drive the update FSM too: claim is gated on
+				// running a DONE rev, so an unclaimed device that
+				// boots into a try revision (e.g. a local upgrade
+				// installed before claim under
+				// PV_CONTROL_REMOTE_ALWAYS=1) would otherwise
+				// deadlock — claim refuses while INPROGRESS, and
+				// pv_wait_update() never runs from this branch.
+				if (next_state == PV_STATE_WAIT)
+					next_state = pv_wait_update();
 			} else {
 				// rest of network wait stuff: connectivity check. update management,
 				// meta data uppload, ph logger push start...
@@ -883,8 +893,7 @@ static void _arm_wait_timer(int secs, event_callback_fn cb)
 		return;
 
 	if (!wait_timer_ev) {
-		wait_timer_ev =
-			event_new(base, -1, EV_PERSIST, cb, NULL);
+		wait_timer_ev = event_new(base, -1, EV_PERSIST, cb, NULL);
 		if (!wait_timer_ev) {
 			pv_log(ERROR, "could not create wait safety-net timer");
 			return;
@@ -958,7 +967,8 @@ static void _next_state(pv_state_t next_state)
 		return;
 	}
 
-	int interval = (state == PV_STATE_WAIT) ? WAIT_INTERVAL : BLOCK_INTERVAL;
+	int interval =
+		(state == PV_STATE_WAIT) ? WAIT_INTERVAL : BLOCK_INTERVAL;
 
 	// First entry into WAIT / BLOCK_REBOOT: run the handler immediately so
 	// container group progression and command handling do not pay a full


### PR DESCRIPTION
## Summary

An unclaimed device that boots into a try (non-DONE) revision deadlocks: `pv_wait_unclaimed()` refuses to attempt claim while not running a DONE rev, and `pv_wait_update()` — which would drive INPROGRESS → TESTING → DONE — is only called from `pv_wait_network()` on the claimed branch. Result: progress stays at \`{\"status\":\"INPROGRESS\",\"status-msg\":\"Trying new revision\",\"progress\":50,\"retries\":0}\` indefinitely, the pantahub state machine is never started, and reconnecting wlan does nothing because nothing is polling.

In practice this is reachable only under `PV_CONTROL_REMOTE_ALWAYS=1` on a device that boots into a local upgrade before it has been claimed (a remote/Hub-pulled rev cannot exist on an unclaimed device since pulling one requires auth).

## Fix

In `_pv_wait()`, after `pv_wait_unclaimed()` returns `PV_STATE_WAIT`, also call `pv_wait_update()` so the local update lifecycle can complete without Hub involvement:

```c
if (pv->unclaimed) {
    next_state = pv_wait_unclaimed(pv);
    if (next_state == PV_STATE_WAIT)
        next_state = pv_wait_update();
}
```

Once the rev reaches DONE, claim proceeds normally on the next tick. If goals fail/timeout, `pv_wait_update()` returns `PV_STATE_ROLLBACK` and the device recovers. This matches the semantics already in place for local revs under `PV_CONTROL_REMOTE`-only mode.

## Behavior

| Mode | Claimed | Rev | Pre-fix | Post-fix |
|---|---|---|---|---|
| any | yes | any | normal flow | unchanged |
| `REMOTE` only | no | local try | `pv->remote_mode=false`, takes plain-`else` path → commits | unchanged |
| `REMOTE_ALWAYS=1` | no | local try | **deadlocks at INPROGRESS** | commits to DONE on goals; claim then proceeds |
| `REMOTE_ALWAYS=1` | no | factory (DONE) | claim attempts (rev is DONE) | unchanged |

## Test plan

- [ ] `PV_CONTROL_REMOTE_ALWAYS=1`, fresh unclaimed device with a local try rev installed → boots, reaches DONE, then attempts claim on next tick.
- [ ] Same scenario, container goal-timeout during the try rev → rolls back instead of sticking at INPROGRESS.
- [ ] `PV_CONTROL_REMOTE_ALWAYS=1`, unclaimed device on factory rev (DONE) → claim flow unchanged.
- [ ] `PV_CONTROL_REMOTE=1` only, unclaimed device, local try rev → unchanged (\`pv->remote_mode=false\`).
- [ ] Claimed device, any rev → unchanged path.