### PR TITLE
fix(disk): remove set -x from crypt volmount script

### DIFF
--- a/scripts/volmount/crypt/crypt
+++ b/scripts/volmount/crypt/crypt
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -x
-
 #
 # Copyright (c) 2021-2026 Pantacor Ltd.
 #


### PR DESCRIPTION
## Summary
- `set -x` in the crypt volmount script sends execution traces to stderr, which pantavisor captures and logs at WARN level via the `disk-crypt-err` channel on every successful mount
- The debug flag was left in from development; removing it stops the log flood without affecting error reporting (`set -e` is retained)

## Changes
- Remove `set -x` from `scripts/volmount/crypt/crypt`