### PR TITLE
fix(xconnect): bound half-open proxy sessions + re-establish links on restart

### DIFF
--- a/xconnect/CMakeLists.txt
+++ b/xconnect/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(
 add_executable(pv-xconnect
     main.c
     plumbing.c
+    plugins/proxy_common.c
     plugins/unix.c
     plugins/rest.c
     plugins/drm.c

--- a/xconnect/main.c
+++ b/xconnect/main.c
@@ -66,6 +66,19 @@ static void pvx_link_free(struct pvx_link *link)
 	if (!link)
 		return;
 
+	// Let the plugin release any per-link resources before we drop the
+	// listener that owns the (possibly injected) listening socket.
+	if (link->plugin && link->plugin->on_link_removed)
+		link->plugin->on_link_removed(link);
+
+	// The link owns its listener; freeing it here closes the listening
+	// socket and prevents a listener/fd leak when a link is replaced (e.g.
+	// on container restart) or retried.
+	if (link->listener) {
+		evconnlistener_free(link->listener);
+		link->listener = NULL;
+	}
+
 	free(link->name);
 	free(link->consumer);
 	free(link->role);
@@ -152,12 +165,32 @@ static void reconcile_link(const char *json, jsmntok_t *itok, int obj_tokc)
 	struct pvx_link *existing = find_link(consumer, name);
 
 	if (existing && existing->established) {
-		free(consumer);
-		free(name);
-		return;
-	}
-
-	if (existing) {
+		// A link is keyed on consumer+name, which survive a container
+		// restart. If a peer restarted, its pid changes: the old proxy
+		// would keep connecting to the dead provider pid and the consumer
+		// socket would never be re-injected into the new namespace. Detect
+		// the pid change and re-establish; otherwise leave it untouched.
+		int new_cpid =
+			parse_pid_field(json, "consumer_pid", itok, obj_tokc);
+		int new_ppid =
+			parse_pid_field(json, "provider_pid", itok, obj_tokc);
+		// A reported pid of 0 means "unknown/down" (or a host-side peer);
+		// don't tear down a working link until a real, different pid shows.
+		bool cpid_changed =
+			new_cpid && new_cpid != existing->consumer_pid;
+		bool ppid_changed =
+			new_ppid && new_ppid != existing->provider_pid;
+		if (!cpid_changed && !ppid_changed) {
+			free(consumer);
+			free(name);
+			return;
+		}
+		printf("Re-establishing link %s/%s after restart (consumer pid %d->%d, provider pid %d->%d)\n",
+		       consumer, name, existing->consumer_pid, new_cpid,
+		       existing->provider_pid, new_ppid);
+		dl_list_del(&existing->list);
+		pvx_link_free(existing);
+	} else if (existing) {
 		printf("Retrying link: %s/%s\n", consumer, name);
 		dl_list_del(&existing->list);
 		pvx_link_free(existing);

--- a/xconnect/plugins/dbus.c
+++ b/xconnect/plugins/dbus.c
@@ -29,15 +29,13 @@
 #include <unistd.h>
 #include <linux/limits.h>
 #include "../include/xconnect.h"
+#include "proxy_common.h"
 
 #define MODULE_NAME "pvx-dbus"
 
 struct dbus_proxy_session {
-	struct bufferevent *be_client;
-	struct bufferevent *be_provider;
+	struct pvx_proxy proxy; // must stay first: shared callbacks cast to it
 	struct pvx_link *link;
-	int client_eof;
-	int provider_eof;
 	int authenticated;
 };
 
@@ -90,56 +88,13 @@ static int lookup_uid_in_provider(const char *username, int provider_pid)
 	return uid;
 }
 
-static void proxy_check_close(struct dbus_proxy_session *sess)
-{
-	if (sess->client_eof && sess->provider_eof) {
-		if (sess->be_client)
-			bufferevent_free(sess->be_client);
-		if (sess->be_provider)
-			bufferevent_free(sess->be_provider);
-		free(sess);
-	}
-}
-
-static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
-{
-	struct dbus_proxy_session *sess = arg;
-
-	if (events & BEV_EVENT_ERROR) {
-		sess->client_eof = 1;
-		sess->provider_eof = 1;
-		proxy_check_close(sess);
-		return;
-	}
-
-	if (events & BEV_EVENT_EOF) {
-		if (bev == sess->be_client) {
-			sess->client_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		} else {
-			sess->provider_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		}
-		proxy_check_close(sess);
-	}
-}
-
-static void proxy_read_cb(struct bufferevent *bev, void *arg)
-{
-	struct dbus_proxy_session *sess = arg;
-	struct bufferevent *other =
-		(bev == sess->be_client) ? sess->be_provider : sess->be_client;
-	struct evbuffer *src = bufferevent_get_input(bev);
-	struct evbuffer *dst = bufferevent_get_output(other);
-	evbuffer_add_buffer(dst, src);
-}
-
 static void dbus_client_read_cb(struct bufferevent *bev, void *arg)
 {
 	struct dbus_proxy_session *sess = arg;
 
 	if (sess->authenticated) {
-		proxy_read_cb(bev, arg);
+		// Past the auth handshake: behave as a plain byte splice.
+		pvx_proxy_read_cb(bev, arg);
 		return;
 	}
 
@@ -151,8 +106,8 @@ static void dbus_client_read_cb(struct bufferevent *bev, void *arg)
 	// D-Bus authentication starts with a single NULL byte
 	unsigned char *data = evbuffer_pullup(src, 1);
 	if (data[0] == '\0') {
-		evbuffer_add(bufferevent_get_output(sess->be_provider), "\0",
-			     1);
+		evbuffer_add(bufferevent_get_output(sess->proxy.be_provider),
+			     "\0", 1);
 		evbuffer_drain(src, 1);
 		if (evbuffer_get_length(src) == 0)
 			return;
@@ -183,19 +138,20 @@ static void dbus_client_read_cb(struct bufferevent *bev, void *arg)
 		printf("%s: Masquerading D-Bus identity as role '%s' (UID %d) for service %s\n",
 		       MODULE_NAME, role, uid, sess->link->name);
 
-		evbuffer_add_printf(bufferevent_get_output(sess->be_provider),
-				    "AUTH EXTERNAL %s\r\n", hex_identity);
+		evbuffer_add_printf(
+			bufferevent_get_output(sess->proxy.be_provider),
+			"AUTH EXTERNAL %s\r\n", hex_identity);
 		sess->authenticated = 1;
 	} else if (strncmp(line, "BEGIN", 5) == 0) {
-		evbuffer_add(bufferevent_get_output(sess->be_provider),
+		evbuffer_add(bufferevent_get_output(sess->proxy.be_provider),
 			     "BEGIN\r\n", 7);
 		sess->authenticated = 1;
 	} else {
 		// Pass-through anything else during auth
-		evbuffer_add(bufferevent_get_output(sess->be_provider), line,
-			     strlen(line));
-		evbuffer_add(bufferevent_get_output(sess->be_provider), "\r\n",
-			     2);
+		evbuffer_add(bufferevent_get_output(sess->proxy.be_provider),
+			     line, strlen(line));
+		evbuffer_add(bufferevent_get_output(sess->proxy.be_provider),
+			     "\r\n", 2);
 	}
 
 	free(line);
@@ -210,6 +166,9 @@ static void dbus_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 	struct pvx_link *link = arg;
 	struct event_base *base = pvx_get_base();
 	char provider_path[PATH_MAX];
+	(void)listener;
+	(void)address;
+	(void)socklen;
 
 	if (!link->name || !link->provider_socket) {
 		close(fd);
@@ -236,34 +195,38 @@ static void dbus_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 	}
 	sess->link = link;
 
-	sess->be_client =
-		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
-	sess->be_provider =
-		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+	// DEFER_CALLBACKS keeps bufferevent_socket_connect() from invoking our
+	// event callback re-entrantly on an immediate connect failure (which
+	// would free the session while we still use it below), and makes
+	// freeing a bufferevent from within its own callback safe.
+	sess->proxy.be_client = bufferevent_socket_new(
+		base, fd, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+	sess->proxy.be_provider = bufferevent_socket_new(
+		base, -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
 
-	bufferevent_setcb(sess->be_client, dbus_client_read_cb, NULL,
-			  proxy_event_cb, sess);
-	bufferevent_setcb(sess->be_provider, proxy_read_cb, NULL,
-			  proxy_event_cb, sess);
+	// Client side runs the dbus auth filter first, then plain splicing;
+	// provider side and both event callbacks are the shared proxy core.
+	bufferevent_setcb(sess->proxy.be_client, dbus_client_read_cb, NULL,
+			  pvx_proxy_event_cb, sess);
+	bufferevent_setcb(sess->proxy.be_provider, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, sess);
 
 	struct sockaddr_un sun;
 	memset(&sun, 0, sizeof(sun));
 	sun.sun_family = AF_UNIX;
 	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
 
-	if (bufferevent_socket_connect(sess->be_provider,
+	if (bufferevent_socket_connect(sess->proxy.be_provider,
 				       (struct sockaddr *)&sun,
 				       sizeof(sun)) < 0) {
 		fprintf(stderr, "Could not connect to provider %s\n",
 			provider_path);
-		bufferevent_free(sess->be_client);
-		bufferevent_free(sess->be_provider);
-		free(sess);
+		pvx_proxy_free(&sess->proxy);
 		return;
 	}
 
-	bufferevent_enable(sess->be_client, EV_READ | EV_WRITE);
-	bufferevent_enable(sess->be_provider, EV_READ | EV_WRITE);
+	bufferevent_enable(sess->proxy.be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(sess->proxy.be_provider, EV_READ | EV_WRITE);
 }
 
 static int dbus_on_link_added(struct pvx_link *link)
@@ -306,6 +269,9 @@ static int dbus_on_link_added(struct pvx_link *link)
 		close(fd);
 		return -1;
 	}
+
+	// Survive fd exhaustion instead of busy-looping on accept().
+	pvx_listener_set_emfile_backoff(link->listener);
 
 	return 0;
 }

--- a/xconnect/plugins/proxy_common.c
+++ b/xconnect/plugins/proxy_common.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <event2/event.h>
+#include <event2/buffer.h>
+#include <event2/util.h>
+#include "../include/xconnect.h"
+#include "proxy_common.h"
+
+/*
+ * How long a half-open proxy session (one side EOF'd, the other never closing)
+ * may sit idle before we reclaim it. The timer is reset on every byte spliced,
+ * so an actively streaming response never trips it; it only fires when nothing
+ * has flowed for this long, which is what bounds fds against a provider that
+ * holds a connection open after its consumer has gone.
+ */
+#define PVX_PROXY_LINGER_SECS 60
+
+/* How long to pause a listener after running out of file descriptors. */
+#define PVX_EMFILE_BACKOFF_SECS 2
+
+struct bufferevent *pvx_proxy_peer(const struct pvx_proxy *p,
+				   struct bufferevent *bev)
+{
+	return bev == p->be_client ? p->be_provider : p->be_client;
+}
+
+void pvx_proxy_free(struct pvx_proxy *p)
+{
+	if (!p)
+		return;
+	if (p->linger)
+		event_free(p->linger);
+	if (p->be_client)
+		bufferevent_free(p->be_client);
+	if (p->be_provider)
+		bufferevent_free(p->be_provider);
+	free(p);
+}
+
+static void proxy_linger_cb(evutil_socket_t fd, short what, void *ctx)
+{
+	(void)fd;
+	(void)what;
+	// Half-open session went idle past the window: reclaim it.
+	pvx_proxy_free(ctx);
+}
+
+// Arm (or, if already armed, push back) the idle-linger timer. Called when a
+// session becomes half-open and again on every splice so active transfers are
+// never cut short.
+static void proxy_bump_linger(struct pvx_proxy *p)
+{
+	struct timeval tv = { PVX_PROXY_LINGER_SECS, 0 };
+
+	if (!p->linger) {
+		struct event_base *base = pvx_get_base();
+		if (!base)
+			return;
+		p->linger = evtimer_new(base, proxy_linger_cb, p);
+		if (!p->linger)
+			return;
+	}
+	evtimer_add(p->linger, &tv);
+}
+
+void pvx_proxy_read_cb(struct bufferevent *bev, void *ctx)
+{
+	struct pvx_proxy *p = ctx;
+	struct bufferevent *other = pvx_proxy_peer(p, bev);
+
+	evbuffer_add_buffer(bufferevent_get_output(other),
+			    bufferevent_get_input(bev));
+
+	// Keep a half-open session alive as long as data keeps moving.
+	if (p->linger)
+		proxy_bump_linger(p);
+}
+
+void pvx_proxy_event_cb(struct bufferevent *bev, short events, void *ctx)
+{
+	struct pvx_proxy *p = ctx;
+
+	if (events & BEV_EVENT_ERROR) {
+		// A peer errored (e.g. write to a closed consumer): drop the pair.
+		pvx_proxy_free(p);
+		return;
+	}
+
+	if (events & BEV_EVENT_EOF) {
+		if (bev == p->be_client)
+			p->client_eof = 1;
+		else
+			p->provider_eof = 1;
+		bufferevent_disable(bev, EV_READ);
+
+		// Both ends done: the response (if any) has already been spliced
+		// to the still-draining side's output, so freeing now is safe.
+		if (p->client_eof && p->provider_eof) {
+			pvx_proxy_free(p);
+			return;
+		}
+
+		// One end closed but the other has not. Keep the session so an
+		// in-flight response can still flow, but bound the wait so a
+		// provider that never EOFs cannot leak fds forever.
+		proxy_bump_linger(p);
+	}
+}
+
+static void listener_reenable_cb(evutil_socket_t fd, short what, void *arg)
+{
+	(void)fd;
+	(void)what;
+	evconnlistener_enable((struct evconnlistener *)arg);
+}
+
+static void listener_error_cb(struct evconnlistener *lev, void *ctx)
+{
+	struct pvx_link *link = ctx;
+	const char *who = (link && link->type) ? link->type : "pvx";
+	const char *name = (link && link->name) ? link->name : "?";
+	int err = EVUTIL_SOCKET_ERROR();
+
+	if (err == EMFILE || err == ENFILE) {
+		struct event_base *base = pvx_get_base();
+		struct timeval tv = { PVX_EMFILE_BACKOFF_SECS, 0 };
+
+		fprintf(stderr,
+			"pvx-%s: accept() for %s failed: %s; pausing listener for %ds\n",
+			who, name, strerror(err), PVX_EMFILE_BACKOFF_SECS);
+
+		evconnlistener_disable(lev);
+		if (!base ||
+		    event_base_once(base, -1, EV_TIMEOUT, listener_reenable_cb,
+				    lev, &tv) < 0)
+			evconnlistener_enable(lev);
+		return;
+	}
+
+	fprintf(stderr, "pvx-%s: accept() for %s failed: %s\n", who, name,
+		strerror(err));
+}
+
+void pvx_listener_set_emfile_backoff(struct evconnlistener *lev)
+{
+	if (!lev)
+		return;
+	evconnlistener_set_error_cb(lev, listener_error_cb);
+}

--- a/xconnect/plugins/proxy_common.h
+++ b/xconnect/plugins/proxy_common.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef PVX_PROXY_COMMON_H
+#define PVX_PROXY_COMMON_H
+
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+#include <event2/listener.h>
+
+/*
+ * Shared bidirectional proxy session used by the stream plugins (unix, rest,
+ * dbus, wayland). It splices bytes between a consumer ("client") and the
+ * provider it was wired to.
+ *
+ * Plugins that need extra per-session state (e.g. dbus auth) embed this struct
+ * as their FIRST member, so a pointer to the outer session is also a valid
+ * `struct pvx_proxy *`. That lets every plugin share the read/event callbacks
+ * and teardown below while keeping its own bufferevent callback arg.
+ *
+ * Lifecycle (see proxy_common.c): the pair is freed when BOTH sides have EOF'd,
+ * or on error, or once a half-open session (one side gone) has been idle past a
+ * linger window. Waiting for both EOFs preserves the response on a normal
+ * request/response; the idle linger bounds fds when a provider never closes
+ * (e.g. an idle stream whose consumer has already left).
+ */
+struct pvx_proxy {
+	struct bufferevent *be_client;
+	struct bufferevent *be_provider;
+	int client_eof;
+	int provider_eof;
+	struct event *linger;
+};
+
+/* The opposite bufferevent of `bev` within the session (for forwarding). */
+struct bufferevent *pvx_proxy_peer(const struct pvx_proxy *p,
+				   struct bufferevent *bev);
+
+/* Default read callback: splice all input from `bev` to its peer's output. */
+void pvx_proxy_read_cb(struct bufferevent *bev, void *ctx);
+
+/* Shared event callback: drives the lifecycle described above. */
+void pvx_proxy_event_cb(struct bufferevent *bev, short events, void *ctx);
+
+/* Tear down both bufferevents, cancel the linger timer, and free the session.
+ * Use this in the accept path when wiring fails before callbacks are live. */
+void pvx_proxy_free(struct pvx_proxy *p);
+
+/*
+ * Install an error callback on a proxy listener that survives fd exhaustion.
+ * libevent's default on an accept() EMFILE/ENFILE is to log and retry
+ * immediately, spinning the loop and flooding the log. Instead we disable the
+ * listener and re-enable it after a short back-off. The listener's user arg
+ * (a struct pvx_link *) is reused to label log lines with the service name.
+ */
+void pvx_listener_set_emfile_backoff(struct evconnlistener *lev);
+
+#endif /* PVX_PROXY_COMMON_H */

--- a/xconnect/plugins/rest.c
+++ b/xconnect/plugins/rest.c
@@ -27,64 +27,9 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include "../include/xconnect.h"
+#include "proxy_common.h"
 
 #define MODULE_NAME "pvx-rest"
-
-struct rest_proxy_session {
-	struct bufferevent *be_client;
-	struct bufferevent *be_provider;
-	struct pvx_link *link;
-	int client_eof;
-	int provider_eof;
-};
-
-static void proxy_check_close(struct rest_proxy_session *session)
-{
-	// Only close when both sides have EOF'd or errored
-	if (session->client_eof && session->provider_eof) {
-		if (session->be_client)
-			bufferevent_free(session->be_client);
-		if (session->be_provider)
-			bufferevent_free(session->be_provider);
-		free(session);
-	}
-}
-
-static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
-{
-	struct rest_proxy_session *session = arg;
-
-	if (events & BEV_EVENT_ERROR) {
-		// On error, mark both as done and close
-		session->client_eof = 1;
-		session->provider_eof = 1;
-		proxy_check_close(session);
-		return;
-	}
-
-	if (events & BEV_EVENT_EOF) {
-		// Half-close: one side sent EOF
-		if (bev == session->be_client) {
-			session->client_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		} else {
-			session->provider_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		}
-		proxy_check_close(session);
-	}
-}
-
-static void rest_read_cb(struct bufferevent *bev, void *arg)
-{
-	struct rest_proxy_session *session = arg;
-	struct bufferevent *other = (bev == session->be_client) ?
-					    session->be_provider :
-					    session->be_client;
-	struct evbuffer *src = bufferevent_get_input(bev);
-	struct evbuffer *dst = bufferevent_get_output(other);
-	evbuffer_add_buffer(dst, src);
-}
 
 static void rest_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 			   struct sockaddr *address, int socklen, void *arg)
@@ -92,6 +37,9 @@ static void rest_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 	struct pvx_link *link = arg;
 	struct event_base *base = pvx_get_base();
 	char provider_path[256];
+	(void)listener;
+	(void)address;
+	(void)socklen;
 
 	if (!link->name || !link->provider_socket) {
 		close(fd);
@@ -112,42 +60,44 @@ static void rest_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 			sizeof(provider_path) - 1);
 		provider_path[sizeof(provider_path) - 1] = '\0';
 	}
-	struct rest_proxy_session *session = calloc(1, sizeof(*session));
-	if (!session) {
+
+	struct pvx_proxy *p = calloc(1, sizeof(*p));
+	if (!p) {
 		fprintf(stderr, "Could not allocate REST proxy session\n");
 		close(fd);
 		return;
 	}
 
-	session->link = link;
-	session->be_client =
-		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
-	session->be_provider =
-		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+	// DEFER_CALLBACKS keeps bufferevent_socket_connect() from invoking our
+	// event callback re-entrantly on an immediate connect failure (which
+	// would free the session while we still use it below), and makes
+	// freeing a bufferevent from within its own callback safe.
+	p->be_client = bufferevent_socket_new(
+		base, fd, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+	p->be_provider = bufferevent_socket_new(
+		base, -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+
+	// Register callbacks before connecting so a deferred error is handled.
+	bufferevent_setcb(p->be_client, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
+	bufferevent_setcb(p->be_provider, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
 
 	struct sockaddr_un sun;
 	memset(&sun, 0, sizeof(sun));
 	sun.sun_family = AF_UNIX;
 	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
 
-	if (bufferevent_socket_connect(session->be_provider,
-				       (struct sockaddr *)&sun,
+	if (bufferevent_socket_connect(p->be_provider, (struct sockaddr *)&sun,
 				       sizeof(sun)) < 0) {
 		fprintf(stderr, "Could not connect to provider socket %s\n",
 			provider_path);
-		bufferevent_free(session->be_client);
-		bufferevent_free(session->be_provider);
-		free(session);
+		pvx_proxy_free(p);
 		return;
 	}
 
-	bufferevent_setcb(session->be_client, rest_read_cb, NULL,
-			  proxy_event_cb, session);
-	bufferevent_setcb(session->be_provider, rest_read_cb, NULL,
-			  proxy_event_cb, session);
-
-	bufferevent_enable(session->be_client, EV_READ | EV_WRITE);
-	bufferevent_enable(session->be_provider, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_provider, EV_READ | EV_WRITE);
 }
 
 static int rest_on_link_added(struct pvx_link *link)
@@ -187,6 +137,9 @@ static int rest_on_link_added(struct pvx_link *link)
 		close(fd);
 		return -1;
 	}
+
+	// Survive fd exhaustion instead of busy-looping on accept().
+	pvx_listener_set_emfile_backoff(link->listener);
 
 	return 0;
 }

--- a/xconnect/plugins/unix.c
+++ b/xconnect/plugins/unix.c
@@ -27,64 +27,9 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include "../include/xconnect.h"
+#include "proxy_common.h"
 
 #define MODULE_NAME "pvx-unix"
-
-struct unix_proxy_session {
-	struct bufferevent *be_client;
-	struct bufferevent *be_provider;
-	int client_eof;
-	int provider_eof;
-};
-
-static void proxy_check_close(struct unix_proxy_session *sess)
-{
-	// Only close when both sides have EOF'd or errored
-	if (sess->client_eof && sess->provider_eof) {
-		if (sess->be_client)
-			bufferevent_free(sess->be_client);
-		if (sess->be_provider)
-			bufferevent_free(sess->be_provider);
-		free(sess);
-	}
-}
-
-static void proxy_event_cb(struct bufferevent *bev, short events, void *arg)
-{
-	struct unix_proxy_session *sess = arg;
-
-	if (events & BEV_EVENT_ERROR) {
-		// On error, mark both as done and close
-		sess->client_eof = 1;
-		sess->provider_eof = 1;
-		proxy_check_close(sess);
-		return;
-	}
-
-	if (events & BEV_EVENT_EOF) {
-		// Half-close: one side sent EOF
-		if (bev == sess->be_client) {
-			sess->client_eof = 1;
-			// Client done sending, but keep reading from provider
-			bufferevent_disable(bev, EV_READ);
-		} else {
-			sess->provider_eof = 1;
-			// Provider done sending, but keep reading from client
-			bufferevent_disable(bev, EV_READ);
-		}
-		proxy_check_close(sess);
-	}
-}
-
-static void proxy_read_cb(struct bufferevent *bev, void *arg)
-{
-	struct unix_proxy_session *sess = arg;
-	struct bufferevent *other =
-		(bev == sess->be_client) ? sess->be_provider : sess->be_client;
-	struct evbuffer *src = bufferevent_get_input(bev);
-	struct evbuffer *dst = bufferevent_get_output(other);
-	evbuffer_add_buffer(dst, src);
-}
 
 static void unix_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 			   struct sockaddr *address, int socklen, void *arg)
@@ -92,6 +37,9 @@ static void unix_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 	struct pvx_link *link = arg;
 	struct event_base *base = pvx_get_base();
 	char provider_path[256];
+	(void)listener;
+	(void)address;
+	(void)socklen;
 
 	if (!link->name || !link->provider_socket) {
 		close(fd);
@@ -111,41 +59,44 @@ static void unix_on_accept(struct evconnlistener *listener, evutil_socket_t fd,
 			sizeof(provider_path) - 1);
 		provider_path[sizeof(provider_path) - 1] = '\0';
 	}
-	struct unix_proxy_session *sess = calloc(1, sizeof(*sess));
-	if (!sess) {
+
+	struct pvx_proxy *p = calloc(1, sizeof(*p));
+	if (!p) {
 		fprintf(stderr, "Could not allocate proxy session\n");
 		close(fd);
 		return;
 	}
 
-	sess->be_client =
-		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
-	sess->be_provider =
-		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+	// DEFER_CALLBACKS keeps bufferevent_socket_connect() from invoking our
+	// event callback re-entrantly on an immediate connect failure (which
+	// would free the session while we still use it below), and makes
+	// freeing a bufferevent from within its own callback safe.
+	p->be_client = bufferevent_socket_new(
+		base, fd, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+	p->be_provider = bufferevent_socket_new(
+		base, -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+
+	// Register callbacks before connecting so a deferred error is handled.
+	bufferevent_setcb(p->be_client, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
+	bufferevent_setcb(p->be_provider, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
 
 	struct sockaddr_un sun;
 	memset(&sun, 0, sizeof(sun));
 	sun.sun_family = AF_UNIX;
 	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
 
-	if (bufferevent_socket_connect(sess->be_provider,
-				       (struct sockaddr *)&sun,
+	if (bufferevent_socket_connect(p->be_provider, (struct sockaddr *)&sun,
 				       sizeof(sun)) < 0) {
 		fprintf(stderr, "Could not connect to provider socket %s\n",
 			provider_path);
-		bufferevent_free(sess->be_client);
-		bufferevent_free(sess->be_provider);
-		free(sess);
+		pvx_proxy_free(p);
 		return;
 	}
 
-	bufferevent_setcb(sess->be_client, proxy_read_cb, NULL, proxy_event_cb,
-			  sess);
-	bufferevent_setcb(sess->be_provider, proxy_read_cb, NULL,
-			  proxy_event_cb, sess);
-
-	bufferevent_enable(sess->be_client, EV_READ | EV_WRITE);
-	bufferevent_enable(sess->be_provider, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_provider, EV_READ | EV_WRITE);
 }
 
 static int unix_on_link_added(struct pvx_link *link)
@@ -186,6 +137,9 @@ static int unix_on_link_added(struct pvx_link *link)
 		close(fd);
 		return -1;
 	}
+
+	// Survive fd exhaustion instead of busy-looping on accept().
+	pvx_listener_set_emfile_backoff(link->listener);
 
 	return 0;
 }

--- a/xconnect/plugins/wayland.c
+++ b/xconnect/plugins/wayland.c
@@ -27,63 +27,9 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include "../include/xconnect.h"
+#include "proxy_common.h"
 
 #define MODULE_NAME "pvx-wayland"
-
-struct wayland_proxy_session {
-	struct bufferevent *be_client;
-	struct bufferevent *be_provider;
-	int client_eof;
-	int provider_eof;
-};
-
-static void wayland_proxy_check_close(struct wayland_proxy_session *sess)
-{
-	// Only close when both sides have EOF'd or errored
-	if (sess->client_eof && sess->provider_eof) {
-		if (sess->be_client)
-			bufferevent_free(sess->be_client);
-		if (sess->be_provider)
-			bufferevent_free(sess->be_provider);
-		free(sess);
-	}
-}
-
-static void wayland_proxy_event_cb(struct bufferevent *bev, short events,
-				   void *arg)
-{
-	struct wayland_proxy_session *sess = arg;
-
-	if (events & BEV_EVENT_ERROR) {
-		// On error, mark both as done and close
-		sess->client_eof = 1;
-		sess->provider_eof = 1;
-		wayland_proxy_check_close(sess);
-		return;
-	}
-
-	if (events & BEV_EVENT_EOF) {
-		// Half-close: one side sent EOF
-		if (bev == sess->be_client) {
-			sess->client_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		} else {
-			sess->provider_eof = 1;
-			bufferevent_disable(bev, EV_READ);
-		}
-		wayland_proxy_check_close(sess);
-	}
-}
-
-static void wayland_proxy_read_cb(struct bufferevent *bev, void *arg)
-{
-	struct wayland_proxy_session *sess = arg;
-	struct bufferevent *other =
-		(bev == sess->be_client) ? sess->be_provider : sess->be_client;
-	struct evbuffer *src = bufferevent_get_input(bev);
-	struct evbuffer *dst = bufferevent_get_output(other);
-	evbuffer_add_buffer(dst, src);
-}
 
 static void wayland_on_accept(struct evconnlistener *listener,
 			      evutil_socket_t fd, struct sockaddr *address,
@@ -92,6 +38,9 @@ static void wayland_on_accept(struct evconnlistener *listener,
 	struct pvx_link *link = arg;
 	struct event_base *base = pvx_get_base();
 	char provider_path[256];
+	(void)listener;
+	(void)address;
+	(void)socklen;
 
 	if (!link->name || !link->provider_socket) {
 		close(fd);
@@ -111,43 +60,46 @@ static void wayland_on_accept(struct evconnlistener *listener,
 			sizeof(provider_path) - 1);
 		provider_path[sizeof(provider_path) - 1] = '\0';
 	}
-	struct wayland_proxy_session *sess = calloc(1, sizeof(*sess));
-	if (!sess) {
+
+	struct pvx_proxy *p = calloc(1, sizeof(*p));
+	if (!p) {
 		fprintf(stderr, "%s: Could not allocate proxy session\n",
 			MODULE_NAME);
 		close(fd);
 		return;
 	}
 
-	sess->be_client =
-		bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
-	sess->be_provider =
-		bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
+	// DEFER_CALLBACKS keeps bufferevent_socket_connect() from invoking our
+	// event callback re-entrantly on an immediate connect failure (which
+	// would free the session while we still use it below), and makes
+	// freeing a bufferevent from within its own callback safe.
+	p->be_client = bufferevent_socket_new(
+		base, fd, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+	p->be_provider = bufferevent_socket_new(
+		base, -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS);
+
+	// Register callbacks before connecting so a deferred error is handled.
+	bufferevent_setcb(p->be_client, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
+	bufferevent_setcb(p->be_provider, pvx_proxy_read_cb, NULL,
+			  pvx_proxy_event_cb, p);
 
 	struct sockaddr_un sun;
 	memset(&sun, 0, sizeof(sun));
 	sun.sun_family = AF_UNIX;
 	strncpy(sun.sun_path, provider_path, sizeof(sun.sun_path) - 1);
 
-	if (bufferevent_socket_connect(sess->be_provider,
-				       (struct sockaddr *)&sun,
+	if (bufferevent_socket_connect(p->be_provider, (struct sockaddr *)&sun,
 				       sizeof(sun)) < 0) {
 		fprintf(stderr,
 			"%s: Could not connect to compositor socket %s\n",
 			MODULE_NAME, provider_path);
-		bufferevent_free(sess->be_client);
-		bufferevent_free(sess->be_provider);
-		free(sess);
+		pvx_proxy_free(p);
 		return;
 	}
 
-	bufferevent_setcb(sess->be_client, wayland_proxy_read_cb, NULL,
-			  wayland_proxy_event_cb, sess);
-	bufferevent_setcb(sess->be_provider, wayland_proxy_read_cb, NULL,
-			  wayland_proxy_event_cb, sess);
-
-	bufferevent_enable(sess->be_client, EV_READ | EV_WRITE);
-	bufferevent_enable(sess->be_provider, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_client, EV_READ | EV_WRITE);
+	bufferevent_enable(p->be_provider, EV_READ | EV_WRITE);
 }
 
 static int wayland_on_link_added(struct pvx_link *link)
@@ -193,6 +145,9 @@ static int wayland_on_link_added(struct pvx_link *link)
 		close(fd);
 		return -1;
 	}
+
+	// Survive fd exhaustion instead of busy-looping on accept().
+	pvx_listener_set_emfile_backoff(link->listener);
 
 	return 0;
 }


### PR DESCRIPTION
## Problem
A proxy session is torn down only when **both** ends EOF. A provider that keeps its connection open after the consumer leaves (e.g. an idle stream) never EOFs, so the pair leaks 2 fds. Over time this exhausts the fd table; `accept()` then returns EMFILE and libevent's listener busy-loops, wedging `pv-xconnect` (observed in the field: device hung with the log spammed by xconnect while the main loop stalled).

## Fix (commit 1 — fd leak)
- Factor the proxy session lifecycle into a shared `proxy_common` core (was duplicated across the 4 stream plugins).
- Free on **both-EOF** (unchanged — preserves the in-flight response, no truncation), on **error**, or once a **half-open** session has been **idle** past a linger window. The linger timer resets on every byte spliced, so active/streaming transfers are never cut short. This bounds the never-EOF case **without** breaking half-close request/response.
- `BEV_OPT_DEFER_CALLBACKS` + register callbacks before `connect()` → fixes a use-after-free when connect fails synchronously.
- Listener backs off on EMFILE/ENFILE instead of retrying immediately.

## Fix (commit 2 — link re-establishment on restart)
`reconcile_link` returned early on any `established` link, but links are keyed on consumer+name (stable across a container restart). A restarted peer gets a **new pid**, so the proxy kept connecting to the dead provider pid ("Connection reset"), and the consumer socket was never re-injected into the new namespace ("Socket not found").
- Detect a changed consumer/provider pid and re-establish the link.
- `pvx_link_free` now frees `link->listener` (and calls `on_link_removed`), fixing a listener leak on the replace/retry path.

## Test
Validated in the x86_64 appengine **and on a live armhf Raspberry Pi 5** with the `pv-example-{unix,rest,dbus}` pairs in the app group:
- half-close (`nc -N`) request/response returns the full body; normal request/response works; dbus auth masquerade + unix + rest all functional.
- fd-leak: fds stay bounded (e.g. 62↔64 over 200 mixed requests; held flat under a consumer hammering a dead provider) where the old code leaked +2 each.
- restart: stop/start of either peer (incl. 18 rapid restarts across 6 containers) now **recovers automatically** — socket re-injected on consumer restart, proxy reconnects on provider restart — with fd bounded throughout.
