### PR TITLE
ci: disable Gemini review workflows

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -1,22 +1,7 @@
 name: "🔀 Gemini Dispatch"
 
 on:
-    pull_request_review_comment:
-        types:
-            - "created"
-    pull_request_review:
-        types:
-            - "submitted"
-    pull_request:
-        types:
-            - "opened"
-    issues:
-        types:
-            - "opened"
-            - "reopened"
-    issue_comment:
-        types:
-            - "created"
+    workflow_dispatch:
 
 defaults:
     run:

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,12 +1,7 @@
 name: '🔎 Gemini Review'
 
 on:
-  workflow_call:
-    inputs:
-      additional_context:
-        type: 'string'
-        description: 'Any additional context from the request'
-        required: false
+  workflow_dispatch:
 
 concurrency:
   group: 'gemini-review-${{ github.repository }}'


### PR DESCRIPTION
## Summary

- Replace automatic event triggers in `gemini-dispatch.yml` and `gemini-review.yml` with `workflow_dispatch`
- Workflows no longer fire on PR open, issue open, or comment events
- Can still be triggered manually from the GitHub Actions UI if needed