### PR TITLE
fix(memory): free cert path strings in pv_get_trest_client

### DIFF
--- a/pantahub/pantahub.c
+++ b/pantahub/pantahub.c
@@ -162,6 +162,15 @@ const char **pv_ph_get_certs()
 	return (const char **)cafiles;
 }
 
+void pv_ph_free_certs(const char **certs)
+{
+	if (!certs)
+		return;
+	for (int i = 0; certs[i]; i++)
+		free((char *)certs[i]);
+	free(certs);
+}
+
 struct pv_connection *pv_get_instance_connection()
 {
 	struct pv_connection *conn = NULL;
@@ -255,8 +264,11 @@ static int pv_ph_register_self_builtin(struct pantavisor *pv)
 	jsmntok_t *tokv = NULL;
 	char **headers = NULL;
 
+	const char **certs = NULL;
+
 	tls_req = thttp_request_tls_new_0();
-	tls_req->crtfiles = (char **)pv_ph_get_certs();
+	certs = pv_ph_get_certs();
+	tls_req->crtfiles = (char **)certs;
 
 	thttp_request_t *req = (thttp_request_t *)tls_req;
 
@@ -332,6 +344,7 @@ static int pv_ph_register_self_builtin(struct pantavisor *pv)
 		thttp_request_free(req);
 	if (res)
 		thttp_response_free(res);
+	pv_ph_free_certs(certs);
 
 	return ret;
 }

--- a/pantahub/pantahub.h
+++ b/pantahub/pantahub.h
@@ -41,6 +41,7 @@ int pv_ph_device_exists(struct pantavisor *pv);
 int pv_ph_register_self(struct pantavisor *pv);
 bool pv_ph_is_auth(struct pantavisor *pv);
 const char **pv_ph_get_certs();
+void pv_ph_free_certs(const char **certs);
 int pv_ph_device_is_owned(struct pantavisor *pv, char **c);
 void pv_ph_release_client(struct pantavisor *pv);
 void pv_ph_update_hint_file(struct pantavisor *pv, char *c);

--- a/trestclient.c
+++ b/trestclient.c
@@ -153,7 +153,7 @@ err:
 
 trest_ptr pv_get_trest_client(struct pantavisor *pv, struct pv_connection *conn)
 {
-	const char **cafiles;
+	const char **cafiles = NULL;
 	trest_ptr client;
 
 	if (!conn)
@@ -260,7 +260,9 @@ trest_ptr pv_get_trest_client(struct pantavisor *pv, struct pv_connection *conn)
 					!noproxyconnect);
 	}
 
+	pv_ph_free_certs(cafiles);
 	return client;
 err:
+	pv_ph_free_certs(cafiles);
 	return NULL;
 }

--- a/updater.c
+++ b/updater.c
@@ -381,6 +381,8 @@ static int trail_put_objects(struct pantavisor *pv)
 	}
 	pv_objects_iter_end;
 
+	pv_ph_free_certs(crtfiles);
+
 	return ret;
 }
 
@@ -458,4 +460,3 @@ int pv_updater_sync()
 	// sync factory revision with Hub
 	return trail_first_boot(pv);
 }
-


### PR DESCRIPTION
## Problem

`pv_ph_get_certs()` allocates a NULL-terminated array of cert path strings and returns it to
the caller. Three call sites were leaking this allocation:

- `pv_get_trest_client()` — never freed `cafiles` on either the success or error return path
- `pv_ph_register_self_builtin()` — never freed its cert array after the request
- `trail_put_objects()` — never freed `crtfiles` after the upload loop

Valgrind confirms this in `always-remote-disabled` / `always-remote-enabled` tests:

```
==175== 103 (24 direct, 79 indirect) bytes in 1 blocks are definitely lost
==175==    by 0x145A71: pv_ph_get_certs (in /usr/bin/pantavisor)
==175==    by 0x168156: pv_get_trest_client (in /usr/bin/pantavisor)
...
==175==    definitely lost: 424 bytes in 7 blocks
```

(7 blocks because `pv_get_trest_client` is called repeatedly per test run.)

## Fix

Introduce `pv_ph_free_certs(const char **certs)` in `pantahub/pantahub.c`:
iterates the NULL-terminated array freeing each string, then frees the array itself.
Declare it in `pantahub/pantahub.h`.

Use `pv_ph_free_certs()` at all three call sites. Also initialize `cafiles = NULL` in
`pv_get_trest_client()` so the error path is safe even when `pv_ph_get_certs()` was never
reached.

## Files changed

- `pantahub/pantahub.h` — declare `pv_ph_free_certs`
- `pantahub/pantahub.c` — implement `pv_ph_free_certs`; free certs in `pv_ph_register_self_builtin`
- `trestclient.c` — init `cafiles = NULL`; free on both return paths
- `updater.c` — free `crtfiles` after upload loop
anibal@anibal-desktop:~/sw/pantacor/workdir$ 