### PR TITLE
feat(pantahub,event_rest): add missing run event trace logs

### DIFF
--- a/event/event_rest.c
+++ b/event/event_rest.c
@@ -140,6 +140,8 @@ static void _add_header(struct evkeyvalq *output_headers, const char *key,
 
 static void _print_error_cb(enum evhttp_request_error error, void *ctx)
 {
+	pv_log(TRACE, "run event: cb=%p", (void *)_print_error_cb);
+
 	switch (error) {
 	case EVREQ_HTTP_TIMEOUT:
 		pv_log(WARN, "timeout reached");
@@ -170,6 +172,8 @@ static void _print_error_cb(enum evhttp_request_error error, void *ctx)
 
 static int _header_cb(struct evhttp_request *req, void *ctx)
 {
+	pv_log(TRACE, "run event: cb=%p", (void *)_header_cb);
+
 	struct evhttp_connection *evcon;
 	const struct sockaddr *sa;
 	struct sockaddr_in6 *addr_in6;

--- a/pantahub/pantahub.c
+++ b/pantahub/pantahub.c
@@ -833,6 +833,8 @@ static void _run_state_download()
 
 static void _run_state_cb(evutil_socket_t fd, short events, void *arg)
 {
+	pv_log(TRACE, "run event: cb=%p", (void *)_run_state_cb);
+
 	struct pv_pantahub *ph = _get_ph_instance();
 	if (!ph)
 		return;


### PR DESCRIPTION
## Summary
- `_run_state_cb`, `_header_cb`, and `_print_error_cb` were the only libevent
  callbacks missing the `run event: cb=` TRACE log convention, making them
  invisible in TRACE-level output alongside all other event callbacks.

## Changes
- Add `pv_log(TRACE, "run event: cb=%p", ...)` to `_print_error_cb` and `_header_cb` in `event/event_rest.c`
- Add `pv_log(TRACE, "run event: cb=%p", ...)` to `_run_state_cb` in `pantahub/pantahub.c`