### PR TITLE
fix(pantahub): cap download read buffer to prevent event loop starvation

### DIFF
--- a/event/event_rest.c
+++ b/event/event_rest.c
@@ -48,6 +48,7 @@
 #include "utils/str.h"
 
 #define MODULE_NAME "event_rest"
+#define HTTP_DOWNLOAD_READ_HIGHWATER (128 * 1024)
 #define pv_log(level, msg, ...)                                                \
 	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
 	     ##__VA_ARGS__)
@@ -234,6 +235,8 @@ int pv_event_rest_send_by_components(
 	}
 
 	bufferevent_mbedtls_set_allow_dirty_shutdown(bev, 1);
+	/* Bound buffered read data so large downloads don't starve the event loop. */
+	bufferevent_setwatermark(bev, EV_READ, 0, HTTP_DOWNLOAD_READ_HIGHWATER);
 
 	struct evhttp_connection *evcon;
 	evcon = evhttp_connection_base_bufferevent_new(pv_event_get_base(),


### PR DESCRIPTION
## Summary
- During large binary downloads, libevent read all available TCP data into
  the bufferevent in one shot, causing chunk_cb to fire with the entire
  payload (up to 50 MB) at once
- The synchronous write loop blocked the event loop for the full download
  duration, starving pvcontrol requests ("ctrl gap")
- A 128 KB read high-watermark limits data buffered per event-loop tick;
  combined with BEV_OPT_DEFER_CALLBACKS (already set), ctrl requests are
  dispatched between download chunks

## Changes
- `event/event_rest.c`: add `HTTP_DOWNLOAD_READ_HIGHWATER` (128 KB) constant
- `event/event_rest.c`: call `bufferevent_setwatermark(bev, EV_READ, 0, HTTP_DOWNLOAD_READ_HIGHWATER)` after creating the TLS bufferevent in `pv_event_rest_send_by_components()`