### PR TITLE
feat(xconnect): TCP service-IP layer with kernel-DNAT fast path + host↔host reachability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ add_executable(pantavisor
 			ctrl/ctrl_upload.h
 			ctrl/ctrl_usrmeta_ep.c
 			ctrl/ctrl_xconnect_graph_ep.c
+			ctrl/ctrl_xconnect_status_ep.c
 			ctrl/ctrl_util.c
 			ctrl/ctrl_util.h
 			daemons.c
@@ -338,6 +339,8 @@ add_executable(pantavisor
 			utils/socket.h
 			utils/str.c
 			utils/strrep.c
+			utils/sysctl.c
+			utils/sysctl.h
 			utils/system.c
 			utils/timer.c
 			utils/tsh.c

--- a/config.c
+++ b/config.c
@@ -112,6 +112,7 @@ typedef enum {
 #define SYSTEM_LIBDIR_DEF "/lib"
 #define SYSTEM_MEDIADIR_DEF "/media"
 #define SYSTEM_RUNDIR_DEF "/pv"
+#define XCONNECT_SERVICES_CIDR_DEF "198.18.0.0/15"
 #define SYSTEM_DISKSDIR_DEF "/run/pantavisor/disks"
 #define SYSTEM_USRDIR_DEF "/usr"
 
@@ -274,7 +275,9 @@ static struct pv_config_entry entries[] = {
 	{ STR, "PV_VOLMOUNT_DM_EXTRA_ARGS", PV | OEM, 0, false,
 	  .value.s = NULL },
 	{ WDT_MODE, "PV_WDT_MODE", PV, 0, false, .value.i = WDT_SHUTDOWN },
-	{ INT, "PV_WDT_TIMEOUT", PV, 0, false, .value.i = 15 }
+	{ INT, "PV_WDT_TIMEOUT", PV, 0, false, .value.i = 15 },
+	{ STR, "PV_XCONNECT_SERVICES_CIDR", PV | OEM | RUN, 0, false,
+	  .value.s = XCONNECT_SERVICES_CIDR_DEF }
 };
 
 struct pv_config_alias {
@@ -366,6 +369,7 @@ static struct pv_config_alias aliases[] = {
 	{ "updater.use_tmp_objects", "PV_UPDATER_USE_TMP_OBJECTS" },
 	{ "wdt.mode", "PV_WDT_MODE" },
 	{ "wdt.timeout", "PV_WDT_TIMEOUT" },
+	{ "xconnect.services.cidr", "PV_XCONNECT_SERVICES_CIDR" },
 	// OTHER COMPATIBLE KEYS
 	{ "meta.cache.dir", "PV_CACHE_USRMETADIR" },
 	{ "pantahub.log.push", "PV_LOG_PUSH" },

--- a/config.h
+++ b/config.h
@@ -130,6 +130,7 @@ typedef enum {
 	PV_VOLMOUNT_DM_EXTRA_ARGS,
 	PV_WDT_MODE,
 	PV_WDT_TIMEOUT,
+	PV_XCONNECT_SERVICES_CIDR,
 	PV_MAX
 } config_index_t;
 

--- a/ctrl/ctrl.c
+++ b/ctrl/ctrl.c
@@ -281,6 +281,7 @@ static void ctrl_add_endpoints()
 	pv_ctrl_endpoints_commands_init();
 	pv_ctrl_endpoints_config_init();
 	pv_ctrl_endpoints_xconnect_graph_init();
+	pv_ctrl_endpoints_xconnect_status_init();
 	pv_ctrl_endpoints_daemons_init();
 }
 

--- a/ctrl/ctrl_endpoints.h
+++ b/ctrl/ctrl_endpoints.h
@@ -35,6 +35,7 @@ int pv_ctrl_endpoints_drivers_init(void);
 int pv_ctrl_endpoints_commands_init(void);
 int pv_ctrl_endpoints_config_init(void);
 int pv_ctrl_endpoints_xconnect_graph_init(void);
+int pv_ctrl_endpoints_xconnect_status_init(void);
 int pv_ctrl_endpoints_daemons_init(void);
 
 #endif

--- a/ctrl/ctrl_xconnect_status_ep.c
+++ b/ctrl/ctrl_xconnect_status_ep.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//
+// /xconnect-status endpoint pair
+// ------------------------------
+// pv-xconnect POSTs an array of {consumer, name, established, last_error}
+// objects on every reconcile pass. We stash the most recent body verbatim and
+// serve it back via GET. A future container-health subsystem inside pantavisor
+// will consume this to gate `pv_platform_start` outcomes on link establishment;
+// for v1.1 the endpoint primarily exists for external observability (test
+// drivers, dashboards, CI assertions).
+//
+// pv-ctrl is single-threaded (libevent), so a plain static buffer with no mutex
+// is safe — POST replaces it, GET dups it, no concurrency.
+//
+#include "ctrl_endpoints.h"
+#include "ctrl.h"
+#include "ctrl_util.h"
+#include "pantavisor.h"
+
+#include <event2/http.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#define MODULE_NAME "xconnect-status-ep"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#include "log.h"
+
+#ifdef PANTAVISOR_XCONNECT
+
+#define XCONNECT_STATUS_MAX_SIZE (64 * 1024)
+
+// Latest status body posted by pv-xconnect. Owned here, replaced on each POST.
+static char *g_status_json = NULL;
+
+static void ctrl_xconnect_status_post(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0)
+		return;
+
+	char *data = pv_ctrl_utils_get_data(req, XCONNECT_STATUS_MAX_SIZE, NULL);
+	if (!data) {
+		pv_ctrl_utils_send_error(req, HTTP_BADREQUEST,
+					 "empty status body");
+		return;
+	}
+
+	free(g_status_json);
+	g_status_json = data; // owned now
+	pv_ctrl_utils_send_ok(req);
+}
+
+static void ctrl_xconnect_status_get(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0)
+		return;
+
+	const char *body = g_status_json ? g_status_json : "[]";
+	pv_ctrl_utils_send_json(req, HTTP_OK, NULL, (char *)body);
+}
+
+#else
+static void ctrl_xconnect_status_post(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0)
+		return;
+	pv_ctrl_utils_send_error(req, HTTP_NOTFOUND,
+				 "xconnect not enabled at build time");
+}
+static void ctrl_xconnect_status_get(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0)
+		return;
+	pv_ctrl_utils_send_error(req, HTTP_NOTFOUND,
+				 "xconnect not enabled at build time");
+}
+#endif
+
+// libevent's evhttp_set_cb only allows one callback per path, so we
+// dispatch GET vs POST inside this single handler.
+static void ctrl_xconnect_status_dispatch(struct evhttp_request *req, void *ctx)
+{
+	enum evhttp_cmd_type m = evhttp_request_get_command(req);
+	if (m == EVHTTP_REQ_POST)
+		ctrl_xconnect_status_post(req, ctx);
+	else
+		ctrl_xconnect_status_get(req, ctx);
+}
+
+int pv_ctrl_endpoints_xconnect_status_init()
+{
+	pv_ctrl_add_endpoint("/xconnect-status",
+			     EVHTTP_REQ_POST | EVHTTP_REQ_GET, true,
+			     ctrl_xconnect_status_dispatch);
+	return 0;
+}

--- a/daemons.c
+++ b/daemons.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -30,6 +31,7 @@
 
 #include "init.h"
 #include "daemons.h"
+#include "config.h"
 #include "tsh.h"
 
 #define MODULE_NAME "daemons"
@@ -82,11 +84,23 @@ struct pv_init_daemon *pv_init_get_daemons(void)
 	return daemons;
 }
 
+// Export config values that managed daemons consume via env. Children
+// inherit our environment on fork+exec, so a single setenv() here is
+// enough; no per-daemon env plumbing needed.
+static void daemons_export_env(void)
+{
+	char *cidr = pv_config_get_str(PV_XCONNECT_SERVICES_CIDR);
+	if (cidr && cidr[0])
+		setenv("PV_XCONNECT_SERVICES_CIDR", cidr, 1);
+}
+
 int pv_init_spawn_daemons(init_mode_t mode)
 {
 	int i = 0;
 	struct stat sb;
 	unsigned int mode_flag = (1 << mode);
+
+	daemons_export_env();
 
 	sigset_t blocked_sig, old_sigset;
 	sigemptyset(&blocked_sig);

--- a/ipam.c
+++ b/ipam.c
@@ -27,6 +27,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "utils/sysctl.h"
+
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
@@ -641,10 +643,10 @@ static int setup_nat(struct pv_ip_pool *pool)
 	mask_host = ntohl(pool->mask);
 	prefix_len = __builtin_popcount(mask_host);
 
-	// Enable IP forwarding
-	ret = system("echo 1 > /proc/sys/net/ipv4/ip_forward");
-	if (ret != 0) {
-		pv_log(WARN, "failed to enable IP forwarding");
+	// Enable IP forwarding via direct /proc/sys write (no shell fork).
+	if (pv_sysctl_write("/proc/sys/net/ipv4/ip_forward", "1\n") != 0) {
+		pv_log(WARN, "failed to enable IP forwarding: %s",
+		       strerror(errno));
 	}
 
 	// Prefer nftables (default on modern distros and kernel-native since

--- a/parser/parser_system1.c
+++ b/parser/parser_system1.c
@@ -751,6 +751,8 @@ static service_type_t service_str_to_type(char *str)
 		return SVC_TYPE_WAYLAND;
 	if (!strcmp(str, "input"))
 		return SVC_TYPE_INPUT;
+	if (!strcmp(str, "tcp"))
+		return SVC_TYPE_TCP;
 	return SVC_TYPE_UNKNOWN;
 }
 
@@ -914,14 +916,24 @@ static int parse_service_exports(struct pv_state *s, struct pv_platform *p,
 			char *t_s = pv_json_get_value(svc_s, "type", sv, svc_c);
 			char *sock =
 				pv_json_get_value(svc_s, "socket", sv, svc_c);
+			char *port_s =
+				pv_json_get_value(svc_s, "port", sv, svc_c);
+			uint16_t port = 0;
+			if (port_s) {
+				long v = strtol(port_s, NULL, 10);
+				if (v > 0 && v <= 65535)
+					port = (uint16_t)v;
+			}
 			pv_platform_add_service_export(
-				p, service_str_to_type(t_s), n, sock);
+				p, service_str_to_type(t_s), n, sock, port);
 			if (n)
 				free(n);
 			if (t_s)
 				free(t_s);
 			if (sock)
 				free(sock);
+			if (port_s)
+				free(port_s);
 			free(sv);
 		}
 		free(svc_s);

--- a/platforms.c
+++ b/platforms.c
@@ -1195,9 +1195,24 @@ int pv_platform_start(struct pv_platform *p)
 
 	pv_paths_storage_trail_file(path, PATH_MAX, s->rev, filename);
 
+	// Manifest-level network-anchor invariant for xconnect participants:
+	// any container that touches the service mesh (exports a service via
+	// services.json or requires one via services.required) must declare
+	// a network anchor in run.json — either an IPAM pool or explicit
+	// host mode. Pantavisor never silently rewrites a container's
+	// network config; ambiguity is a hard parse-time failure that flows
+	// through the existing status-goal/rollback machinery.
+	if (pv_platform_is_service_participant(p) && !p->network) {
+		pv_log(ERROR,
+		       "platform '%s' touches xconnect services but declares no network anchor; specify network.pool or network.mode=host in run.json",
+		       p->name);
+		return -1;
+	}
+
 	// Give the backend plugin a chance to veto the start on backend-
 	// specific config problems (e.g. the LXC plugin refuses an IPAM
-	// pool-using container that also bakes lxc.net.* / keep=net).
+	// pool-using container that also bakes lxc.net.* / keep=net, or a
+	// host-net service participant that does NOT bake lxc.net.*).
 	if (ctrl->validate_config && ctrl->validate_config(p, path) != 0) {
 		pv_log(ERROR,
 		       "platform '%s' refused by backend pre-start validation",
@@ -1504,6 +1519,14 @@ bool pv_platform_check_running(struct pv_platform *p)
 	}
 
 	return running;
+}
+
+bool pv_platform_is_service_participant(struct pv_platform *p)
+{
+	if (!p)
+		return false;
+	return !dl_list_empty(&p->services) ||
+	       !dl_list_empty(&p->service_exports);
 }
 
 bool pv_platform_is_installed(struct pv_platform *p)

--- a/platforms.c
+++ b/platforms.c
@@ -1657,7 +1657,7 @@ void pv_platform_add_service(struct pv_platform *p, plat_service_t type,
 
 void pv_platform_add_service_export(struct pv_platform *p,
 				    service_type_t svc_type, char *name,
-				    char *socket)
+				    char *socket, uint16_t port)
 {
 	struct pv_platform_service_export *se =
 		calloc(1, sizeof(struct pv_platform_service_export));
@@ -1669,6 +1669,7 @@ void pv_platform_add_service_export(struct pv_platform *p,
 		se->name = strdup(name);
 	if (socket)
 		se->socket = strdup(socket);
+	se->port = port;
 	dl_list_init(&se->list);
 	dl_list_add_tail(&p->service_exports, &se->list);
 }

--- a/platforms.h
+++ b/platforms.h
@@ -217,6 +217,11 @@ void pv_platform_set_recovering(struct pv_platform *p);
 int pv_platform_set_ready(struct pv_platform *p);
 void pv_platform_set_updated(struct pv_platform *p);
 
+// True if the platform participates in the xconnect service mesh,
+// either by exporting a service via services.json or by requiring one
+// via services.required. Used to gate network-anchor invariants.
+bool pv_platform_is_service_participant(struct pv_platform *p);
+
 bool pv_platform_is_installed(struct pv_platform *p);
 bool pv_platform_is_blocked(struct pv_platform *p);
 bool pv_platform_is_starting(struct pv_platform *p);

--- a/platforms.h
+++ b/platforms.h
@@ -23,6 +23,7 @@
 #define PV_PLATFORMS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <sys/types.h>
 
@@ -66,7 +67,8 @@ typedef enum {
 	SVC_TYPE_UNIX,
 	SVC_TYPE_DRM,
 	SVC_TYPE_WAYLAND,
-	SVC_TYPE_INPUT
+	SVC_TYPE_INPUT,
+	SVC_TYPE_TCP, // IP/TCP service, addressable by ClusterIP+port
 } service_type_t;
 
 typedef enum {
@@ -89,6 +91,7 @@ struct pv_platform_service_export {
 	service_type_t svc_type;
 	char *name;
 	char *socket;
+	uint16_t port; // For SVC_TYPE_TCP: backend port. Zero otherwise.
 	struct dl_list list;
 };
 typedef enum {
@@ -193,7 +196,7 @@ void pv_platform_add_service(struct pv_platform *p, plat_service_t type,
 			     char *interface, char *target);
 void pv_platform_add_service_export(struct pv_platform *p,
 				    service_type_t svc_type, char *name,
-				    char *socket);
+				    char *socket, uint16_t port);
 int pv_platform_load_drivers(struct pv_platform *p, char *namematch,
 			     plat_driver_t typematch);
 void pv_platform_unload_drivers(struct pv_platform *p, char *namematch,

--- a/plugins/pv_lxc.c
+++ b/plugins/pv_lxc.c
@@ -255,11 +255,20 @@ int pv_validate_container_config(struct pv_platform *p, const char *conf_file)
 	FILE *f;
 	char line[512];
 	bool has_net = false;
+	bool is_pool;
+	bool is_host;
+	bool is_participant;
 
 	if (!p || !conf_file)
 		return 0;
 
-	if (!p->network || p->network->mode != NET_MODE_POOL)
+	is_pool = p->network && p->network->mode == NET_MODE_POOL;
+	is_host = p->network && p->network->mode == NET_MODE_HOST;
+	is_participant = pv_platform_is_service_participant(p);
+
+	// Bail early when neither rule applies: no pool to protect from
+	// stale lxc.net.*, and no service participation to require one.
+	if (!is_pool && !(is_host && is_participant))
 		return 0;
 
 	f = fopen(conf_file, "r");
@@ -283,9 +292,16 @@ int pv_validate_container_config(struct pv_platform *p, const char *conf_file)
 	}
 	fclose(f);
 
-	if (has_net) {
+	if (is_pool && has_net) {
 		pv_log(ERROR,
 		       "platform '%s' declares an IPAM pool but its lxc.container.conf already contains lxc.net.* entries — pantavisor will not overwrite them. Remove the baked lxc.net.* config, or drop the PV_NETWORK_POOL reference.",
+		       p->name);
+		return -1;
+	}
+
+	if (is_host && is_participant && !has_net) {
+		pv_log(ERROR,
+		       "platform '%s' declares network.mode=host and participates in xconnect services but its lxc.container.conf has no lxc.net.* entries — host-net service participants must bring their own network config. Add lxc.net.* to the conf, or declare an IPAM pool instead.",
 		       p->name);
 		return -1;
 	}

--- a/state.c
+++ b/state.c
@@ -30,6 +30,8 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 #include "state.h"
 #include "drivers.h"
@@ -43,6 +45,7 @@
 #include "addons.h"
 #include "pantavisor.h"
 #include "ipam.h"
+#include "config.h"
 #include "storage.h"
 #include "metadata.h"
 #include "update/update.h"
@@ -1938,9 +1941,163 @@ static const char *pvx_svc_type_to_str(service_type_t type)
 		return "wayland";
 	case SVC_TYPE_INPUT:
 		return "input";
+	case SVC_TYPE_TCP:
+		return "tcp";
 	default:
 		return "unknown";
 	}
+}
+
+// Tag a service_type_t with its transport family, so xconnect can pick the
+// right data plane (kernel-DNAT for tcp/tcp, userspace proxy otherwise).
+static const char *pvx_svc_transport_str(service_type_t type)
+{
+	return (type == SVC_TYPE_TCP) ? "tcp" : "unix";
+}
+
+// Deterministic ClusterIP from service name. Mirrors xconnect/services.c:
+// FNV-1a hash mapped into 198.18.0.0/15 (RFC 2544 benchmark range, no
+// avahi/zeroconf/Tailscale conflicts). Same algorithm both sides — pv-ctrl
+// computes and emits, xconnect bind/DNATs the same value. Override via
+// PV_XCONNECT_SERVICES_CIDR is honored on the xconnect side; for graph
+// emission we use the same default unless the config override is set, in
+// which case we read it via pv_config_get_str(PV_XCONNECT_SERVICES_CIDR).
+static uint32_t pvx_fnv1a(const char *s)
+{
+	uint32_t h = 0x811c9dc5u;
+	for (; *s; s++) {
+		h ^= (unsigned char)*s;
+		h *= 0x01000193u;
+	}
+	return h;
+}
+
+static int pvx_parse_cidr(const char *cidr, uint32_t *net_host,
+			  uint32_t *host_mask_host)
+{
+	if (!cidr)
+		return -1;
+	char buf[64];
+	strncpy(buf, cidr, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+	char *slash = strchr(buf, '/');
+	if (!slash)
+		return -1;
+	*slash = '\0';
+	int prefix = atoi(slash + 1);
+	if (prefix < 0 || prefix > 32)
+		return -1;
+	struct in_addr a;
+	if (inet_aton(buf, &a) == 0)
+		return -1;
+	uint32_t netmask = (prefix == 0) ? 0u : (~0u << (32 - prefix));
+	*net_host = ntohl(a.s_addr) & netmask;
+	*host_mask_host = ~netmask;
+	return 0;
+}
+
+static uint32_t pvx_clusterip_for_name(const char *name)
+{
+	if (!name || !name[0])
+		return 0;
+	uint32_t subnet = 0, host_mask = 0;
+	const char *cidr = pv_config_get_str(PV_XCONNECT_SERVICES_CIDR);
+	if (!cidr || pvx_parse_cidr(cidr, &subnet, &host_mask) != 0) {
+		// Fall back to the same default xconnect uses.
+		pvx_parse_cidr("198.18.0.0/15", &subnet, &host_mask);
+	}
+	uint32_t h = pvx_fnv1a(name);
+	uint32_t host_part = h & host_mask;
+	if (host_part == 0)
+		host_part = 1;
+	if (host_part == host_mask)
+		host_part = host_mask - 1;
+	return htonl(subnet | host_part);
+}
+
+// IPAM-allocated IPv4 (network byte order) on the platform's first
+// pool-mode interface. Returns 0 if no such interface (legacy containers,
+// host-net providers — caller decides the fallback policy).
+static uint32_t pvx_platform_ipam_ipv4(struct pv_platform *p)
+{
+	if (!p || !p->network)
+		return 0;
+	struct pv_platform_network_iface *it;
+	dl_list_for_each(it, &p->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (!it->ipv4_address || !it->ipv4_address[0])
+			continue;
+		char tmp[INET_ADDRSTRLEN + 8];
+		strncpy(tmp, it->ipv4_address, sizeof(tmp) - 1);
+		tmp[sizeof(tmp) - 1] = '\0';
+		char *slash = strchr(tmp, '/');
+		if (slash)
+			*slash = '\0';
+		struct in_addr a;
+		if (inet_aton(tmp, &a) != 0)
+			return a.s_addr;
+	}
+	return 0;
+}
+
+// Find the gateway IP of the IPAM pool that a consumer container sits on.
+// For host-net providers (which bind 0.0.0.0 in the host netns), this is
+// the address the consumer reaches the host at — its own default route.
+// Returns 0 if the consumer has no IPAM-pool interface.
+static uint32_t pvx_consumer_pool_gateway(struct pv_platform *consumer)
+{
+	if (!consumer || !consumer->network)
+		return 0;
+	struct pv_platform_network_iface *it;
+	dl_list_for_each(it, &consumer->network->interfaces,
+			 struct pv_platform_network_iface, list)
+	{
+		if (!it->pool || !it->pool[0])
+			continue;
+		struct pv_ip_pool *pool = pv_ipam_find_pool(it->pool);
+		if (pool && pool->gateway)
+			return pool->gateway; // already network byte order
+	}
+	return 0;
+}
+
+// Resolve the provider IP that pv-xconnect should target for this specific
+// (consumer, provider) link.
+//
+//   1. Provider has an IPAM lease  →  its IPAM IP (pool-to-pool service mesh).
+//   2. Provider is host-net AND consumer is on an IPAM pool  →  the gateway
+//      IP of the consumer's pool. Provider binds 0.0.0.0 in the host netns;
+//      from inside the consumer netns the host is reachable at that gateway.
+//      Lets host-services participate in the service mesh without an IPAM
+//      lease of their own.
+//   3. Provider is host-net AND consumer is host-net  →  127.0.0.1. Both
+//      live in the host netns, so loopback is the natural backend;
+//      pv-xconnect's OUTPUT-chain DNAT rewrites the locally generated
+//      packet from ClusterIP → 127.0.0.1 before routing.
+//   4. Otherwise  →  0.0.0.0. xconnect treats that as no resolvable backend
+//      and the link surfaces unhealthy via /xconnect-status.
+static uint32_t pvx_provider_ipv4_for(struct pv_platform *consumer,
+				      struct pv_platform *provider)
+{
+	uint32_t prov = pvx_platform_ipam_ipv4(provider);
+	if (prov)
+		return prov;
+
+	if (provider && provider->network &&
+	    provider->network->mode == NET_MODE_HOST) {
+		uint32_t gw = pvx_consumer_pool_gateway(consumer);
+		if (gw)
+			return gw;
+
+		// Host-net provider + host-net consumer: backend is loopback.
+		// Reachable only via the OUTPUT-chain DNAT installed by
+		// pv-xconnect's services_nft layer.
+		if (consumer && consumer->network &&
+		    consumer->network->mode == NET_MODE_HOST)
+			return htonl(INADDR_LOOPBACK);
+	}
+	return 0;
 }
 
 char *pv_state_get_xconnect_graph_json(struct pv_state *s)
@@ -2040,6 +2197,73 @@ char *pv_state_get_xconnect_graph_json(struct pv_state *s)
 								pv_json_ser_string(
 									&js,
 									exp->socket);
+
+								// Service-IP layer: emit
+								// cluster_ip / provider_ip / ports
+								// / transports for TCP services.
+								// Other types keep legacy shape.
+								if (exp->svc_type ==
+								    SVC_TYPE_TCP) {
+									uint32_t cip =
+										pvx_clusterip_for_name(
+											svc->name);
+									uint32_t pip =
+										pvx_provider_ipv4_for(
+											cp, pp);
+									char ipbuf
+										[INET_ADDRSTRLEN];
+									struct in_addr a;
+
+									a.s_addr = cip;
+									inet_ntop(AF_INET,
+										  &a,
+										  ipbuf,
+										  sizeof(ipbuf));
+									pv_json_ser_key(
+										&js,
+										"cluster_ip");
+									pv_json_ser_string(
+										&js,
+										ipbuf);
+									pv_json_ser_key(
+										&js,
+										"cluster_port");
+									pv_json_ser_number(
+										&js,
+										exp->port);
+
+									a.s_addr = pip;
+									inet_ntop(AF_INET,
+										  &a,
+										  ipbuf,
+										  sizeof(ipbuf));
+									pv_json_ser_key(
+										&js,
+										"provider_ip");
+									pv_json_ser_string(
+										&js,
+										ipbuf);
+									pv_json_ser_key(
+										&js,
+										"provider_port");
+									pv_json_ser_number(
+										&js,
+										exp->port);
+									pv_json_ser_key(
+										&js,
+										"provider_transport");
+									pv_json_ser_string(
+										&js,
+										pvx_svc_transport_str(
+											exp->svc_type));
+									pv_json_ser_key(
+										&js,
+										"consumer_transport");
+									pv_json_ser_string(
+										&js,
+										pvx_svc_transport_str(
+											exp->svc_type));
+								}
 							}
 							pv_json_ser_object_pop(
 								&js);

--- a/utils/sysctl.c
+++ b/utils/sysctl.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "sysctl.h"
+
+int pv_sysctl_write(const char *path, const char *value)
+{
+	if (!path || !value)
+		return -1;
+
+	int fd = open(path, O_WRONLY | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+
+	size_t len = strlen(value);
+	ssize_t n;
+	int saved_errno = 0;
+	do {
+		n = write(fd, value, len);
+	} while (n < 0 && errno == EINTR);
+	if (n < 0)
+		saved_errno = errno;
+	close(fd);
+
+	if (n < 0) {
+		errno = saved_errno;
+		return -1;
+	}
+	return 0;
+}

--- a/utils/sysctl.h
+++ b/utils/sysctl.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef PV_UTILS_SYSCTL_H
+#define PV_UTILS_SYSCTL_H
+
+// Write `value` (caller chooses trailing newline if desired) to a /proc/sys
+// path. Direct open()/write()/close() — no fork, no shell.
+//
+// Returns 0 on success, -1 on failure (errno preserved). Use this instead of
+// `system("echo ... > /proc/sys/...")` everywhere.
+int pv_sysctl_write(const char *path, const char *value);
+
+#endif

--- a/xconnect/CMakeLists.txt
+++ b/xconnect/CMakeLists.txt
@@ -17,13 +17,18 @@ include_directories(
 add_executable(pv-xconnect
     main.c
     plumbing.c
+    services.c
+    services_bridge.c
+    services_nft.c
     plugins/unix.c
     plugins/rest.c
+    plugins/tcp.c
     plugins/drm.c
     plugins/wayland.c
     plugins/dbus.c
     ../utils/json.c
     ../utils/str.c
+    ../utils/sysctl.c
 )
 
 target_link_libraries(pv-xconnect

--- a/xconnect/XCONNECT.md
+++ b/xconnect/XCONNECT.md
@@ -268,6 +268,29 @@ pvcurl -X PUT --data '{"action":"stop"}' --unix-socket /run/pantavisor/pv/pv-ctr
 
 A CLI wrapper around pvcurl for common pv-ctrl operations.
 
+## Service-IP layer (k8s-Services-style)
+
+On top of the legacy unix-socket / dbus / drm / wayland mediation, xconnect supports **named TCP services with stable virtual ClusterIPs and DNS** (`<service>.pv.local`). Provider declares `type: tcp, port: N` in `services.json`, consumer declares the service name in `args.json`, and the runtime wires up:
+
+1. **ClusterIP** — deterministic FNV-1a hash of the service name into a configurable subnet (default `198.18.0.0/15`, RFC 2544 benchmark range; override via `pantavisor.config` key `xconnect.services.cidr` or env `PV_XCONNECT_SERVICES_CIDR`). Reboot-stable without on-disk allocator state.
+2. **`pv-services` bridge** — owns each ClusterIP as a `/32`. Brought up by `pv-xconnect` on start; idempotent.
+3. **Two-tier data plane**:
+   - **Tier 1 (TCP→TCP, kernel forward)**: `inet pvx_services` PREROUTING rule rewrites `cluster_ip:port → backend_ip:port`. Zero-copy. Used by default for embedded throughput.
+   - **Tier 2 (cross-transport)**: userspace listener on ClusterIP, proxies bytes to a unix-socket backend (or to TCP with TLS termination etc.). Same `evconnlistener` shape as `unix.c` / `rest.c`.
+4. **DNS** — `<service>.pv.local` injected into the consumer's `/etc/hosts` via mount-namespace setns. Marker comment (`# pvx-services managed`) so re-injection / removal touches only managed lines.
+5. **Failure semantics** — hosts injection failure (read-only fs, missing file, EPERM, setns fail) is a **hard link establishment failure**: `last_error` is set, link stays in retry queue, never silently dropped. Surfaces via `/xconnect-graph/status` (v1.1) to drive pantavisor's health/rollback path.
+
+Manifest example (provider):
+```json
+{"#spec": "service-manifest-xconnect@2", "services": [{"name": "my-api", "type": "tcp", "port": 8080}]}
+```
+
+Code map: `xconnect/services.c` (hash + range parsing), `xconnect/services_bridge.{c,h}` (bridge + /32s + ip_forward), `xconnect/services_nft.{c,h}` (DNAT table), `xconnect/plugins/tcp.c` (per-link plugin with kernel-forward / userspace-proxy branch), `xconnect/plumbing.c:pvx_helper_inject_hosts_entry`. pv-ctrl side: `state.c:pv_state_get_xconnect_graph_json` emits `cluster_ip` / `provider_ip` / port / transport when `svc_type == SVC_TYPE_TCP`.
+
+Status (v1): TCP→TCP fast path, ClusterIP, DNS, config knob, IPAM coexistence — all wired and tested. Cross-transport plugin, `/xconnect-graph/status` endpoint, and `pv_platform_start` health gate are deferred to v1.1; multi-backend policies and an explicit `services` block in `device.json` to v2.
+
+See [meta-pantavisor `docs/overview/xconnect-services.md`](https://github.com/pantavisor/meta-pantavisor/blob/master/docs/overview/xconnect-services.md) for the integrator's view.
+
 ## Testing
 
 For testing instructions and example containers, see the `meta-pantavisor` layer documentation:

--- a/xconnect/include/xconnect.h
+++ b/xconnect/include/xconnect.h
@@ -27,10 +27,19 @@
 #include <event2/bufferevent.h>
 #include <event2/listener.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/queue.h>
 
 // We use the same list implementation as pantavisor if available
 #include "../../utils/list.h"
+
+// Transport classification of a link endpoint.
+// PVX_TRANSPORT_UNIX  - unix-domain socket (legacy default; provider_socket carries path)
+// PVX_TRANSPORT_TCP   - IP/TCP service (provider_ip:provider_port carries endpoint)
+typedef enum {
+	PVX_TRANSPORT_UNIX = 0,
+	PVX_TRANSPORT_TCP = 1,
+} pvx_transport_t;
 
 struct pvx_link {
 	char *consumer;
@@ -44,10 +53,29 @@ struct pvx_link {
 	char *provider_socket;
 	char *consumer_socket; // Virtual socket path
 
+	// Service / IP layer (added with services-IP feature).
+	// cluster_ip is the stable virtual IP minted from the service name;
+	// provider_ip/provider_port is the live backend (looked up via IPAM
+	// when pv-ctrl builds the graph). Both sides use network-byte-order
+	// uint32_t for IPv4. Zero means "not set".
+	uint32_t cluster_ip;
+	uint16_t cluster_port;
+	uint32_t provider_ip;
+	uint16_t provider_port;
+	pvx_transport_t provider_transport;
+	pvx_transport_t consumer_transport;
+
+	// Last error message recorded by reconcile/plugins on a failed link
+	// establishment. Heap-allocated, owned by pvx_link, NULL when healthy.
+	// Surfaces via the status endpoint so pantavisor can gate container
+	// health on link establishment.
+	char *last_error;
+
 	struct pvx_plugin *plugin;
 	struct evconnlistener *listener;
 	void *plugin_data;
 	bool established; // Track if link setup completed
+	bool data_plane_up; // Plugin's on_link_added succeeded; don't redo it
 	struct dl_list list;
 };
 
@@ -67,5 +95,29 @@ struct event_base *pvx_get_base(void);
 int pvx_helper_inject_unix_socket(const char *path, int pid);
 int pvx_helper_inject_devnode(const char *target_path, int consumer_pid,
 			      const char *source_path, int provider_pid);
+
+// Inject (or remove) a single line in /etc/hosts inside the consumer's mount
+// namespace. Returns 0 on success, -1 on any failure (read-only fs, missing
+// /etc/hosts, EPERM, setns failure, etc). Callers MUST treat -1 as a hard
+// link-establishment failure: a consumer with broken DNS for a wired service
+// is not a working consumer, and the link must surface unhealthy so pantavisor
+// can apply its standard rollback policy.
+int pvx_helper_inject_hosts_entry(int consumer_pid, const char *hostname,
+				  uint32_t ipv4_network_order);
+int pvx_helper_remove_hosts_entry(int consumer_pid, const char *hostname);
+
+// Service / ClusterIP helpers (services.c).
+//
+// Compute the stable virtual ClusterIP for a service name. Deterministic:
+// FNV-1a over the name, mapped into 198.18.0.0/15 (RFC 2544 benchmark
+// range, not routable, no userland conflicts — see services.c for why
+// we avoid 169.254/16 and the RFC1918 / CGNAT ranges). Same name always
+// yields the same IP across reboots, so no persistence is required.
+// Returns the IP in network byte order, or 0 if name is NULL/empty.
+uint32_t pvx_service_clusterip(const char *service_name);
+
+// Compute the stable hostname for a service: "<name>.pv.local".
+// Caller frees. Returns NULL on allocation failure or empty input.
+char *pvx_service_hostname(const char *service_name);
 
 #endif

--- a/xconnect/main.c
+++ b/xconnect/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <signal.h>
 #include <string.h>
 #include <errno.h>
@@ -7,6 +8,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <arpa/inet.h>
 #include <event2/event.h>
 #include <event2/bufferevent.h>
 #include <event2/buffer.h>
@@ -16,6 +18,8 @@
 #include "utils/json.h"
 
 #include "include/xconnect.h"
+#include "services_bridge.h"
+#include "services_nft.h"
 
 #define PV_CTRL_SOCKET "/run/pantavisor/pv/pv-ctrl"
 #define RECONCILE_INTERVAL_SEC 5
@@ -26,13 +30,16 @@ static struct event *g_reconcile_timer;
 
 extern struct pvx_plugin pvx_plugin_unix;
 extern struct pvx_plugin pvx_plugin_rest;
+extern struct pvx_plugin pvx_plugin_tcp;
 extern struct pvx_plugin pvx_plugin_dbus;
 extern struct pvx_plugin pvx_plugin_drm;
 extern struct pvx_plugin pvx_plugin_wayland;
 
-static struct pvx_plugin *plugins[] = { &pvx_plugin_unix,    &pvx_plugin_rest,
-					&pvx_plugin_dbus,    &pvx_plugin_drm,
-					&pvx_plugin_wayland, NULL };
+static struct pvx_plugin *plugins[] = {
+	&pvx_plugin_unix, &pvx_plugin_rest,    &pvx_plugin_tcp,
+	&pvx_plugin_dbus, &pvx_plugin_drm,     &pvx_plugin_wayland,
+	NULL
+};
 
 struct event_base *pvx_get_base(void)
 {
@@ -73,21 +80,72 @@ static void pvx_link_free(struct pvx_link *link)
 	free(link->interface);
 	free(link->consumer_socket);
 	free(link->type);
+	free(link->last_error);
 	free(link);
 }
 
 static int parse_pid_field(const char *json, const char *key, jsmntok_t *tokv,
 			   int tokc)
 {
+	// pv-ctrl emits transitional values like consumer_pid:-1 while a
+	// container is starting; we treat those as "not ready" (return 0)
+	// so the link stays unestablished and reconcile retries on the next
+	// pass. Real pids parse via the existing string path; the int helper
+	// is a fallback for primitives the string getter doesn't surface.
 	char *pid_str = pv_json_get_value(json, key, tokv, tokc);
-	if (!pid_str)
-		return 0;
-
-	char *endptr;
-	long val = strtol(pid_str, &endptr, 10);
-	int pid = (*endptr == '\0' && val > 0 && val <= INT_MAX) ? (int)val : 0;
-	free(pid_str);
+	int pid = 0;
+	if (pid_str) {
+		char *endptr;
+		long val = strtol(pid_str, &endptr, 10);
+		if (*endptr == '\0' && val > 0 && val <= INT_MAX)
+			pid = (int)val;
+		free(pid_str);
+	} else {
+		pid = pv_json_get_value_int(json, key, tokv, tokc);
+		if (pid <= 0)
+			pid = 0;
+	}
 	return pid;
+}
+
+// Returns network-byte-order IPv4, or 0 if missing/invalid.
+static uint32_t parse_ipv4_field(const char *json, const char *key,
+				 jsmntok_t *tokv, int tokc)
+{
+	char *s = pv_json_get_value(json, key, tokv, tokc);
+	if (!s)
+		return 0;
+	struct in_addr a;
+	uint32_t out = (inet_aton(s, &a) != 0) ? a.s_addr : 0;
+	free(s);
+	return out;
+}
+
+static uint16_t parse_u16_field(const char *json, const char *key,
+				jsmntok_t *tokv, int tokc)
+{
+	char *s = pv_json_get_value(json, key, tokv, tokc);
+	if (!s)
+		return 0;
+	long v = strtol(s, NULL, 10);
+	free(s);
+	if (v < 0 || v > 65535)
+		return 0;
+	return (uint16_t)v;
+}
+
+// Defaults to UNIX (legacy) when the field is absent so existing graphs
+// keep working unchanged. Only the new IP services need to set it.
+static pvx_transport_t parse_transport_field(const char *json, const char *key,
+					     jsmntok_t *tokv, int tokc)
+{
+	char *s = pv_json_get_value(json, key, tokv, tokc);
+	if (!s)
+		return PVX_TRANSPORT_UNIX;
+	pvx_transport_t t = (!strcmp(s, "tcp")) ? PVX_TRANSPORT_TCP :
+						  PVX_TRANSPORT_UNIX;
+	free(s);
+	return t;
 }
 
 static struct pvx_link *parse_link(const char *json, jsmntok_t *itok,
@@ -105,7 +163,13 @@ static struct pvx_link *parse_link(const char *json, jsmntok_t *itok,
 		pv_json_get_value(json, "socket", itok, obj_tokc);
 	link->interface = pv_json_get_value(json, "interface", itok, obj_tokc);
 
-	if (!link->name || !link->consumer || !link->provider_socket) {
+	// Service-IP links use cluster_ip/provider_ip/port and may omit the
+	// legacy `socket` field entirely. Validate whichever shape applies.
+	bool has_service_ip =
+		(parse_ipv4_field(json, "cluster_ip", itok, obj_tokc) != 0);
+
+	if (!link->name || !link->consumer ||
+	    (!link->provider_socket && !has_service_ip)) {
 		fprintf(stderr, "Link missing required fields\n");
 		pvx_link_free(link);
 		return NULL;
@@ -115,6 +179,22 @@ static struct pvx_link *parse_link(const char *json, jsmntok_t *itok,
 		parse_pid_field(json, "consumer_pid", itok, obj_tokc);
 	link->provider_pid =
 		parse_pid_field(json, "provider_pid", itok, obj_tokc);
+
+	// Service / IP layer fields. All optional — pv-ctrl only fills these
+	// for declared services. Legacy unix-socket bind-mount links leave
+	// them zero and the link parses unchanged.
+	link->cluster_ip =
+		parse_ipv4_field(json, "cluster_ip", itok, obj_tokc);
+	link->cluster_port = parse_u16_field(json, "cluster_port", itok,
+					     obj_tokc);
+	link->provider_ip =
+		parse_ipv4_field(json, "provider_ip", itok, obj_tokc);
+	link->provider_port = parse_u16_field(json, "provider_port", itok,
+					      obj_tokc);
+	link->provider_transport = parse_transport_field(
+		json, "provider_transport", itok, obj_tokc);
+	link->consumer_transport = parse_transport_field(
+		json, "consumer_transport", itok, obj_tokc);
 
 	char *target = pv_json_get_value(json, "target", itok, obj_tokc);
 	if (target && target[0]) {
@@ -131,6 +211,49 @@ static struct pvx_link *parse_link(const char *json, jsmntok_t *itok,
 
 	link->plugin = plugin;
 	return link;
+}
+
+// Record a failure reason on `link` so the status endpoint can surface it
+// to pantavisor's container health subsystem. Failure is sticky: the link
+// stays in g_links with established=false so retry happens on the next
+// reconcile pass; no silent removal.
+static void link_set_error(struct pvx_link *link, const char *fmt, ...)
+{
+	free(link->last_error);
+	link->last_error = NULL;
+	char buf[256];
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+	link->last_error = strdup(buf);
+	fprintf(stderr, "link %s/%s unhealthy: %s\n",
+		link->consumer ? link->consumer : "?",
+		link->name ? link->name : "?", buf);
+}
+
+// Inject `<service>.pv.local` into the consumer's /etc/hosts pointing at the
+// ClusterIP. Hard-fail (caller marks link unhealthy) on any error: a wired
+// consumer that can't see its services in DNS is not a working consumer.
+//
+// If this is a service-IP link (cluster_ip set) but consumer_pid is not yet
+// valid (pv-ctrl emits -1 early during container start), we MUST return
+// failure so the link stays unestablished and the next reconcile retries.
+// Returning 0 (success) would mark the link "established" with no actual
+// /etc/hosts entry — the link would then never be re-evaluated.
+static int link_inject_hosts(struct pvx_link *link)
+{
+	if (!link->cluster_ip)
+		return 0; // legacy (unix-socket) link, nothing to do
+	if (link->consumer_pid <= 0)
+		return -1; // service-IP link but pid not ready yet; retry
+	char *host = pvx_service_hostname(link->name);
+	if (!host)
+		return -1;
+	int rc = pvx_helper_inject_hosts_entry(link->consumer_pid, host,
+					       link->cluster_ip);
+	free(host);
+	return rc;
 }
 
 static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
@@ -157,34 +280,66 @@ static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
 		return;
 	}
 
-	if (existing) {
-		printf("Retrying link: %s/%s\n", consumer, name);
-		dl_list_del(&existing->list);
-		pvx_link_free(existing);
-	}
-
 	free(consumer);
 	free(name);
 
-	struct pvx_link *link = parse_link(json, itok, obj_tokc, plugin);
-	if (!link)
-		return;
-
-	dl_list_init(&link->list);
-	dl_list_add_tail(&g_links, &link->list);
-
-	printf("Adding link: %s (pid=%d, %s) -> %s (inject to: %s)\n",
-	       link->consumer ? link->consumer : "unknown", link->consumer_pid,
-	       link->type, link->provider_socket, link->consumer_socket);
-
-	if (plugin->on_link_added(link) < 0) {
-		fprintf(stderr, "Failed to add link for %s\n", link->name);
-		dl_list_del(&link->list);
-		pvx_link_free(link);
+	struct pvx_link *link;
+	if (existing) {
+		// Retry path: REFRESH dynamic fields from the latest JSON
+		// (consumer_pid, provider_pid, etc. transition from -1 to
+		// real values as containers come up) but PRESERVE the
+		// data-plane state (listener bound to ClusterIP:port, bridge
+		// /32, nft DNAT rule) IF it came up successfully — tearing
+		// down a live listener and re-binding the same socket races
+		// with kernel close, producing EADDRINUSE on the rebind.
+		struct pvx_link *fresh =
+			parse_link(json, itok, obj_tokc, plugin);
+		if (!fresh)
+			return;
+		existing->consumer_pid = fresh->consumer_pid;
+		existing->provider_pid = fresh->provider_pid;
+		existing->provider_ip = fresh->provider_ip;
+		existing->provider_port = fresh->provider_port;
+		pvx_link_free(fresh);
+		free(existing->last_error);
+		existing->last_error = NULL;
+		link = existing;
 	} else {
-		link->established = true;
-		printf("Link established: %s/%s\n", link->consumer, link->name);
+		link = parse_link(json, itok, obj_tokc, plugin);
+		if (!link)
+			return;
+		dl_list_init(&link->list);
+		dl_list_add_tail(&g_links, &link->list);
+
+		printf("Adding link: %s (pid=%d, %s)\n",
+		       link->consumer ? link->consumer : "unknown",
+		       link->consumer_pid, link->type);
 	}
+
+	// Plugin runs until it succeeds. data_plane_up gates re-runs so we
+	// don't tear down a working listener and rebind. A failed plugin call
+	// (e.g. nft DNAT install fails because provider_ip wasn't allocated
+	// yet) leaves data_plane_up=false and retries next reconcile pass.
+	if (!link->data_plane_up) {
+		if (plugin->on_link_added(link) < 0) {
+			link_set_error(link, "plugin %s on_link_added failed",
+				       link->type ? link->type : "?");
+			return;
+		}
+		link->data_plane_up = true;
+	}
+
+	// Hosts injection runs every reconcile while not yet successful.
+	// Idempotent: re-injection just rewrites the same line.
+	if (link_inject_hosts(link) < 0) {
+		link_set_error(link,
+			       "/etc/hosts injection failed in pid %d (errno=%d %s)",
+			       link->consumer_pid, errno, strerror(errno));
+		return;
+	}
+
+	link->established = true;
+	printf("Link established: %s/%s\n", link->consumer, link->name);
 }
 
 static void reconcile_graph(const char *json)
@@ -222,6 +377,129 @@ static void reconcile_graph(const char *json)
 	jsmnutil_tokv_free(items);
 	free(tokv);
 }
+
+// Build a JSON array describing every link's establishment state, suitable for
+// POSTing to pv-ctrl's /xconnect-status endpoint. Caller frees.
+//
+// Each element: {"consumer", "name", "established", "last_error"}. Strings
+// are escaped minimally — service names + container names are alnum/dash by
+// convention, last_error is generated by us and never contains quotes.
+static char *build_status_json(void)
+{
+	// Rough cap: 256 bytes per link is plenty.
+	size_t cap = 1024;
+	char *buf = malloc(cap);
+	if (!buf)
+		return NULL;
+	size_t len = 0;
+	buf[len++] = '[';
+
+	struct pvx_link *link;
+	int first = 1;
+	dl_list_for_each(link, &g_links, struct pvx_link, list)
+	{
+		char obj[512];
+		int n = snprintf(obj, sizeof(obj),
+				 "%s{\"consumer\":\"%s\",\"name\":\"%s\","
+				 "\"established\":%s,\"last_error\":%s%s%s}",
+				 first ? "" : ",",
+				 link->consumer ? link->consumer : "",
+				 link->name ? link->name : "",
+				 link->established ? "true" : "false",
+				 link->last_error ? "\"" : "null",
+				 link->last_error ? link->last_error : "",
+				 link->last_error ? "\"" : "");
+		if (n < 0 || (size_t)n >= sizeof(obj))
+			continue;
+		if (len + n + 2 >= cap) {
+			size_t new_cap = cap * 2 + n;
+			char *grown = realloc(buf, new_cap);
+			if (!grown) {
+				free(buf);
+				return NULL;
+			}
+			buf = grown;
+			cap = new_cap;
+		}
+		memcpy(buf + len, obj, n);
+		len += n;
+		first = 0;
+	}
+	if (len + 2 >= cap) {
+		char *grown = realloc(buf, cap + 4);
+		if (!grown) {
+			free(buf);
+			return NULL;
+		}
+		buf = grown;
+	}
+	buf[len++] = ']';
+	buf[len] = '\0';
+	return buf;
+}
+
+struct status_post_ctx {
+	char *body;
+};
+
+static void status_event_cb(struct bufferevent *bev, short events, void *arg)
+{
+	struct status_post_ctx *ctx = arg;
+	if (events & BEV_EVENT_CONNECTED) {
+		struct evbuffer *out = bufferevent_get_output(bev);
+		evbuffer_add_printf(out,
+				    "POST /xconnect-status HTTP/1.0\r\n"
+				    "Host: localhost\r\n"
+				    "Content-Type: application/json\r\n"
+				    "Content-Length: %zu\r\n\r\n",
+				    strlen(ctx->body));
+		evbuffer_add(out, ctx->body, strlen(ctx->body));
+		free(ctx->body);
+		ctx->body = NULL;
+		bufferevent_disable(bev, EV_READ);
+	} else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF)) {
+		free(ctx->body); // safe if NULL
+		free(ctx);
+		bufferevent_free(bev);
+	}
+}
+
+// Fire-and-forget POST of the link status to pv-ctrl. Called after each
+// reconcile pass. Failures are logged but don't block the daemon.
+static void post_status(void)
+{
+	char *body = build_status_json();
+	if (!body)
+		return;
+
+	struct sockaddr_un sun;
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strncpy(sun.sun_path, PV_CTRL_SOCKET, sizeof(sun.sun_path) - 1);
+
+	struct bufferevent *bev = bufferevent_socket_new(g_base, -1,
+							 BEV_OPT_CLOSE_ON_FREE);
+	if (!bev) {
+		free(body);
+		return;
+	}
+	struct status_post_ctx *ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		bufferevent_free(bev);
+		free(body);
+		return;
+	}
+	ctx->body = body;
+	bufferevent_setcb(bev, NULL, NULL, status_event_cb, ctx);
+	bufferevent_enable(bev, EV_WRITE);
+	if (bufferevent_socket_connect(bev, (struct sockaddr *)&sun,
+				       sizeof(sun)) < 0) {
+		bufferevent_free(bev);
+		free(ctx->body);
+		free(ctx);
+	}
+}
+
 static void ctrl_read_cb(struct bufferevent *bev, void *ctx)
 {
 	struct evbuffer *input = bufferevent_get_input(bev);
@@ -296,6 +574,12 @@ static void reconcile_timer_cb(evutil_socket_t fd, short event, void *arg)
 	printf("Periodic reconciliation check...\n");
 	fetch_graph();
 
+	// After kicking the graph fetch, also push current link health back
+	// to pv-ctrl. This is decoupled from the fetch (no ordering needed):
+	// status reflects the previous reconcile pass, the new fetch starts
+	// the next one, both async via libevent.
+	post_status();
+
 	// Re-arm the timer
 	struct timeval tv = { RECONCILE_INTERVAL_SEC, 0 };
 	evtimer_add(g_reconcile_timer, &tv);
@@ -327,6 +611,18 @@ int main(int argc, char **argv)
 	}
 	printf("pv-xconnect starting...\n");
 
+	// Service-IP layer: bring up the pv-services bridge and our nft
+	// table before any link reconciles. Both are idempotent so a crash-
+	// restart picks up cleanly. Failure here is logged but non-fatal:
+	// legacy unix-socket links still work, only service-IP links would
+	// fail to establish (and thus surface unhealthy via last_error).
+	if (pvx_services_bridge_up() != 0)
+		fprintf(stderr,
+			"pv-xconnect: pv-services bridge bring-up failed; service-IP links will fail\n");
+	if (pvx_services_nft_init() != 0)
+		fprintf(stderr,
+			"pv-xconnect: nft init failed; TCP fast-path DNAT unavailable\n");
+
 	// Set up periodic reconciliation timer
 	g_reconcile_timer = evtimer_new(g_base, reconcile_timer_cb, NULL);
 	if (!g_reconcile_timer) {
@@ -340,6 +636,11 @@ int main(int argc, char **argv)
 	fetch_graph();
 
 	event_base_dispatch(g_base);
+
+	// Tear down service-IP infrastructure before exiting so the bridge,
+	// nft rules, and ClusterIP /32 addresses don't outlive the daemon.
+	pvx_services_nft_teardown();
+	pvx_services_bridge_down();
 
 	event_free(g_reconcile_timer);
 	event_free(signal_event);

--- a/xconnect/plugins/tcp.c
+++ b/xconnect/plugins/tcp.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//
+// pvx tcp plugin — service ClusterIP proxy
+// ----------------------------------------
+//
+// One listener per established service link, bound to ClusterIP:cluster_port
+// on the host (the IP lives on the pv-services bridge). On accept, we open a
+// connection to the backend — TCP if provider_transport == PVX_TRANSPORT_TCP,
+// unix-socket via /proc/<provider_pid>/root<provider_socket> if UNIX — and
+// bidirectionally pump bytes.
+//
+// Same proxy session shape as plugins/rest.c and plugins/unix.c; the only
+// new thing here is the bind-to-ClusterIP and the choice of backend AF_*.
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+
+#include "../include/xconnect.h"
+#include "../services_bridge.h"
+#include "../services_nft.h"
+
+#define MODULE_NAME "pvx-tcp"
+
+struct tcp_proxy_session {
+	struct bufferevent *be_client;
+	struct bufferevent *be_provider;
+	int client_eof;
+	int provider_eof;
+};
+
+static void session_check_close(struct tcp_proxy_session *s)
+{
+	if (s->client_eof && s->provider_eof) {
+		if (s->be_client)
+			bufferevent_free(s->be_client);
+		if (s->be_provider)
+			bufferevent_free(s->be_provider);
+		free(s);
+	}
+}
+
+static void session_event_cb(struct bufferevent *bev, short events, void *arg)
+{
+	struct tcp_proxy_session *s = arg;
+	if (events & BEV_EVENT_ERROR) {
+		s->client_eof = s->provider_eof = 1;
+		session_check_close(s);
+		return;
+	}
+	if (events & BEV_EVENT_EOF) {
+		if (bev == s->be_client)
+			s->client_eof = 1;
+		else
+			s->provider_eof = 1;
+		bufferevent_disable(bev, EV_READ);
+		session_check_close(s);
+	}
+}
+
+static void session_read_cb(struct bufferevent *bev, void *arg)
+{
+	struct tcp_proxy_session *s = arg;
+	struct bufferevent *other =
+		(bev == s->be_client) ? s->be_provider : s->be_client;
+	struct evbuffer *src = bufferevent_get_input(bev);
+	struct evbuffer *dst = bufferevent_get_output(other);
+	evbuffer_add_buffer(dst, src);
+}
+
+static int connect_backend_tcp(struct bufferevent *be, uint32_t ip_n, uint16_t port)
+{
+	struct sockaddr_in sin;
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = ip_n;
+	sin.sin_port = htons(port);
+	return bufferevent_socket_connect(be, (struct sockaddr *)&sin,
+					  sizeof(sin));
+}
+
+static int connect_backend_unix(struct bufferevent *be, int provider_pid,
+				const char *socket_path)
+{
+	if (!socket_path)
+		return -1;
+	char path[256];
+	if (provider_pid > 0)
+		snprintf(path, sizeof(path), "/proc/%d/root%s", provider_pid,
+			 socket_path);
+	else {
+		strncpy(path, socket_path, sizeof(path) - 1);
+		path[sizeof(path) - 1] = '\0';
+	}
+	struct sockaddr_un sun;
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+	strncpy(sun.sun_path, path, sizeof(sun.sun_path) - 1);
+	return bufferevent_socket_connect(be, (struct sockaddr *)&sun,
+					  sizeof(sun));
+}
+
+static void tcp_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
+			  struct sockaddr *address, int socklen, void *arg)
+{
+	struct pvx_link *link = arg;
+	struct event_base *base = pvx_get_base();
+
+	fprintf(stderr,
+		"%s: accept on %s for service %s (backend=%s)\n", MODULE_NAME,
+		link->consumer ? link->consumer : "?",
+		link->name ? link->name : "?",
+		link->provider_transport == PVX_TRANSPORT_UNIX ?
+			"unix" :
+			"tcp");
+
+	struct tcp_proxy_session *s = calloc(1, sizeof(*s));
+	if (!s) {
+		close(fd);
+		return;
+	}
+
+	s->be_client = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+	s->be_provider =
+		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+
+	int rc;
+	if (link->provider_transport == PVX_TRANSPORT_UNIX)
+		rc = connect_backend_unix(s->be_provider, link->provider_pid,
+					  link->provider_socket);
+	else
+		rc = connect_backend_tcp(s->be_provider, link->provider_ip,
+					 link->provider_port);
+
+	if (rc < 0) {
+		fprintf(stderr,
+			"%s: backend connect failed for %s/%s\n", MODULE_NAME,
+			link->consumer ? link->consumer : "?",
+			link->name ? link->name : "?");
+		bufferevent_free(s->be_client);
+		bufferevent_free(s->be_provider);
+		free(s);
+		return;
+	}
+
+	bufferevent_setcb(s->be_client, session_read_cb, NULL,
+			  session_event_cb, s);
+	bufferevent_setcb(s->be_provider, session_read_cb, NULL,
+			  session_event_cb, s);
+	bufferevent_enable(s->be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(s->be_provider, EV_READ | EV_WRITE);
+}
+
+// True when this link can take the lightweight kernel-forward path: both
+// sides are TCP and we have a backend ip:port to DNAT to. Embedded boxes
+// shouldn't pay userspace-proxy cost for plain IP-to-IP traffic.
+static bool tcp_can_kernel_forward(const struct pvx_link *link)
+{
+	return link->provider_transport == PVX_TRANSPORT_TCP &&
+	       link->consumer_transport == PVX_TRANSPORT_TCP &&
+	       link->provider_ip && link->provider_port;
+}
+
+static int tcp_on_link_added(struct pvx_link *link)
+{
+	if (!link->cluster_ip || !link->cluster_port) {
+		fprintf(stderr,
+			"%s: link %s missing cluster_ip/port — service-IP layer not provisioned by pv-ctrl?\n",
+			MODULE_NAME, link->name ? link->name : "?");
+		return -1;
+	}
+
+	if (pvx_services_bridge_add_ip(link->cluster_ip) != 0)
+		return -1;
+
+	// Fast path: kernel DNAT, no userspace listener. Conntrack tracks
+	// the rewrite so the consumer experiences a clean ClusterIP-targeted
+	// connection; bytes never leave kernel.
+	if (tcp_can_kernel_forward(link)) {
+		if (pvx_services_nft_add_dnat(link) != 0) {
+			fprintf(stderr,
+				"%s: nft DNAT install failed for %s/%s\n",
+				MODULE_NAME,
+				link->consumer ? link->consumer : "?",
+				link->name ? link->name : "?");
+			pvx_services_bridge_del_ip(link->cluster_ip);
+			return -1;
+		}
+		char ip[INET_ADDRSTRLEN];
+		struct in_addr a = { .s_addr = link->cluster_ip };
+		inet_ntop(AF_INET, &a, ip, sizeof(ip));
+		fprintf(stderr,
+			"%s: kernel-forward %s:%u for service %s (consumer=%s)\n",
+			MODULE_NAME, ip, link->cluster_port,
+			link->name ? link->name : "?",
+			link->consumer ? link->consumer : "?");
+		return 0;
+	}
+
+	// Cross-transport path: userspace proxy bound on ClusterIP.
+	int fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0) {
+		perror("tcp: socket");
+		return -1;
+	}
+	int one = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+	evutil_make_socket_nonblocking(fd);
+
+	struct sockaddr_in sin;
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = link->cluster_ip;
+	sin.sin_port = htons(link->cluster_port);
+
+	if (bind(fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+		fprintf(stderr,
+			"%s: bind to ClusterIP:%u failed: %s\n", MODULE_NAME,
+			link->cluster_port, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (listen(fd, 16) < 0) {
+		perror("tcp: listen");
+		close(fd);
+		return -1;
+	}
+
+	link->listener = evconnlistener_new(
+		pvx_get_base(), tcp_on_accept, link,
+		LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1, fd);
+	if (!link->listener) {
+		fprintf(stderr,
+			"%s: evconnlistener_new failed for %s\n", MODULE_NAME,
+			link->name ? link->name : "?");
+		close(fd);
+		return -1;
+	}
+
+	{
+		char ip[INET_ADDRSTRLEN];
+		struct in_addr a = { .s_addr = link->cluster_ip };
+		inet_ntop(AF_INET, &a, ip, sizeof(ip));
+		fprintf(stderr,
+			"%s: listening on %s:%u for service %s (consumer=%s)\n",
+			MODULE_NAME, ip, link->cluster_port,
+			link->name ? link->name : "?",
+			link->consumer ? link->consumer : "?");
+	}
+	return 0;
+}
+
+static int tcp_on_link_removed(struct pvx_link *link)
+{
+	if (link->listener) {
+		evconnlistener_free(link->listener);
+		link->listener = NULL;
+	}
+	if (link->cluster_ip)
+		pvx_services_bridge_del_ip(link->cluster_ip);
+	return 0;
+}
+
+struct pvx_plugin pvx_plugin_tcp = { .type = "tcp",
+				     .on_link_added = tcp_on_link_added,
+				     .on_link_removed = tcp_on_link_removed,
+				     .on_accept = tcp_on_accept };

--- a/xconnect/plumbing.c
+++ b/xconnect/plumbing.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <arpa/inet.h>
 #include <linux/limits.h>
 #include <libgen.h>
 #include <stddef.h>
@@ -146,6 +147,124 @@ out:
 
 	return fd;
 }
+// Marker we tag onto every line we manage in a consumer's /etc/hosts so
+// re-injection / removal does not touch user-authored entries.
+#define PVX_HOSTS_MARK "# pvx-services managed"
+
+static int hosts_rewrite_locked(const char *hostname, const char *ip_str_or_null)
+{
+	// Read existing /etc/hosts (if present), strip prior pvx-managed line
+	// for `hostname`, append fresh line if ip_str_or_null != NULL, write
+	// back atomically via temp + rename. We're already inside the consumer
+	// mount namespace at this point; all paths are container-local.
+	FILE *in = fopen("/etc/hosts", "r");
+	FILE *out = fopen("/etc/hosts.pvx.tmp", "w");
+	if (!out) {
+		if (in)
+			fclose(in);
+		return -1;
+	}
+
+	char line[1024];
+	char marker[256];
+	snprintf(marker, sizeof(marker), "\t%s %s\n", hostname, PVX_HOSTS_MARK);
+
+	if (in) {
+		while (fgets(line, sizeof(line), in)) {
+			// Drop any prior pvx-managed line for this hostname.
+			// We match the trailing tab+hostname+marker so we
+			// don't accidentally clobber a user line that just
+			// happens to contain the hostname.
+			if (strstr(line, PVX_HOSTS_MARK) &&
+			    strstr(line, hostname))
+				continue;
+			fputs(line, out);
+		}
+		fclose(in);
+	}
+
+	if (ip_str_or_null) {
+		fprintf(out, "%s%s", ip_str_or_null, marker);
+	}
+
+	if (fclose(out) != 0)
+		return -1;
+
+	if (rename("/etc/hosts.pvx.tmp", "/etc/hosts") != 0) {
+		unlink("/etc/hosts.pvx.tmp");
+		return -1;
+	}
+	return 0;
+}
+
+static int hosts_setns_and_rewrite(int consumer_pid, const char *hostname,
+				   const char *ip_str_or_null)
+{
+	int old_ns_fd = -1;
+	int target_ns_fd = -1;
+	int ret = -1;
+	char ns_path[PATH_MAX];
+
+	if (!hostname || !hostname[0])
+		return -1;
+
+	old_ns_fd = open("/proc/self/ns/mnt", O_RDONLY);
+	if (old_ns_fd < 0) {
+		perror("hosts: open current ns");
+		return -1;
+	}
+
+	snprintf(ns_path, sizeof(ns_path), "/proc/%d/ns/mnt", consumer_pid);
+	target_ns_fd = open(ns_path, O_RDONLY);
+	if (target_ns_fd < 0) {
+		perror("hosts: open target ns");
+		close(old_ns_fd);
+		return -1;
+	}
+
+	if (setns(target_ns_fd, CLONE_NEWNS) < 0) {
+		perror("hosts: setns");
+		goto out;
+	}
+
+	ret = hosts_rewrite_locked(hostname, ip_str_or_null);
+	if (ret != 0)
+		fprintf(stderr,
+			"hosts: rewrite failed for %s in pid %d (errno=%d %s)\n",
+			hostname, consumer_pid, errno, strerror(errno));
+
+out:
+	if (setns(old_ns_fd, CLONE_NEWNS) < 0) {
+		perror("hosts: setns back");
+		exit(1);
+	}
+	if (old_ns_fd >= 0)
+		close(old_ns_fd);
+	if (target_ns_fd >= 0)
+		close(target_ns_fd);
+	return ret;
+}
+
+int pvx_helper_inject_hosts_entry(int consumer_pid, const char *hostname,
+				  uint32_t ipv4_network_order)
+{
+	if (consumer_pid <= 0 || !hostname || !ipv4_network_order)
+		return -1;
+
+	unsigned char *o = (unsigned char *)&ipv4_network_order;
+	char ip_str[INET_ADDRSTRLEN];
+	snprintf(ip_str, sizeof(ip_str), "%u.%u.%u.%u", o[0], o[1], o[2],
+		 o[3]);
+	return hosts_setns_and_rewrite(consumer_pid, hostname, ip_str);
+}
+
+int pvx_helper_remove_hosts_entry(int consumer_pid, const char *hostname)
+{
+	if (consumer_pid <= 0 || !hostname)
+		return -1;
+	return hosts_setns_and_rewrite(consumer_pid, hostname, NULL);
+}
+
 int pvx_helper_inject_devnode(const char *target_path, int consumer_pid,
 			      const char *source_path, int provider_pid)
 {

--- a/xconnect/plumbing.c
+++ b/xconnect/plumbing.c
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 #define _GNU_SOURCE
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -147,16 +148,56 @@ out:
 
 	return fd;
 }
-// Marker we tag onto every line we manage in a consumer's /etc/hosts so
-// re-injection / removal does not touch user-authored entries.
-#define PVX_HOSTS_MARK "# pvx-services managed"
+// Layout we maintain inside a consumer's /etc/hosts:
+//
+//     <user content above — preserved verbatim, append-friendly>
+//     # >>> pvx-services managed BEGIN — DO NOT EDIT INSIDE THIS BLOCK
+//     # Lines between BEGIN and END are rewritten by pv-xconnect on every
+//     # service reconcile. Add your own entries ABOVE the BEGIN line or
+//     # BELOW the END line; both regions are preserved across reconciles.
+//     198.18.x.y	<service>.pv.local	# pvx-services managed
+//     ...
+//     # <<< pvx-services managed END — safe to append your own lines below
+//     <user content below — preserved verbatim, append-friendly>
+//
+// The fence comments give the user (and append-blind tooling like Docker
+// bridge setup or `echo ... >> /etc/hosts` from init scripts) a clear
+// visual contract: the inside is ours, everything else is theirs. The
+// per-line `# pvx-services managed` marker is still used inside the
+// block so we can update individual entries without rewriting siblings.
+#define PVX_HOSTS_BEGIN "# >>> pvx-services managed BEGIN"
+#define PVX_HOSTS_END   "# <<< pvx-services managed END"
+#define PVX_HOSTS_MARK  "# pvx-services managed"
+
+// Block header lines emitted on first install. The trailing newlines
+// keep the fputs path simple; we never include leading whitespace so
+// matching is straightforward.
+#define PVX_HOSTS_BEGIN_LINE                                                   \
+	PVX_HOSTS_BEGIN " — DO NOT EDIT INSIDE THIS BLOCK\n"                  \
+	"# Lines between BEGIN and END are rewritten by pv-xconnect on every\n" \
+	"# service reconcile. Add your own entries ABOVE the BEGIN line or\n" \
+	"# BELOW the END line; both regions are preserved across reconciles.\n"
+#define PVX_HOSTS_END_LINE PVX_HOSTS_END " — safe to append your own lines below\n"
 
 static int hosts_rewrite_locked(const char *hostname, const char *ip_str_or_null)
 {
-	// Read existing /etc/hosts (if present), strip prior pvx-managed line
-	// for `hostname`, append fresh line if ip_str_or_null != NULL, write
-	// back atomically via temp + rename. We're already inside the consumer
-	// mount namespace at this point; all paths are container-local.
+	// Algorithm:
+	//   1. Walk existing /etc/hosts line-by-line.
+	//   2. Track whether we're outside / inside / past the managed block.
+	//   3. Outside the block: copy through verbatim (user content).
+	//   4. Inside the block: drop the prior line for `hostname` (matched
+	//      by per-line marker AND hostname). Other managed entries —
+	//      different hostnames — are copied through verbatim. The new
+	//      entry is emitted just before the END marker if `ip_str_or_null`
+	//      is non-NULL.
+	//   5. After the loop: if no BEGIN was seen and we have something to
+	//      add, append a fresh BEGIN/entry/END block at the end. If we
+	//      saw BEGIN but never END (truncated/malformed input), emit the
+	//      missing END so future reconciles resume cleanly.
+	//
+	// We're already inside the consumer mount namespace; paths are
+	// container-local. /etc/hosts is small (a few KB at most), so the
+	// streaming approach is fine.
 	FILE *in = fopen("/etc/hosts", "r");
 	FILE *out = fopen("/etc/hosts.pvx.tmp", "w");
 	if (!out) {
@@ -167,24 +208,71 @@ static int hosts_rewrite_locked(const char *hostname, const char *ip_str_or_null
 
 	char line[1024];
 	char marker[256];
-	snprintf(marker, sizeof(marker), "\t%s %s\n", hostname, PVX_HOSTS_MARK);
+	snprintf(marker, sizeof(marker), "\t%s\t%s\n", hostname, PVX_HOSTS_MARK);
+
+	enum { ST_BEFORE, ST_INSIDE, ST_AFTER } state = ST_BEFORE;
+	bool entry_written = false;
 
 	if (in) {
 		while (fgets(line, sizeof(line), in)) {
-			// Drop any prior pvx-managed line for this hostname.
-			// We match the trailing tab+hostname+marker so we
-			// don't accidentally clobber a user line that just
-			// happens to contain the hostname.
-			if (strstr(line, PVX_HOSTS_MARK) &&
-			    strstr(line, hostname))
+			if (state == ST_BEFORE) {
+				if (strstr(line, PVX_HOSTS_BEGIN)) {
+					// Re-emit a fresh BEGIN header (in case
+					// someone trimmed the explanatory lines).
+					fputs(PVX_HOSTS_BEGIN_LINE, out);
+					state = ST_INSIDE;
+				} else {
+					fputs(line, out);
+				}
 				continue;
+			}
+			if (state == ST_INSIDE) {
+				if (strstr(line, PVX_HOSTS_END)) {
+					// Emit the new entry just before END.
+					if (ip_str_or_null && !entry_written) {
+						fprintf(out, "%s%s",
+							ip_str_or_null, marker);
+						entry_written = true;
+					}
+					fputs(PVX_HOSTS_END_LINE, out);
+					state = ST_AFTER;
+					continue;
+				}
+				// Drop the prior line for this hostname so we
+				// don't emit duplicates. Other managed lines
+				// (different hostnames) are preserved.
+				if (strstr(line, PVX_HOSTS_MARK) &&
+				    strstr(line, hostname))
+					continue;
+				// Skip the explanatory header lines that the
+				// previous BEGIN block emitted; we re-emit a
+				// fresh header above. Match by leading "# ".
+				if (line[0] == '#' && line[1] == ' ' &&
+				    (strstr(line, "DO NOT EDIT") ||
+				     strstr(line, "rewritten by pv-xconnect") ||
+				     strstr(line, "Add your own entries") ||
+				     strstr(line, "service reconcile")))
+					continue;
+				fputs(line, out);
+				continue;
+			}
+			// ST_AFTER: copy through.
 			fputs(line, out);
 		}
 		fclose(in);
 	}
 
-	if (ip_str_or_null) {
+	// Tail handling:
+	//   - never saw BEGIN: append a fresh block if we have something to add
+	//   - saw BEGIN but never END (malformed): close the block now
+	if (state == ST_BEFORE && ip_str_or_null) {
+		fputs(PVX_HOSTS_BEGIN_LINE, out);
 		fprintf(out, "%s%s", ip_str_or_null, marker);
+		fputs(PVX_HOSTS_END_LINE, out);
+	} else if (state == ST_INSIDE) {
+		if (ip_str_or_null && !entry_written)
+			fprintf(out, "%s%s", ip_str_or_null, marker);
+		fputs(PVX_HOSTS_END_LINE, out);
 	}
 
 	if (fclose(out) != 0)

--- a/xconnect/services.c
+++ b/xconnect/services.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <arpa/inet.h>
+
+#include "include/xconnect.h"
+
+// FNV-1a 32-bit. Not cryptographic; just a stable, well-distributed hash so
+// deterministic ClusterIP derivation survives reboots without on-disk state.
+static uint32_t fnv1a(const char *s)
+{
+	uint32_t h = 0x811c9dc5u;
+	for (; *s; s++) {
+		h ^= (unsigned char)*s;
+		h *= 0x01000193u;
+	}
+	return h;
+}
+
+// ClusterIP range default: 198.18.0.0/15 (RFC 2544 benchmark range).
+//
+// Why not 169.254.0.0/16? avahi-daemon, NetworkManager IPv4LL, and other
+// zeroconf machinery actively use it; on a host with avahi we'd see ARP
+// fights, mDNS leakage, and IPv4LL probes claiming the same addresses.
+//
+// Why not 10.0.0.0/8 / 172.16/12 / 192.168/16? Conflicts with site networks
+// and with IPAM pool defaults already used by pantavisor deployments.
+//
+// Why not 100.64.0.0/10? It's CGNAT, but more importantly Tailscale uses it
+// for its mesh; pantavisor devices commonly run Tailscale (lab nodes have
+// 100.x.y.z addresses).
+//
+// 198.18.0.0/15 is RFC 2544 reserved for inter-network benchmarking, not
+// routable on the public internet, and not consumed by any common userland
+// service. 131k addresses are plenty for service name hashing.
+//
+// Override path: pantavisor.config key `xconnect.services.cidr` (see
+// PV_XCONNECT_SERVICES_CIDR in the pantavisor config schema). Pantavisor
+// exports this into the daemon environment as PV_XCONNECT_SERVICES_CIDR
+// before spawning pv-xconnect. v2 will move the authoritative knob into
+// device.json `services` block when explicit service pools land.
+#define PVX_DEFAULT_CIDR "198.18.0.0/15"
+
+// Resolved at first use. host-byte-order subnet+host-mask. host_mask = ~netmask
+// so we can & it with hash bits to derive the host portion in one shot.
+static uint32_t g_subnet_host = 0; // network address, host byte order
+static uint32_t g_host_mask_host = 0; // 1-bits = host portion
+static int g_resolved = 0;
+
+// Parse "A.B.C.D/N" into host-order net + host_mask. Returns 0 on success.
+static int parse_cidr(const char *s, uint32_t *net_out, uint32_t *host_mask_out)
+{
+	if (!s || !s[0])
+		return -1;
+
+	char buf[64];
+	strncpy(buf, s, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	char *slash = strchr(buf, '/');
+	if (!slash)
+		return -1;
+	*slash = '\0';
+	int prefix = atoi(slash + 1);
+	if (prefix < 0 || prefix > 32)
+		return -1;
+
+	struct in_addr a;
+	if (inet_aton(buf, &a) == 0)
+		return -1;
+
+	uint32_t net_host = ntohl(a.s_addr);
+	uint32_t netmask = (prefix == 0) ? 0u : (~0u << (32 - prefix));
+	*net_out = net_host & netmask;
+	*host_mask_out = ~netmask;
+	return 0;
+}
+
+static void resolve_range(void)
+{
+	if (g_resolved)
+		return;
+
+	const char *env = getenv("PV_XCONNECT_SERVICES_CIDR");
+	if (env && env[0]) {
+		if (parse_cidr(env, &g_subnet_host, &g_host_mask_host) == 0) {
+			fprintf(stderr,
+				"pvx-services: ClusterIP range from env: %s\n",
+				env);
+			g_resolved = 1;
+			return;
+		}
+		fprintf(stderr,
+			"pvx-services: invalid PV_XCONNECT_SERVICES_CIDR=%s, falling back to default %s\n",
+			env, PVX_DEFAULT_CIDR);
+	}
+
+	if (parse_cidr(PVX_DEFAULT_CIDR, &g_subnet_host, &g_host_mask_host) !=
+	    0) {
+		// Should be unreachable - default is a constant.
+		fprintf(stderr, "pvx-services: built-in default CIDR is broken\n");
+		g_subnet_host = 0;
+		g_host_mask_host = 0xfffffffeu;
+	}
+	g_resolved = 1;
+}
+
+uint32_t pvx_service_clusterip(const char *service_name)
+{
+	if (!service_name || !service_name[0])
+		return 0;
+
+	resolve_range();
+
+	uint32_t h = fnv1a(service_name);
+	uint32_t host_part = h & g_host_mask_host;
+
+	// Avoid the all-zeros (network) and all-ones (broadcast) host parts
+	// inside the configured range. Everything in between is fair game.
+	if (host_part == 0)
+		host_part = 1;
+	if (host_part == g_host_mask_host)
+		host_part = g_host_mask_host - 1;
+
+	uint32_t ip_host = g_subnet_host | host_part;
+	return htonl(ip_host);
+}
+
+char *pvx_service_hostname(const char *service_name)
+{
+	if (!service_name || !service_name[0])
+		return NULL;
+
+	size_t n = strlen(service_name) + sizeof(".pv.local");
+	char *out = malloc(n);
+	if (!out)
+		return NULL;
+	snprintf(out, n, "%s.pv.local", service_name);
+	return out;
+}

--- a/xconnect/services_bridge.c
+++ b/xconnect/services_bridge.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//
+// pv-services bridge
+// ------------------
+//
+// Owns the pv-services bridge interface that Tier-2 (userspace proxy)
+// services bind their ClusterIPs onto. Tier-1 (DNAT) services don't strictly
+// need the bridge — kernel PREROUTING DNAT happens before the routing
+// decision — but we always bring it up so:
+//   (a) ClusterIP /32s have a stable home for Tier-2 listeners,
+//   (b) the IPAM mental model (bridge per pool) carries over to services,
+//   (c) v2 'services' pools in device.json can attach real interfaces here.
+//
+// We deliberately keep this implementation tiny and shell-driven: bridge
+// management on Yocto BSPs is reliably done via `ip` from iproute2 (already
+// pulled in by IPAM). Mirroring IPAM's `system()`-based NAT setup keeps the
+// surface consistent and avoids dragging in libnl just for one bridge.
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include "include/xconnect.h"
+#include "services_bridge.h"
+#include "../utils/sysctl.h"
+
+#define PVX_BRIDGE_NAME "pv-services"
+
+static int run(const char *cmd)
+{
+	int rc = system(cmd);
+	if (rc != 0)
+		fprintf(stderr,
+			"pvx-bridge: command failed (rc=%d): %s\n", rc, cmd);
+	return rc;
+}
+
+// Idempotent: safe to call repeatedly. Returns 0 on success.
+int pvx_services_bridge_up(void)
+{
+	char cmd[256];
+
+	// Create bridge if it doesn't exist. `ip link add` returns nonzero
+	// when the iface already exists, which is fine — we follow with
+	// `set ... up` so the steady state is the same.
+	snprintf(cmd, sizeof(cmd),
+		 "ip link add name %s type bridge 2>/dev/null; "
+		 "ip link set %s up 2>/dev/null",
+		 PVX_BRIDGE_NAME, PVX_BRIDGE_NAME);
+	run(cmd);
+
+	// Sanity: confirm the bridge is now up. If not, surface as error.
+	snprintf(cmd, sizeof(cmd),
+		 "ip link show %s up >/dev/null 2>&1", PVX_BRIDGE_NAME);
+	if (system(cmd) != 0) {
+		fprintf(stderr,
+			"pvx-bridge: %s did not come up\n", PVX_BRIDGE_NAME);
+		return -1;
+	}
+
+	// Kernel forward path (TCP→TCP DNAT) needs ip_forward. IPAM enables
+	// it conditionally on NAT-pool presence; we enable unconditionally
+	// here since service-IP forwarding is always on.
+	if (pv_sysctl_write("/proc/sys/net/ipv4/ip_forward", "1\n") != 0)
+		fprintf(stderr,
+			"pvx-bridge: could not enable ip_forward (errno=%d %s)\n",
+			errno, strerror(errno));
+
+	fprintf(stderr, "pvx-bridge: %s is up\n", PVX_BRIDGE_NAME);
+	return 0;
+}
+
+void pvx_services_bridge_down(void)
+{
+	char cmd[256];
+	snprintf(cmd, sizeof(cmd),
+		 "ip link set %s down 2>/dev/null; "
+		 "ip link delete %s 2>/dev/null",
+		 PVX_BRIDGE_NAME, PVX_BRIDGE_NAME);
+	run(cmd);
+}
+
+static void ip_to_str(uint32_t ip_n, char *out, size_t outlen)
+{
+	struct in_addr a = { .s_addr = ip_n };
+	const char *p = inet_ntoa(a);
+	strncpy(out, p ? p : "0.0.0.0", outlen - 1);
+	out[outlen - 1] = '\0';
+}
+
+int pvx_services_bridge_add_ip(uint32_t cluster_ip_n)
+{
+	if (!cluster_ip_n)
+		return -1;
+	char ip[INET_ADDRSTRLEN];
+	ip_to_str(cluster_ip_n, ip, sizeof(ip));
+
+	// /32 host route. Already-assigned is fine (treated as success).
+	char cmd[256];
+	snprintf(cmd, sizeof(cmd),
+		 "ip addr add %s/32 dev %s 2>/dev/null; "
+		 "ip addr show dev %s | grep -q ' %s/32'",
+		 ip, PVX_BRIDGE_NAME, PVX_BRIDGE_NAME, ip);
+	int rc = system(cmd);
+	if (rc != 0) {
+		fprintf(stderr,
+			"pvx-bridge: failed to ensure %s/32 on %s\n", ip,
+			PVX_BRIDGE_NAME);
+		return -1;
+	}
+	return 0;
+}
+
+int pvx_services_bridge_del_ip(uint32_t cluster_ip_n)
+{
+	if (!cluster_ip_n)
+		return -1;
+	char ip[INET_ADDRSTRLEN];
+	ip_to_str(cluster_ip_n, ip, sizeof(ip));
+
+	char cmd[256];
+	snprintf(cmd, sizeof(cmd),
+		 "ip addr del %s/32 dev %s 2>/dev/null", ip, PVX_BRIDGE_NAME);
+	system(cmd);
+	return 0;
+}

--- a/xconnect/services_bridge.h
+++ b/xconnect/services_bridge.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef PVX_SERVICES_BRIDGE_H
+#define PVX_SERVICES_BRIDGE_H
+
+#include <stdint.h>
+
+// Bring up (idempotent) / tear down the pv-services bridge.
+int pvx_services_bridge_up(void);
+void pvx_services_bridge_down(void);
+
+// Add/remove a ClusterIP /32 on the bridge so Tier-2 userspace proxies can
+// bind to it. cluster_ip_n is in network byte order. Idempotent.
+int pvx_services_bridge_add_ip(uint32_t cluster_ip_n);
+int pvx_services_bridge_del_ip(uint32_t cluster_ip_n);
+
+#endif

--- a/xconnect/services_nft.c
+++ b/xconnect/services_nft.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//
+// pvx_services nft table
+// ----------------------
+//
+// Owns the `ip pvx_services` nftables table. We keep this STRICTLY
+// separate from IPAM's `pvipam` table so we never trip over each other's
+// rules during reload, flush, or teardown. Same rationale as the IPAM
+// setup_nat() function (ipam.c) and same nft/iptables fallback shape.
+//
+// Layout:
+//   table ip pvx_services {
+//     chain prerouting { type nat hook prerouting priority dstnat; }
+//   }
+// Per established Tier-1 link, we install one rule:
+//   ip daddr <ClusterIP> <proto> dport <svc-port> dnat to <backend-ip>:<port>
+//
+// Tier-2 (userspace proxy) does NOT use this table — those services bind
+// the ClusterIP directly on the pv-services bridge.
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+#include "include/xconnect.h"
+#include "services_nft.h"
+
+static int g_have_nft = -1;
+static int g_have_iptables = -1;
+
+static void detect_backends(void)
+{
+	if (g_have_nft < 0)
+		g_have_nft = (system("command -v nft >/dev/null 2>&1") == 0);
+	if (g_have_iptables < 0)
+		g_have_iptables =
+			(system("command -v iptables >/dev/null 2>&1") == 0);
+}
+
+static int run(const char *cmd)
+{
+	int rc = system(cmd);
+	if (rc != 0)
+		fprintf(stderr, "pvx-nft: rc=%d cmd=%s\n", rc, cmd);
+	return rc;
+}
+
+int pvx_services_nft_init(void)
+{
+	detect_backends();
+	if (!g_have_nft && !g_have_iptables) {
+		fprintf(stderr,
+			"pvx-nft: neither nft nor iptables available; Tier-1 DNAT disabled\n");
+		return -1;
+	}
+
+	if (g_have_nft) {
+		// Idempotent table+chain creation. Errors on already-exists
+		// are silenced; any real failure surfaces on the rule installs.
+		// Two chains: prerouting catches packets arriving from a pool
+		// bridge (consumer in container netns); output catches locally
+		// generated packets (consumer in host netns).
+		run("nft add table ip pvx_services 2>/dev/null");
+		run("nft 'add chain ip pvx_services prerouting "
+		    "{ type nat hook prerouting priority dstnat ; }' 2>/dev/null");
+		run("nft 'add chain ip pvx_services output "
+		    "{ type nat hook output priority -100 ; }' 2>/dev/null");
+		fprintf(stderr,
+			"pvx-nft: initialized ip pvx_services (nftables)\n");
+		return 0;
+	}
+
+	// iptables fallback: nothing to set up upfront — we add MASQUERADE-
+	// style PREROUTING rules per-link directly into the nat table.
+	fprintf(stderr, "pvx-nft: using iptables fallback (legacy)\n");
+	return 0;
+}
+
+void pvx_services_nft_teardown(void)
+{
+	detect_backends();
+	if (g_have_nft)
+		run("nft delete table ip pvx_services 2>/dev/null");
+	// iptables fallback rules carry the comment "pvx-services" so we can
+	// flush them by comment match if the table API isn't available.
+	if (g_have_iptables) {
+		run("iptables -t nat -S PREROUTING 2>/dev/null | "
+		    "grep -- '--comment pvx-services' | "
+		    "sed 's/^-A /-D /' | "
+		    "while read line; do iptables -t nat $line; done");
+		run("iptables -t nat -S OUTPUT 2>/dev/null | "
+		    "grep -- '--comment pvx-services' | "
+		    "sed 's/^-A /-D /' | "
+		    "while read line; do iptables -t nat $line; done");
+	}
+}
+
+static void ip_to_str(uint32_t ip_n, char *out, size_t outlen)
+{
+	struct in_addr a = { .s_addr = ip_n };
+	const char *p = inet_ntoa(a);
+	strncpy(out, p ? p : "0.0.0.0", outlen - 1);
+	out[outlen - 1] = '\0';
+}
+
+// Stable, unique-per-link comment we can grep on for removal. nft 1.x
+// treats `:` as a token separator inside unquoted comments and the shell
+// strips our outer quotes before nft sees them, so we use `_` rather than
+// `:` and `/` to keep the comment a single bareword on the nft side.
+static void link_comment(const struct pvx_link *link, char *out, size_t outlen)
+{
+	snprintf(out, outlen, "pvx_services_%s_%s",
+		 link->consumer ? link->consumer : "u",
+		 link->name ? link->name : "u");
+	for (char *p = out; *p; p++) {
+		if (*p == ':' || *p == '/' || *p == ' ' || *p == '-')
+			*p = '_';
+	}
+}
+
+int pvx_services_nft_add_dnat(const struct pvx_link *link)
+{
+	if (!link || !link->cluster_ip || !link->cluster_port ||
+	    !link->provider_ip || !link->provider_port)
+		return -1;
+	detect_backends();
+
+	char cluster_ip[INET_ADDRSTRLEN];
+	char backend_ip[INET_ADDRSTRLEN];
+	ip_to_str(link->cluster_ip, cluster_ip, sizeof(cluster_ip));
+	ip_to_str(link->provider_ip, backend_ip, sizeof(backend_ip));
+
+	char comment[128];
+	link_comment(link, comment, sizeof(comment));
+
+	char cmd[512];
+	// Install in both prerouting (pool consumer ingress through bridge)
+	// and output (host-netns consumer's locally-generated traffic). One
+	// rule each, identical match+rewrite, distinguished only by chain.
+	static const char *const chains[] = { "prerouting", "output" };
+	if (g_have_nft) {
+		for (size_t i = 0; i < sizeof(chains) / sizeof(chains[0]); i++) {
+			// Re-add is idempotent only if we first remove a stale
+			// rule for the same link; best-effort delete-by-handle
+			// dance via the comment.
+			snprintf(cmd, sizeof(cmd),
+				 "nft -a list chain ip pvx_services %s 2>/dev/null | "
+				 "awk -v c='%s' '$0 ~ c {for (i=1;i<=NF;i++) if ($i==\"handle\") print $(i+1)}' | "
+				 "while read h; do nft delete rule ip pvx_services %s handle $h; done",
+				 chains[i], comment, chains[i]);
+			run(cmd);
+
+			snprintf(cmd, sizeof(cmd),
+				 "nft add rule ip pvx_services %s "
+				 "ip daddr %s tcp dport %u "
+				 "dnat to %s:%u "
+				 "comment \"%s\"",
+				 chains[i], cluster_ip, link->cluster_port,
+				 backend_ip, link->provider_port, comment);
+			if (run(cmd) != 0)
+				return -1;
+		}
+		return 0;
+	}
+
+	if (g_have_iptables) {
+		// iptables: chain names are upper-case and OUTPUT is the
+		// equivalent of nft's output hook.
+		static const char *const ipt_chains[] = { "PREROUTING",
+							  "OUTPUT" };
+		for (size_t i = 0; i < sizeof(ipt_chains) / sizeof(ipt_chains[0]);
+		     i++) {
+			// Best-effort de-dupe: -C is silent if missing, otherwise -D.
+			snprintf(cmd, sizeof(cmd),
+				 "iptables -t nat -C %s -p tcp -d %s --dport %u "
+				 "-m comment --comment '%s' "
+				 "-j DNAT --to-destination %s:%u 2>/dev/null && "
+				 "iptables -t nat -D %s -p tcp -d %s --dport %u "
+				 "-m comment --comment '%s' "
+				 "-j DNAT --to-destination %s:%u 2>/dev/null; true",
+				 ipt_chains[i], cluster_ip, link->cluster_port,
+				 comment, backend_ip, link->provider_port,
+				 ipt_chains[i], cluster_ip, link->cluster_port,
+				 comment, backend_ip, link->provider_port);
+			run(cmd);
+
+			snprintf(cmd, sizeof(cmd),
+				 "iptables -t nat -A %s -p tcp -d %s --dport %u "
+				 "-m comment --comment '%s' "
+				 "-j DNAT --to-destination %s:%u",
+				 ipt_chains[i], cluster_ip, link->cluster_port,
+				 comment, backend_ip, link->provider_port);
+			if (run(cmd) != 0)
+				return -1;
+		}
+		return 0;
+	}
+
+	return -1;
+}
+
+int pvx_services_nft_del_dnat(const struct pvx_link *link)
+{
+	if (!link)
+		return -1;
+	detect_backends();
+
+	char comment[128];
+	link_comment(link, comment, sizeof(comment));
+	char cmd[512];
+
+	static const char *const chains[] = { "prerouting", "output" };
+	if (g_have_nft) {
+		int rc = 0;
+		for (size_t i = 0; i < sizeof(chains) / sizeof(chains[0]); i++) {
+			snprintf(cmd, sizeof(cmd),
+				 "nft -a list chain ip pvx_services %s 2>/dev/null | "
+				 "awk -v c='%s' '$0 ~ c {for (i=1;i<=NF;i++) if ($i==\"handle\") print $(i+1)}' | "
+				 "while read h; do nft delete rule ip pvx_services %s handle $h; done",
+				 chains[i], comment, chains[i]);
+			if (run(cmd) != 0)
+				rc = -1;
+		}
+		return rc;
+	}
+
+	if (g_have_iptables) {
+		static const char *const ipt_chains[] = { "PREROUTING",
+							  "OUTPUT" };
+		int rc = 0;
+		for (size_t i = 0; i < sizeof(ipt_chains) / sizeof(ipt_chains[0]);
+		     i++) {
+			snprintf(cmd, sizeof(cmd),
+				 "iptables -t nat -S %s 2>/dev/null | "
+				 "grep -- '--comment %s' | "
+				 "sed 's/^-A /-D /' | "
+				 "while read line; do iptables -t nat $line; done",
+				 ipt_chains[i], comment);
+			if (run(cmd) != 0)
+				rc = -1;
+		}
+		return rc;
+	}
+	return -1;
+}

--- a/xconnect/services_nft.h
+++ b/xconnect/services_nft.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef PVX_SERVICES_NFT_H
+#define PVX_SERVICES_NFT_H
+
+#include "include/xconnect.h"
+
+// Bring up / tear down the inet pvx_services nft table (or iptables fallback).
+int pvx_services_nft_init(void);
+void pvx_services_nft_teardown(void);
+
+// Install / remove the DNAT rule for one Tier-1 link. Idempotent: stale
+// rules for the same (consumer,name) are removed first.
+int pvx_services_nft_add_dnat(const struct pvx_link *link);
+int pvx_services_nft_del_dnat(const struct pvx_link *link);
+
+#endif


### PR DESCRIPTION
## Summary

Add a Kubernetes-Services-style **service-IP (ClusterIP) mediation layer** on top of the existing xconnect / IPAM stack.

- Provider declares `services.json` with `type: tcp, port: N`; consumer declares the service in `services.required` (via `PV_SERVICES_REQUIRED` in `args.json`).
- pv-ctrl mints a deterministic ClusterIP from the service name (FNV-1a hashed into `198.18.0.0/15` by default; configurable via `xconnect.services.cidr` / `PV_XCONNECT_SERVICES_CIDR`) and emits a richer `xconnect-graph` carrying `cluster_ip`, `provider_ip`, ports, and transports.
- pv-xconnect plants the ClusterIP as a `/32` on a host-netns `pv-services` bridge, installs an `inet pvx_services` table with both `prerouting` and `output` chains, and per-link DNAT rules rewriting `cluster_ip:port → backend_ip:port`.
- `/etc/hosts` injection (mount-ns aware) places `<cluster_ip> <service>.pv.local # pvx-services managed` inside the consumer.
- New `/xconnect-status` ctrl endpoint receives reconcile reports from pv-xconnect.

### Reachability — all four quadrants of {pool, host} × {pool, host}

| Provider | Consumer | Path |
|----------|----------|------|
| Pool | Pool | PREROUTING DNAT on bridge ingress → provider's IPAM IP |
| Host | Pool | PREROUTING DNAT → consumer's pool gateway (host-net provider on `0.0.0.0`) |
| Pool | Host | **OUTPUT-chain DNAT** → provider's IPAM IP, routes out pool bridge |
| Host | Host | **OUTPUT-chain DNAT** → `127.0.0.1` (loopback), provider accepts on lo |

The OUTPUT-chain path makes host-netns consumers reachable without leaking ClusterIP setup into container namespaces.

### Network-anchor rejection rules

Containers that touch the service mesh (export via `services.json` or require via `services.required`) must declare exactly one network anchor — IPAM pool or `mode: host`. Pantavisor never silently rewrites a container's network config.

| Brings own `lxc.net.*` | Pool | Mode | Verdict |
|---|---|---|---|
| no  | yes | (n/a)        | OK — IPAM pool member |
| yes | yes | (anything)   | REJECT (existing `99e2fba`) |
| yes | no  | host or absent | OK — host-net, container owns its config |
| no  | no  | host or absent | **REJECT (new)** — no network anchor |

Rejections fire at platform start; the existing status-goal/rollback machinery turns them into a tryboot rollback or "continue degraded" outcome with no new code paths.

### Companion changes

Meta-pantavisor PR: [pantavisor/meta-pantavisor#303](https://github.com/pantavisor/meta-pantavisor/pull/303) (test fixtures, recipes, docs, and the `docs/roadmap/` engineering plan capturing the deferred LISTEN-gate / `expose:` / scoped-DNAT slices).

## Commits in this PR

- `feat(xconnect): add TCP service-IP layer with kernel-DNAT fast path` — services.c, services_bridge.{c,h}, services_nft.{c,h}, plugins/tcp.c, /xconnect-status endpoint, parser tcp+port, config CIDR knob, sysctl helper, ipam.c sysctl conversion, state.c graph emission, host↔host OUTPUT-chain + loopback backend pick.
- `docs(xconnect): document TCP service-IP layer` — XCONNECT.md.
- `feat(xconnect): reject service participants without a clear network anchor` — manifest-level + LXC-plugin checks, `pv_platform_is_service_participant` helper.

## Test plan

All eight test cases run on a fresh build of 2026-05-06 against docker-x86_64 appengine. Full verification log in [meta-pantavisor docs/testing/testplans/testplan-xconnect-services.md](https://github.com/pantavisor/meta-pantavisor/blob/feat/xconnect-services/docs/testing/testplans/testplan-xconnect-services.md).

- [x] TC-01 — Tier-1 happy path (pool↔pool, kernel-DNAT, end-to-end fetch)
- [x] TC-02 — ClusterIP stable across provider restart
- [x] TC-03 — ClusterIP stable across full appengine restart
- [x] TC-04 — IPAM (`ip nat`) and xconnect (`ip pvx_services`) tables coexist; no rule leak after 5 cycles
- [x] TC-05 — `PV_XCONNECT_SERVICES_CIDR` overrides ClusterIP range
- [x] TC-10 — Service participant w/ no anchor → rejected (manifest-level)
- [x] TC-11 — Host-mode service participant w/o `lxc.net.*` → rejected (LXC plugin)
- [x] TC-12 — Pool participant w/ baked `lxc.net.*` → rejected (regression for `99e2fba`)