### PR TITLE
fix(ctrl): guard all evbuffer callbacks against re-entrant drain

### DIFF
--- a/ctrl/ctrl_daemons_ep.c
+++ b/ctrl/ctrl_daemons_ep.c
@@ -68,6 +68,11 @@ static void ctrl_daemons_process_action(struct evbuffer *buf,
 					const struct evbuffer_cb_info *info,
 					void *ctx)
 {
+	(void)buf;
+
+	if (!info->n_added)
+		return;
+
 	struct evhttp_request *req = ctx;
 	char *data = NULL;
 	char *action = NULL;

--- a/ctrl/ctrl_devmeta_ep.c
+++ b/ctrl/ctrl_devmeta_ep.c
@@ -64,6 +64,11 @@ static void ctrl_devmeta_list(struct evhttp_request *req, void *ctx)
 static void ctrl_devmeta_set_key(struct evbuffer *buf,
 				 const struct evbuffer_cb_info *info, void *ctx)
 {
+	(void)buf;
+
+	if (info->n_added == 0)
+		return;
+
 	struct evhttp_request *req = ctx;
 
 	ssize_t len = 0;

--- a/ctrl/ctrl_steps_ep.c
+++ b/ctrl/ctrl_steps_ep.c
@@ -176,7 +176,9 @@ static void ctrl_step_commit_cb(struct evbuffer *buf,
 				const struct evbuffer_cb_info *info, void *ctx)
 {
 	(void)buf;
-	(void)info;
+
+	if (!info->n_added)
+		return;
 
 	struct evhttp_request *req = ctx;
 	char *name = ctrl_steps_rev_name(req);

--- a/ctrl/ctrl_usrmeta_ep.c
+++ b/ctrl/ctrl_usrmeta_ep.c
@@ -66,7 +66,9 @@ static void ctrl_usrmeta_set_cb(struct evbuffer *buf,
 				const struct evbuffer_cb_info *info, void *ctx)
 {
 	(void)buf;
-	(void)info;
+
+	if (info->n_added == 0)
+		return;
 
 	struct evhttp_request *req = ctx;
 

--- a/ctrl/ctrl_util.c
+++ b/ctrl/ctrl_util.c
@@ -326,7 +326,9 @@ static void ctrl_utils_drain_ok_callback(struct evbuffer *buf,
 					 const struct evbuffer_cb_info *info,
 					 void *ctx)
 {
-	(void)info;
+	if (!info->n_added)
+		return;
+
 	ctrl_utils_drain_buf(buf);
 
 	pv_ctrl_utils_send_ok(ctx);
@@ -336,7 +338,9 @@ static void ctrl_utils_drain_error_callback(struct evbuffer *buf,
 					    const struct evbuffer_cb_info *info,
 					    void *ctx)
 {
-	(void)info;
+	if (!info->n_added)
+		return;
+
 	ctrl_utils_drain_buf(buf);
 
 	if (!ctx)

--- a/ctrl/ctrl_util.c
+++ b/ctrl/ctrl_util.c
@@ -52,7 +52,7 @@ struct pv_ctrl_http_code_value {
 struct ctrl_utils_drain_data {
 	struct evhttp_request *req;
 	int code;
-	const char *msg;
+	char msg[PV_CTRL_MAX_ERR];
 };
 
 struct pv_ctrl_http_code_value http_codes[] = {
@@ -348,6 +348,7 @@ static void ctrl_utils_drain_error_callback(struct evbuffer *buf,
 
 	struct ctrl_utils_drain_data *data = ctx;
 	pv_ctrl_utils_send_error(data->req, data->code, data->msg);
+	free(data);
 }
 
 void pv_ctrl_utils_drain_on_arrive_with_ok(struct evhttp_request *req)
@@ -372,7 +373,7 @@ void pv_ctrl_utils_drain_on_arrive_with_err(struct evhttp_request *req,
 	}
 
 	data->code = code;
-	data->msg = err_str;
+	memccpy(data->msg, err_str, '\0', PV_CTRL_MAX_ERR - 1);
 	data->req = req;
 
 	evbuffer_add_cb(evhttp_request_get_input_buffer(req),


### PR DESCRIPTION
## Summary

`evbuffer_add_cb` callbacks on an `evhttp` input buffer fire synchronously on both additions and drains. Without a guard the drain inside the callback re-enters it with `n_added==0`, triggering a second `evhttp_send_reply` — use-after-free / assertion crash exploitable by any local client.

**Commit 1** — adds `if (!info->n_added) return` to four remaining unguarded callbacks: `ctrl_step_commit_cb`, `ctrl_daemons_process_action`, `ctrl_utils_drain_ok_callback`, `ctrl_utils_drain_error_callback`. Places `(void)buf` before the guard per project convention.

**Commit 2** — fixes a dangling-pointer in `ctrl_utils_drain_data`: `msg` stored a pointer to the callers stack-allocated `err[]` buffer, gone before the async callback fires. Embeds the string as `char msg[PV_CTRL_MAX_ERR]`, copies it at registration time. Also frees the struct after use.

Note: equivalent guards for `ctrl_usrmeta_set_cb` and `ctrl_devmeta_set_key` were applied to master directly in `4f3ed21`.

## Test plan

- [ ] `local/control/basic-endpoints` and `local/control/basic-endpoints-curl` pass.
- [ ] `remote/control/device-user-metadata` — PUT usrmeta/devmeta produces single Content-Type header.