### PR TITLE
fix(crypt): unmount stale dm-crypt device before close in clean_disk

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -444,13 +444,23 @@ clean_disk()
 		caam*|dcp__mainline)
 			if dmsetup info -c "$name" >/dev/null 2>&1; then
 				echo "WARN: dm $name still exists"
-				dmsetup remove "$name" > /dev/null 2>&1 || true
+				mnt=$(grep "^/dev/mapper/$name " /proc/mounts | awk '{print $2}' | head -1)
+				if [ -n "$mnt" ]; then
+					echo "WARN: /dev/mapper/$name mounted at $mnt, unmounting"
+					umount "$mnt" >/dev/null 2>&1 || umount -l "$mnt" >/dev/null 2>&1 || true
+				fi
+				dmsetup remove "$name" >/dev/null 2>&1 || true
 			fi
 			;;
 		dcp__nxp|versatile__*)
-			if cryptsetup status "$name" > /dev/null 2>&1; then
-				echo "WARN: cryptdisk $1 still exists"
-				cryptsetup close "$name" > /dev/null 2>&1 || true
+			if cryptsetup status "$name" >/dev/null 2>&1; then
+				echo "WARN: cryptdisk $name still exists"
+				mnt=$(grep "^/dev/mapper/$name " /proc/mounts | awk '{print $2}' | head -1)
+				if [ -n "$mnt" ]; then
+					echo "WARN: /dev/mapper/$name mounted at $mnt, unmounting"
+					umount "$mnt" >/dev/null 2>&1 || umount -l "$mnt" >/dev/null 2>&1 || true
+				fi
+				cryptsetup close "$name" >/dev/null 2>&1 || true
 			fi
 			;;
 	esac


### PR DESCRIPTION
## Problem

`clean_disk()` in `scripts/volmount/crypt/crypt` closes stale dm-crypt and dm devices with
`cryptsetup close` / `dmsetup remove`, but does not check whether the device is still
mounted first. When Pantavisor is killed ungracefully (e.g. during an update-retries test),
the filesystem on the mapper device remains mounted. The close/remove call then fails
silently, leaving the device in a broken state that prevents the next boot from re-opening
the volume.

This is the root cause of `update-retries-pv-crash` test failures: after PV is killed
mid-update, the test harness runs cleanup, cleanup silently fails to close the crypt disk,
and the next PV boot cannot mount the volume.

## Fix

Before attempting `dmsetup remove` or `cryptsetup close`, check `/proc/mounts` for any
filesystem mounted on `/dev/mapper/<name>`. If found, unmount it (with lazy fallback) first.

```sh
mnt=$(grep "^/dev/mapper/$name " /proc/mounts | awk '{print $2}' | head -1)
if [ -n "$mnt" ]; then
    echo "WARN: /dev/mapper/$name mounted at $mnt, unmounting"
    umount "$mnt" >/dev/null 2>&1 || umount -l "$mnt" >/dev/null 2>&1 || true
fi
```

Applied to both the `caam*/dcp__mainline` (dmsetup) and `dcp__nxp/versatile__*`
(cryptsetup) branches of `clean_disk()`.

## Files changed

- `scripts/volmount/crypt/crypt