### PR TITLE
fix(pvcurl): replace busybox-incompatible sed with extract_body()

### DIFF
--- a/tools/pvcurl
+++ b/tools/pvcurl
@@ -125,7 +125,7 @@ if [ -n "$OUTPUT_FILE" ]; then
 elif [ "$SHOW_HEADERS" = true ]; then
     cat /tmp/http_res
 else
-    sed '1,/^\r\{0,1\}$/d' /tmp/http_res
+    extract_body
 fi
 
 if [ -n "$WRITE_OUT" ]; then


### PR DESCRIPTION
## Summary

Replace the GNU-sed-only header-stripping expression in the default output path of `pvcurl` with the existing portable `extract_body()` function. The `sed '1,/^\r\{0,1\}$/d'` form requires GNU sed extensions that are not available under busybox (embedded/Pantavisor devices), causing response bodies to be returned with HTTP headers prepended.

`extract_body()` was already used for the `OUTPUT_FILE` path — this makes the default path consistent with it.

## Test plan

- [ ] `local/control/basic-endpoints` — pvcurl default output path returns clean JSON bodies without headers.
- [ ] `remote/control/device-user-metadata` — same.