### PR TITLE
fix(pvcontrol): prefer pvcurl over curl

### DIFF
--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -10,19 +10,15 @@ response=''
 signal=''
 daemon_name=''
 
-CURL_CMD=${CURL_CMD:-curl}
+CURL_CMD=${CURL_CMD:-pvcurl}
 
 if ! command -v $CURL_CMD >/dev/null 2>&1; then
-	CURL_CMD="pvcurl"
+	CURL_CMD="curl"
 fi
 
 if ! command -v $CURL_CMD >/dev/null 2>&1; then
-	echo "Error: Neither 'curl' nor 'pvcurl' found in PATH." >&2
+	echo "Error: Neither 'pvcurl' nor 'curl' found in PATH." >&2
 	exit 1
-fi
-
-if [ "$CURL_CMD" = "pvcurl" ]; then
-	echo "INFO: Experimental pvcurl backend. Some features might not work..." >&2
 fi
 
 # only use --no-progress-meter if curl supports it


### PR DESCRIPTION
## Summary

Swap backend selection order in `pvcontrol`: try `pvcurl` first, fall back to `curl`. `pvcurl` is always present on Pantavisor devices while system `curl` may not be installed. Remove the experimental warning that was emitted when pvcurl was selected.

## Test plan

- [x] `local/control/basic-endpoints-curl` — pvcontrol with forced `CURL_CMD=curl` still works. **PASSED**
- [x] `local/control/basic-endpoints` — pvcontrol uses pvcurl by default, output is correct. **PASSED**
- [ ] `remote/control/device-user-metadata` — requires pantavisor/pantavisor#722 (ctrl evbuffer guard) to be merged first; the raw HTTP response in that test shows the double Content-Type header which is fixed there, not here.