### PR TITLE
fix(memory): free progress_str and trest client — two valgrind leaks

### DIFF
--- a/update/update.c
+++ b/update/update.c
@@ -166,7 +166,8 @@ static void _finish_update_installation()
 
 	/* Bootloader can force reboot (e.g. pv_rev.txt overflow) */
 	if (bl_rv > 0 && u->transition == PV_SYSTEM_TRANSITION_NONREBOOT) {
-		pv_log(INFO, "bootloader requests forced reboot for this update");
+		pv_log(INFO,
+		       "bootloader requests forced reboot for this update");
 		pv_issue_reboot();
 		u->transition = PV_SYSTEM_TRANSITION_REBOOT;
 	}
@@ -231,7 +232,6 @@ void pv_update_start_install(const char *rev, const char *progress_hub,
 		if (pv_update_is_final()) {
 			pv_log(WARN, "progress already in a final state");
 			_call_report_cb(u->rev, progress_str);
-			free(progress_str);
 			goto out;
 		} else {
 			pv_log(DEBUG, "progress not final, queueing again");
@@ -297,6 +297,7 @@ void pv_update_start_install(const char *rev, const char *progress_hub,
 		_finish_update_installation();
 	}
 out:
+	free(progress_str);
 	if (pv_update_is_final())
 		pv_update_finish();
 }
@@ -654,10 +655,8 @@ int pv_update_resume(void (*report_cb)(const char *, const char *))
 	}
 
 	pv_log(DEBUG, "update_resume: trying=%d failed=%d done=%d factory=%d",
-	       pv_bootloader_trying_update(),
-	       pv_update_is_failed(),
-	       pv_update_is_done(),
-	       _is_factory(rev));
+	       pv_bootloader_trying_update(), pv_update_is_failed(),
+	       pv_update_is_done(), _is_factory(rev));
 
 	// if we are currently trying a revision that already failed
 	if (pv_bootloader_trying_update() && pv_update_is_failed()) {

--- a/updater.c
+++ b/updater.c
@@ -53,6 +53,7 @@ static void pv_trail_remote_free(struct trail_remote *trail)
 
 	pv_log(DEBUG, "removing trail");
 
+	trest_free(trail->client);
 	free(trail);
 }
 
@@ -94,10 +95,8 @@ static int trail_remote_init(struct pantavisor *pv)
 	return 0;
 
 err:
-	if (client)
-		free(client);
-	if (remote)
-		free(remote);
+	trest_free(client);
+	free(remote);
 
 	return -1;
 }


### PR DESCRIPTION
## Summary

Two definite memory leaks identified from overnight valgrind runs (remote and local test suites, all tests passed). Both are small in bytes but consistent — they occur on every update cycle restart on real devices.

### Leak 1 — `progress_str` not freed in `pv_update_start_install` (`update/update.c`)

`progress_str` is allocated either from disk (`pv_storage_get_rev_progress`) or as a `strdup` of the Hub-sourced `progress_hub` string. The only existing `free(progress_str)` was inside the early-exit `is_final()` branch. Every other exit path — non-final disk progress, hub-sourced progress, max-retries abort, signature failure, state-parse failure, state-install failure — fell through to `out:` without freeing it.

**Fix:** move the free to `out:` (removing the now-redundant inline free from the `is_final()` branch).

### Leak 2 — `trest_ptr client` not freed when the trail remote is torn down (`updater.c`)

`pv_trail_remote_free` called `free(trail)` on the wrapping struct but never called `trest_free(trail->client)`, so the entire trest/mbedtls/thttp object graph allocated by `trest_new_tls_from_userpass` was leaked on every shutdown or restart. Additionally, `trail_remote_init`'s error path used a plain `free(client)` instead of `trest_free(client)`, which only freed the top-level pointer and left internal state unreleased.

**Fix:** call `trest_free(trail->client)` inside `pv_trail_remote_free` before freeing the container, and replace `free(client)` with `trest_free(client)` in the error path.

### Why did `fix/trest-free-cert-strings` (8b781c1) miss this?

That branch introduced `pv_ph_free_certs()` to release the `cafiles` cert-path array. That array is allocated **inside** `pv_get_trest_client` and was clearly local to it — the fix was applied at both return sites of the same function.

The `trest_ptr client` is a different object: it is the **output** of `pv_get_trest_client`, and its lifetime is owned entirely by the caller. The place where it must be freed is `pv_trail_remote_free` — a different function in a different role (struct destructor, not factory). The cert-string review was naturally scoped to what `pv_get_trest_client` itself allocated; it did not audit the full ownership chain of the returned pointer across all callers. Only the valgrind run surface the missing destructor call in `pv_trail_remote_free`.

## Changes

| File | Change |
|------|--------|
| `update/update.c` | Free `progress_str` at `out:` instead of only in the `is_final()` early-exit branch |
| `updater.c` | `pv_trail_remote_free`: add `trest_free(trail->client)` before `free(trail)` |
| `updater.c` | `trail_remote_init` error path: replace `free(client)` with `trest_free(client)` |