### PR TITLE
fix: reduce setfd crash exposure (retries=0 + remove Connection: close)

### DIFF
--- a/config.c
+++ b/config.c
@@ -144,7 +144,7 @@ static struct pv_config_entry entries[] = {
 	{ INT, "PH_LIBEVENT_HTTP_TIMEOUT", PH | OEM | RUN, 0, false,
 	  .value.i = 60 },
 	{ INT, "PH_LIBEVENT_HTTP_RETRIES", PH | OEM | RUN, 0, false,
-	  .value.i = 1 },
+	  .value.i = 0 },
 	{ INT, "PH_METADATA_DEVMETA_INTERVAL", PH | OEM | RUN, 0, false,
 	  .value.i = 10 },
 	{ INT, "PH_METADATA_USRMETA_INTERVAL", PH | OEM | RUN, 0, false,

--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -33,7 +33,7 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PH_CREDS_SECRET` | string | empty | set [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) credentials secret |
 | `PH_CREDS_TYPE` | `builtin` | `builtin` | set [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) credentials type |
 | `PH_FACTORY_AUTOTOK` | token | empty | set [factory auto token](https://docs.pantahub.com/pantahub-base/devices/#auto-assign-devices-to-owners) for communication with [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |
-| `PH_LIBEVENT_HTTP_RETRIES` | number of retries | `1` | set HTTP request number of retries for communication with [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |
+| `PH_LIBEVENT_HTTP_RETRIES` | number of retries | `0` | set HTTP request number of retries for communication with [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |
 | `PH_LIBEVENT_HTTP_TIMEOUT` | time (in seconds) | `60` | set HTTP request timeout for communication with [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |
 | `PH_METADATA_DEVMETA_INTERVAL` | time (in seconds) | `10` | set push interval for [device metadata](../../pantavisor-src/docs/overview/storage.md#device-metadata) to [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |
 | `PH_METADATA_USRMETA_INTERVAL` | time (in seconds) | `5` | set refresh interval for [user metadata](../../pantavisor-src/docs/overview/storage.md#user-metadata) from [Pantacor Hub](../../pantavisor-src/docs/overview/remote-control.md#pantacor-hub) |

--- a/event/event_rest.c
+++ b/event/event_rest.c
@@ -274,7 +274,6 @@ int pv_event_rest_send_by_components(
 	output_headers = evhttp_request_get_output_headers(req);
 
 	_add_header(output_headers, "Host", host);
-	_add_header(output_headers, "Connection", "close");
 	_add_header(output_headers, "User-Agent", pv_user_agent);
 
 	if (token) {


### PR DESCRIPTION
## Problem

`evhttp_connection_reset_hard_()` in libevent calls `bufferevent_replacefd(bev, -1)` to detach the fd before reconnecting. SSL (mbedTLS) bufferevents do not support `replacefd`, causing a fatal `EVUTIL_ASSERT(!err && "setfd")` crash. On master, two independent mechanisms trigger this reset unnecessarily on every HTTPS cycle:

### 1. PH_LIBEVENT_HTTP_RETRIES = 1 (default)

When a request fails, libevent retries it by resetting the connection, calling `evhttp_connection_reset_hard_()` → crash. This is redundant: the PH state machine already owns retry semantics at a higher level, while libevent-level retries add no reliability and directly cause the crash.

### 2. Connection: close on every HTTPS request

`event/event_rest.c` adds `Connection: close` to every outgoing request. This tells pantahub to close the TCP connection after each response, forcing PV to reconnect — calling `evhttp_connection_reset_hard_()` → crash on every single request.

```
[pantavisor] ERROR -- [event]: http.c:1451: Assertion !err && "setfd" failed in evhttp_connection_reset_hard_
```

## Fix

**Commit 1:** Set `PH_LIBEVENT_HTTP_RETRIES` default to `0`. The PH state machine handles all retries; libevent-level retry only causes harm here.

**Commit 2:** Remove the `Connection: close` header from `pv_event_rest_send_by_components()`. HTTP/1.1 keep-alive is used instead, eliminating the forced-reconnect on every request.

### Pros  removing Connection: close
- `evhttp_connection_reset_hard_()` is no longer called in normal operation → setfd crash eliminated for the common case.
- TLS sessions are reused across the devmeta/usrmeta/step polling loop → less handshake overhead.

### Cons
- Connections now stay open until pantahub or a load balancer closes them. A server-side close will still trigger reset_hard_()` — but far less frequently than once per request.

## Files changed

- `config/config.c` (or equivalent) — `PH_LIBEVENT_HTTP_RETRIES` default: `1` → `0`
- `event/event_rest.c` — remove `_add_header(output_headers, "Connection", "close")`
anibal@anibal-desktop:~/sw/pantacor/workdir$ 