### PR TITLE
fix(hooks): assign return value of pv_storage_get_rev_progress to json

### DIFF
--- a/hook/hooks.c
+++ b/hook/hooks.c
@@ -97,9 +97,9 @@ static char *get_current_status(const char *pv_rev, const char *pv_try)
 	char *json = NULL;
 
 	if (pv_try && strlen(pv_try) > 0)
-		pv_storage_get_rev_progress(pv_try);
+		json = pv_storage_get_rev_progress(pv_try);
 	else
-		pv_storage_get_rev_progress(pv_rev);
+		json = pv_storage_get_rev_progress(pv_rev);
 
 	if (!json)
 		return NULL;


### PR DESCRIPTION
## Problem

`get_current_status()` in `hook/hooks.c` calls `pv_storage_get_rev_progress()` but discards
the return value — `json` is declared but never assigned, so it stays `NULL` and the
function always returns `NULL` regardless of the actual revision progress state.

```c
// before — return value discarded, json stays NULL
if (pv_try && strlen(pv_try) > 0)
    pv_storage_get_rev_progress(pv_try);
else
    pv_storage_get_rev_progress(pv_rev);

if (!json)   // always true
    return NULL;
```

Any hook that calls `get_current_status()` to check the lifecycle state never sees an
actual status string — it always gets NULL back.

## Fix

Assign the return value:

```c
if (pv_try && strlen(pv_try) > 0)
    json = pv_storage_get_rev_progress(pv_try);
else
    json = pv_storage_get_rev_progress(pv_rev);
```

## Files changed

- `hook/hooks.c`