### PR TITLE
fix(appengine): silence restart noise, configurable delay, and pvtest diff capture

### DIFF
--- a/appengine/pv-appengine.in
+++ b/appengine/pv-appengine.in
@@ -13,9 +13,11 @@ usage() {
 	echo "       -c CMDLINE additional cmdline arguments (incl. legacy configs)"
 	echo "       -e ENVS envs to set (incl. new config format)"
 	echo "       -V         run with valgrind"
+	echo "       -d SECS    restart delay in seconds (default: 5)"
 }
 
 cleanup_cryptdisk() {
+	umount -l /dev/mapper/versatile > /dev/null 2>&1 || true
 	cryptsetup close versatile > /dev/null 2>&1 || true
 }
 
@@ -88,11 +90,12 @@ exec_run() {
 
 	pv_trying=""
 	shutdown=0
+	restart_delay="${restart_delay:-5}"
 	trap 'shutdown=1; echo "Recevied SIGINT, shutting down pantavisor ..."' SIGINT
 
 	while [ "$shutdown" -eq 0 ]; do
 		# load boot info
-		revs=`cat "@PV_INSTALL_FULL_STORAGEDIR@/boot/uboot.txt"`
+		revs=$(tr -d '\0' < "@PV_INSTALL_FULL_STORAGEDIR@/boot/uboot.txt")
 		pv_rev=`echo "$revs" | awk -v FS="(pv_rev=|pv_try=)" '{print $2}' `
 		pv_try=`echo "$revs" | awk -v FS="(pv_rev=|pv_try=)" '{print $3}' `
 
@@ -128,8 +131,10 @@ exec_run() {
 		else
 			eval $envs @CMAKE_INSTALL_FULL_BINDIR@/pantavisor --config @CMAKE_INSTALL_FULL_SYSCONFDIR@/pantavisor-appengine.config --cmdline \"pv_rev=$pv_rev pv_try=$pv_try $cmdline\"
 		fi
-		umount /volumes
-		umount /storage
+		umount -l /volumes || true
+		umount -l /storage || true
+		cleanup_cryptdisk
+		cleanup_cgroup
 
 		set -e
 		if [ "$shutdown" -eq 1 ]; then
@@ -146,8 +151,10 @@ exec_run() {
 				break
 			fi
 		fi
-		echo "restarting in 5 seconds..."
-		sleep 5 || true
+		if [ "$restart_delay" -gt 0 ] 2>/dev/null; then
+			echo "restarting in $restart_delay seconds..."
+			sleep "$restart_delay" || true
+		fi
 	done
 
 	if [ -d @PV_INSTALL_FULL_STORAGEDIR@-ovl ]; then
@@ -178,9 +185,13 @@ while [ $# -gt 0 ]; do
 	-V)
 		valgrind='true'
 		;;
+	-d)
+		shift
+		restart_delay="$1"
+		;;
 	*)
 		break
-		;; 
+		;;
 	esac
 	shift
 done

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -223,8 +223,8 @@ exec_test() {
 
 eval_test() {
 	if [ "$overwrite" != "true" ]; then
-		diff <(grep -vE '^(\+|\$)' $test_path/output) <(grep -vE '^(\+|\$)' "$tmp_out_path")
-		if [ $? -ne 0 ]; then
+		diff <(grep -vE '^(\+|\$)' $test_path/output) <(grep -vE '^(\+|\$)' "$tmp_out_path") | tee /var/pantavisor/storage/diff
+		if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 			stop_pv
 			exit 1
 		fi

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -137,7 +137,7 @@ start_pv() {
 	if [ "$valgrind" = "true" ]; then
 		valgrind_opt="-V"
 	fi
-	pv_cmd="pv-appengine $valgrind_opt -c \"$cmdline\""
+	pv_cmd="pv-appengine $valgrind_opt -d 0 -c \"$cmdline\""
 
 	if [ "$verbose" = "false" ]; then
 		eval "$pv_cmd > /dev/null 2>&1 &"


### PR DESCRIPTION
## Summary

Two areas improved: the appengine restart loop (`pv-appengine`) and the pvtest runner (`pvtest-run`).

### `appengine/pv-appengine.in`

- **Configurable restart delay** via new `-d SECS` flag (default: 5). Passing `-d 0` suppresses both the delay and the "restarting in N seconds…" message entirely — used by pvtest to eliminate noise from test logs.
- **Silent umount**: `umount /volumes` and `umount /storage` replaced with `umount -l ... || true` so a busy mount no longer aborts the restart loop.
- **cryptdisk cleanup** added to the restart loop (`cleanup_cryptdisk` now also unmounts `/dev/mapper/versatile` before closing it).
- **cgroup cleanup** added to the restart loop (`cleanup_cgroup` called on each iteration).
- **Null-byte stripping** when reading `uboot.txt` (`tr -d '\0'`) to avoid awk misparsing on stale boot entries.

### `pvtest/pvtest-run.in`

- pvtest now passes `-d 0` to `pv-appengine` so restarts between test phases produce no log noise.
- On a diff failure, the diff output is tee'd to `/var/pantavisor/storage/diff` (mounted on the host at `$work_path/storage/$test_id/diff`) so `test.docker.sh` can surface it directly in the post-run summary without requiring a grep through the full framework log.