### PR TITLE
fix(ctrl): complete request-body lifecycle and object download streaming

### DIFF
--- a/ctrl/ctrl_containers_ep.c
+++ b/ctrl/ctrl_containers_ep.c
@@ -94,6 +94,11 @@ static void ctrl_container_process_action(struct evbuffer *buf,
 	if (!info->n_added)
 		return;
 
+	if (!pv_ctrl_utils_has_all_data(req))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_container_process_action, ctx);
+
 	const char *uri = evhttp_request_get_uri(req);
 	char split[PV_CTRL_MAX_SPLIT][NAME_MAX] = { 0 };
 	int size = pv_ctrl_utils_split_path(uri, split);

--- a/ctrl/ctrl_daemons_ep.c
+++ b/ctrl/ctrl_daemons_ep.c
@@ -68,6 +68,14 @@ static void ctrl_daemons_process_action(struct evbuffer *buf,
 					const struct evbuffer_cb_info *info,
 					void *ctx)
 {
+	if (!info->n_added)
+		return;
+
+	if (!pv_ctrl_utils_has_all_data(ctx))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_daemons_process_action, ctx);
+
 	struct evhttp_request *req = ctx;
 	char *data = NULL;
 	char *action = NULL;

--- a/ctrl/ctrl_devmeta_ep.c
+++ b/ctrl/ctrl_devmeta_ep.c
@@ -64,6 +64,14 @@ static void ctrl_devmeta_list(struct evhttp_request *req, void *ctx)
 static void ctrl_devmeta_set_key(struct evbuffer *buf,
 				 const struct evbuffer_cb_info *info, void *ctx)
 {
+	if (!info->n_added)
+		return;
+
+	if (!pv_ctrl_utils_has_all_data(ctx))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_devmeta_set_key, ctx);
+
 	struct evhttp_request *req = ctx;
 
 	ssize_t len = 0;

--- a/ctrl/ctrl_steps_ep.c
+++ b/ctrl/ctrl_steps_ep.c
@@ -32,6 +32,7 @@
 #include "utils/fs.h"
 
 #include <event2/http.h>
+#include <event2/buffer.h>
 
 #include <string.h>
 
@@ -176,7 +177,13 @@ static void ctrl_step_commit_cb(struct evbuffer *buf,
 				const struct evbuffer_cb_info *info, void *ctx)
 {
 	(void)buf;
-	(void)info;
+	if (!info->n_added)
+		return;
+
+	if (!pv_ctrl_utils_has_all_data(ctx))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_step_commit_cb, ctx);
 
 	struct evhttp_request *req = ctx;
 	char *name = ctrl_steps_rev_name(req);

--- a/ctrl/ctrl_upload.c
+++ b/ctrl/ctrl_upload.c
@@ -32,7 +32,9 @@
 #include <event2/http.h>
 #include <event2/buffer.h>
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define MODULE_NAME "ctrl_upload"
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
@@ -112,7 +114,14 @@ static void ctrl_upload_read_cb(struct evbuffer *buf,
 
 	pv_storage_gc_defer_run_threshold();
 
-	evbuffer_write(buf, up->file->fd);
+	while (evbuffer_get_length(buf) > 0) {
+		int written = evbuffer_write(buf, up->file->fd);
+		if (written <= 0) {
+			pv_log(WARN, "upload write failed: %s",
+			       strerror(errno));
+			goto err;
+		}
+	}
 
 	return;
 

--- a/ctrl/ctrl_usrmeta_ep.c
+++ b/ctrl/ctrl_usrmeta_ep.c
@@ -66,7 +66,13 @@ static void ctrl_usrmeta_set_cb(struct evbuffer *buf,
 				const struct evbuffer_cb_info *info, void *ctx)
 {
 	(void)buf;
-	(void)info;
+	if (!info->n_added)
+		return;
+
+	if (!pv_ctrl_utils_has_all_data(ctx))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_usrmeta_set_cb, ctx);
 
 	struct evhttp_request *req = ctx;
 

--- a/ctrl/ctrl_util.c
+++ b/ctrl/ctrl_util.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #define MODULE_NAME "ctrl-utils"
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
@@ -52,7 +53,7 @@ struct pv_ctrl_http_code_value {
 struct ctrl_utils_drain_data {
 	struct evhttp_request *req;
 	int code;
-	const char *msg;
+	char *msg;
 };
 
 struct pv_ctrl_http_code_value http_codes[] = {
@@ -135,6 +136,7 @@ void pv_ctrl_utils_send_json_file(struct evhttp_request *req, const char *path)
 		goto out;
 	}
 
+	fd = -1;
 	pv_ctrl_utils_send_ok(req);
 out:
 	if (fd > -1)
@@ -269,6 +271,19 @@ ssize_t pv_ctrl_utils_get_content_length(struct evhttp_request *req)
 	return cl;
 }
 
+bool pv_ctrl_utils_has_all_data(struct evhttp_request *req)
+{
+	ssize_t expected = pv_ctrl_utils_get_content_length(req);
+	if (expected < 0)
+		return true;
+
+	struct evbuffer *buf = evhttp_request_get_input_buffer(req);
+	if (!buf)
+		return false;
+
+	return evbuffer_get_length(buf) >= (size_t)expected;
+}
+
 char *pv_ctrl_utils_get_data(struct evhttp_request *req, ssize_t max,
 			     ssize_t *len)
 {
@@ -313,7 +328,7 @@ char *pv_ctrl_utils_get_data(struct evhttp_request *req, ssize_t max,
 static void ctrl_utils_drain_buf(struct evbuffer *buf)
 {
 	size_t len = evbuffer_get_length(buf);
-	pv_log(DEBUG, "discarding %zd bytes");
+	pv_log(DEBUG, "discarding %zd bytes", len);
 	evbuffer_drain(buf, len);
 }
 
@@ -326,7 +341,13 @@ static void ctrl_utils_drain_ok_callback(struct evbuffer *buf,
 					 const struct evbuffer_cb_info *info,
 					 void *ctx)
 {
-	(void)info;
+	if (!info->n_added)
+		return;
+
+	if (!pv_ctrl_utils_has_all_data(ctx))
+		return;
+
+	evbuffer_remove_cb(buf, ctrl_utils_drain_ok_callback, ctx);
 	ctrl_utils_drain_buf(buf);
 
 	pv_ctrl_utils_send_ok(ctx);
@@ -336,7 +357,16 @@ static void ctrl_utils_drain_error_callback(struct evbuffer *buf,
 					    const struct evbuffer_cb_info *info,
 					    void *ctx)
 {
-	(void)info;
+	if (!info->n_added)
+		return;
+
+	if (ctx) {
+		struct ctrl_utils_drain_data *data = ctx;
+		if (!pv_ctrl_utils_has_all_data(data->req))
+			return;
+	}
+
+	evbuffer_remove_cb(buf, ctrl_utils_drain_error_callback, ctx);
 	ctrl_utils_drain_buf(buf);
 
 	if (!ctx)
@@ -344,6 +374,8 @@ static void ctrl_utils_drain_error_callback(struct evbuffer *buf,
 
 	struct ctrl_utils_drain_data *data = ctx;
 	pv_ctrl_utils_send_error(data->req, data->code, data->msg);
+	free(data->msg);
+	free(data);
 }
 
 void pv_ctrl_utils_drain_on_arrive_with_ok(struct evhttp_request *req)
@@ -368,7 +400,17 @@ void pv_ctrl_utils_drain_on_arrive_with_err(struct evhttp_request *req,
 	}
 
 	data->code = code;
-	data->msg = err_str;
+	data->msg = strdup(err_str ? err_str : "");
+	if (!data->msg) {
+		free(data);
+		pv_log(DEBUG,
+		       "couldn't allocate message data. Request will be "
+		       "drain but a 'broken pipe' could happen on the client side");
+
+		evbuffer_add_cb(evhttp_request_get_input_buffer(req),
+				ctrl_utils_drain_error_callback, NULL);
+		return;
+	}
 	data->req = req;
 
 	evbuffer_add_cb(evhttp_request_get_input_buffer(req),

--- a/ctrl/ctrl_util.h
+++ b/ctrl/ctrl_util.h
@@ -59,6 +59,8 @@ int pv_ctrl_utils_is_req_ok(struct evhttp_request *req, struct pv_ctrl_cb *cb,
 
 ssize_t pv_ctrl_utils_get_content_length(struct evhttp_request *req);
 
+bool pv_ctrl_utils_has_all_data(struct evhttp_request *req);
+
 char *pv_ctrl_utils_get_data(struct evhttp_request *req, ssize_t max,
 			     ssize_t *len);
 

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -724,7 +724,11 @@ exec_cmd() {
 			put_object "$path" "$sha"
 			;;
 		getobject)
-			$CURL_RAW -X GET --unix-socket "$SOCKET" "http://localhost/objects/$sha"
+			if [ -n "$OUTPUT" ]; then
+				$CURL_RAW -o "$OUTPUT" -X GET --unix-socket "$SOCKET" "http://localhost/objects/$sha"
+			else
+				$CURL_RAW -X GET --unix-socket "$SOCKET" "http://localhost/objects/$sha"
+			fi
 			exit 0
 			;;
 		listobjects)

--- a/tools/pvcurl
+++ b/tools/pvcurl
@@ -90,8 +90,9 @@ log_verbose "> $METHOD $URL HTTP/1.0"
 
 NC_EXIT=0
 # Use -N (close write on stdin EOF) for non-streaming requests.
-# For streaming downloads (-o), omit -N to keep connection alive for chunked data.
-if [ -n "$OUTPUT_FILE" ]; then
+# For GET downloads, omit -N to keep the connection alive while the server
+# streams the response body.
+if [ -n "$OUTPUT_FILE" ] || [ "$METHOD" = "GET" ]; then
     nc -w "$CONNECT_TIMEOUT" -U "$SOCKET" < /tmp/http_req > /tmp/http_res 2>/tmp/nc_err || NC_EXIT=$?
 else
     nc -N -w "$CONNECT_TIMEOUT" -U "$SOCKET" < /tmp/http_req > /tmp/http_res 2>/tmp/nc_err || NC_EXIT=$?


### PR DESCRIPTION
## Summary

Two fixes around the pv-ctrl libevent request lifecycle and the pvcontrol/pvcurl object transfer path.

### fix(ctrl): process request body only after full payload arrives
- libevent fires the evbuffer "data added" callbacks on every chunk, so the PUT/POST endpoint handlers could parse the body before the full `Content-Length` had arrived, reading a truncated payload. Add `pv_ctrl_utils_has_all_data()` and gate every body callback (containers, daemons, devmeta, steps, usrmeta and the drain helpers) on it, removing the one-shot callback once it fires.
- `ctrl_upload`: loop `evbuffer_write()` until the buffer is fully drained and bail out on write errors instead of silently dropping data.
- `ctrl_util`: own the deferred error message (`strdup`/`free`) since it can outlive the caller; fix a missing length argument in the discard log and clear a stale fd to avoid a double close.

### fix(pvcontrol,pvcurl): stream object downloads to a file correctly
- `pvcontrol getobject` always wrote to stdout, ignoring the `-o` output path; honor `OUTPUT` when set and stream to stdout otherwise.
- `pvcurl` passed `nc -N` (close the write side on stdin EOF) for every non-file request, tearing down the socket before the server finished streaming a GET response body. Keep the connection open for GET requests as well as `-o` downloads so chunked responses arrive in full.

## Testing
- `./kas-container build kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/with-workspace.yaml --target pantavisor-appengine-distro`
- `./test.docker.sh -v run local/control/basic-endpoints`
- manual pvcontrol object test: 2MB upload, `pvcontrol -f objects get`, and stdout `objects get` all matched SHA256
