### PR TITLE
feat(network): include interface MAC address in device metadata

### DIFF
--- a/docs/reference/pantavisor-metadata.md
+++ b/docs/reference/pantavisor-metadata.md
@@ -8,7 +8,7 @@ This is the device metadata created by Pantavisor that will give you useful info
 
 | Key | Value | Description |
 | --- | ----- | ----------- |
-| `interfaces` | json | network interfaces of the device |
+| `interfaces` | json | network interfaces of the device, keyed by `<iface>.<family>` where family is `ipv4`, `ipv6` or `mac` (see below) |
 | `pantahub.address` | IP:port | Pantacor Hub address the client is communicating with |
 | `pantahub.claimed` | 0 or 1 | 1 if claimed in Pantacor Hub |
 | `pantahub.online` | 0 or 1 | 1 if connection to Pantacor Hub was established |
@@ -25,6 +25,20 @@ This is the device metadata created by Pantavisor that will give you useful info
 | `storage` | json | disk usage of the device |
 | `sysinfo` | json | [sysinfo](https://man7.org/linux/man-pages/man2/sysinfo.2.html) |
 | `time` | json | time information |
+
+## `interfaces` format
+
+The `interfaces` device metadata is a JSON object keyed by `<iface>.<family>`. Each value is an array, since an interface can hold multiple addresses of the same family. The `mac` family carries the interface hardware (MAC) address; interfaces without a hardware address (e.g. `lo`) have no `mac` entry.
+
+```json
+{
+  "eth0.mac": ["b8:27:eb:00:11:22"],
+  "eth0.ipv4": ["192.168.1.10"],
+  "eth0.ipv6": ["fe80::ba27:ebff:fe00:1122"],
+  "lo.ipv4": ["127.0.0.1"],
+  "lo.ipv6": ["::1"]
+}
+```
 
 # User metadata
 

--- a/network.c
+++ b/network.c
@@ -39,6 +39,8 @@
 #include <linux/if.h>
 #include <linux/sockios.h>
 
+#include <netpacket/packet.h>
+
 #include <jsmn/jsmnutil.h>
 
 #include "network.h"
@@ -133,19 +135,34 @@ void pv_network_update_meta(struct pantavisor *pv)
 			continue;
 
 		char *family = NULL;
-		size_t size = 0;
 		if (ifa->ifa_addr->sa_family == AF_PACKET) {
-			continue;
-		} else if (ifa->ifa_addr->sa_family == AF_INET) {
-			family = "ipv4";
-			size = sizeof(struct sockaddr_in);
+			struct sockaddr_ll *sll =
+				(struct sockaddr_ll *)ifa->ifa_addr;
+			// only emit ethernet-style 6-byte addresses, and skip
+			// the all-zero hardware address of loopback-like ifaces
+			static const unsigned char zero[6] = { 0 };
+			if (sll->sll_halen != 6 ||
+			    !memcmp(sll->sll_addr, zero, 6))
+				continue;
+			family = "mac";
+			snprintf(host, NI_MAXHOST,
+				 "%02x:%02x:%02x:%02x:%02x:%02x",
+				 sll->sll_addr[0], sll->sll_addr[1],
+				 sll->sll_addr[2], sll->sll_addr[3],
+				 sll->sll_addr[4], sll->sll_addr[5]);
 		} else {
-			family = "ipv6";
-			size = sizeof(struct sockaddr_in6);
-		}
+			size_t size = 0;
+			if (ifa->ifa_addr->sa_family == AF_INET) {
+				family = "ipv4";
+				size = sizeof(struct sockaddr_in);
+			} else {
+				family = "ipv6";
+				size = sizeof(struct sockaddr_in6);
+			}
 
-		getnameinfo(ifa->ifa_addr, size, host, NI_MAXHOST, NULL, 0,
-			    NI_NUMERICHOST);
+			getnameinfo(ifa->ifa_addr, size, host, NI_MAXHOST, NULL,
+				    0, NI_NUMERICHOST);
+		}
 
 		snprintf(cur, IFACE_KEY_SIZE, "%s.%s", ifa->ifa_name, family);
 		if (strncmp(cur, last, IFACE_KEY_SIZE)) {


### PR DESCRIPTION
## What

`pv_network_update_meta()` builds the `interfaces` device metadata by walking `getifaddrs()`, but it explicitly `continue`d on `AF_PACKET` entries — the address family that carries each interface's hardware (MAC) address. As a result we published per-interface IPv4/IPv6 but never the MAC.

This change emits each interface's MAC under a `<iface>.mac` key, alongside the existing `<iface>.ipv4` / `<iface>.ipv6` keys, keeping the uniform "array of values per key" schema.

## Details

- Handle `AF_PACKET` via `struct sockaddr_ll`, formatting the 6-byte address as `aa:bb:cc:dd:ee:ff`.
- Skip interfaces without a usable hardware address: non-6-byte, or all-zero (e.g. loopback) — so no bogus `lo.mac` of zeros.
- Update `docs/reference/pantavisor-metadata.md` to document the `mac` family with an example.

## Example output

```json
{
  "eth0.mac":  ["b8:27:eb:00:11:22"],
  "eth0.ipv4": ["192.168.1.10"],
  "eth0.ipv6": ["fe80::ba27:ebff:fe00:1122"]
}
```

## Testing

Built `pantavisor-appengine-distro` with the workspace overlay and ran the `local/control/basic-endpoints-curl` appengine test. `pvcontrol devmeta ls` confirmed `interfaces` now includes MAC keys, with loopback correctly carrying no `.mac`:

```json
{
  "lo.ipv4": ["127.0.0.1"],
  "lo.ipv6": ["::1"],
  "lxcbrdock0.mac": ["8e:e8:ca:dd:d7:91"],
  "lxcbrdock0.ipv4": ["172.18.0.2"],
  "lxcbr0.mac": ["8e:34:d9:76:e1:9d"],
  "lxcbr0.ipv4": ["10.0.3.1"],
  "lxcbr0.ipv6": ["fe80::8c34:d9ff:fe76:e19d%lxcbr0"]
}
```