### PR TITLE
feat(disk): volume-disk bind-mount backend + appengine and pvtest fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ add_executable(pantavisor
 			disk/disk.c
 			disk/disk.h
 			disk/disk_crypt.c
-			disk/disk_dir.c
+			disk/disk_volume_bind.c
 			disk/disk_dual.c
 			disk/disk_impl.h
 			disk/disk_swap.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ add_executable(pantavisor
 			disk/disk.c
 			disk/disk.h
 			disk/disk_crypt.c
+			disk/disk_dir.c
 			disk/disk_dual.c
 			disk/disk_impl.h
 			disk/disk_swap.c

--- a/appengine/pv-appengine.in
+++ b/appengine/pv-appengine.in
@@ -16,41 +16,11 @@ usage() {
 	echo "       -d SECS    restart delay in seconds (default: 5)"
 }
 
-cleanup_cryptdisk() {
-	for dev in $(ls /dev/mapper/ 2>/dev/null); do
-		[ "$dev" = "control" ] && continue
-		umount -l "/dev/mapper/$dev" > /dev/null 2>&1 || true
-		cryptsetup close "$dev" > /dev/null 2>&1 || \
-			dmsetup remove --force "$dev" > /dev/null 2>&1 || true
-	done
-}
-
 cleanup_cgroup() {
 	if [ -d /sys/fs/cgroup/lxc ]; then
 		find /sys/fs/cgroup/lxc/ -mindepth 1 -maxdepth 1 -type d -exec rmdir {} \; > /dev/null 2>&1
 		rmdir /sys/fs/cgroup/lxc* > /dev/null 2>&1
 	fi
-}
-
-setup_loop() {
-	local count="$1"
-	local first="$(losetup -f | grep -oE '[0-9]+$' )"
-	first=$((first + 1))
-
-	for i in $(seq "$first" "$((first + count))"); do
-		mknod -m660 "/dev/loop$i" b 7 "$i" > /dev/null 2>&1 || true
-	done
-
-	echo "$first"
-}
-
-teardown_loop() {
-	local first="$1"
-	local count="$2"
-
-	for i in $(seq "$first" "$((first + count))"); do
-		rm -f "/dev/loop$i"
-	done
 }
 
 exec_run() {
@@ -87,10 +57,7 @@ exec_run() {
 		echo -e -n 'pv_rev=0\0\0' > @PV_INSTALL_FULL_STORAGEDIR@/boot/uboot.txt
 	fi
 
-	cleanup_cryptdisk
 	cleanup_cgroup
-	loop_n=100
-	first_loop=$(setup_loop "$loop_n")
 
 	pv_trying=""
 	shutdown=0
@@ -137,7 +104,6 @@ exec_run() {
 		fi
 		umount -l /volumes || true
 		umount -l /storage || true
-		cleanup_cryptdisk
 		cleanup_cgroup
 
 		set -e
@@ -165,7 +131,6 @@ exec_run() {
 		umount /var/pantavisor/storage
 	fi
 
-	teardown_loop "$first_loop" "$loop_n"
 	cleanup_cgroup
 }
 # parse options

--- a/appengine/pv-appengine.in
+++ b/appengine/pv-appengine.in
@@ -4,6 +4,8 @@ set -e
 
 interrupt='false'
 
+pvtest_log() { local level=$1; shift; printf '[pvtest] %s %s -- [pv-appengine]: %s\n' "$(date +%s)" "$level" "$*"; }
+
 usage() {
 	echo "Usage: $0 [options]"
 	echo "Run Pantavisor in an existing OS"
@@ -29,20 +31,22 @@ exec_run() {
 
 	# check installed
 	if [ ! -f "@CMAKE_INSTALL_FULL_SYSCONFDIR@/pantavisor-appengine.config" ]; then
-		echo "ERROR: installation path '@CMAKE_INSTALL_FULL_SYSCONFDIR@/pantavisor-appengine.config' not found"
+		pvtest_log ERROR "installation path '@CMAKE_INSTALL_FULL_SYSCONFDIR@/pantavisor-appengine.config' not found"
 		exit 1
 	fi
 
 	if ! cat /proc/mounts | awk '{ print $2}' | grep -q '^@PV_INSTALL_FULL_STORAGEDIR@$' ; then
-		echo "WARN: @PV_INSTALL_FULL_STORAGEDIR@ is not a mountpoint. Automatic installation might fail."
+		pvtest_log WARN "@PV_INSTALL_FULL_STORAGEDIR@ is not a mountpoint. Automatic installation might fail."
 	fi
 
 	if ! [ -f @PV_INSTALL_FULL_STORAGEDIR@/.created ]; then
+		pvtest_log DEBUG "first boot: initialising storage skeleton"
 		cp -a @PV_INSTALL_FULL_SKELDIR@/* @PV_INSTALL_FULL_STORAGEDIR@/ || true
 		touch @PV_INSTALL_FULL_STORAGEDIR@/.created || true
 	fi
 
 	if ! [ -f @PV_INSTALL_FULL_STORAGEDIR@/.pvtx-done ]; then
+		pvtest_log DEBUG "first boot: running pvtx deploy"
 		pvtx abort
 		pvtx begin @PV_INSTALL_FULL_STORAGEDIR@/trails/0 @PV_INSTALL_FULL_STORAGEDIR@/objects
 		for a in `ls @PV_INSTALL_FULL_PVTXDIR@/* 2>/dev/null`; do
@@ -53,6 +57,7 @@ exec_run() {
 	fi
 
 	if ! [ -f @PV_INSTALL_FULL_STORAGEDIR@/boot/uboot.txt ]; then
+		pvtest_log DEBUG "first boot: initialising boot state"
 		mkdir -p @PV_INSTALL_FULL_STORAGEDIR@/boot
 		echo -e -n 'pv_rev=0\0\0' > @PV_INSTALL_FULL_STORAGEDIR@/boot/uboot.txt
 	fi
@@ -62,7 +67,7 @@ exec_run() {
 	pv_trying=""
 	shutdown=0
 	restart_delay="${restart_delay:-5}"
-	trap 'shutdown=1; echo "Recevied SIGINT, shutting down pantavisor ..."' SIGINT
+	trap 'shutdown=1; pvtest_log INFO "received SIGINT, shutting down Pantavisor..."' SIGINT
 
 	while [ "$shutdown" -eq 0 ]; do
 		# load boot info
@@ -81,6 +86,7 @@ exec_run() {
 		fi
 
 		# exec Pantavisor
+		pvtest_log INFO "launching pantavisor rev=$pv_rev${pv_try:+ (try=$pv_try)}"
 		set +e
 		if ! grep -q "cgroup2" /proc/mounts | grep -q "/sys/fs/cgroup"; then
 			if [ -z "$(ls -A /sys/fs/cgroup 2>/dev/null)" ]; then
@@ -105,6 +111,7 @@ exec_run() {
 		umount -l /volumes || true
 		umount -l /storage || true
 		cleanup_cgroup
+		pvtest_log DEBUG "pantavisor exited"
 
 		set -e
 		if [ "$shutdown" -eq 1 ]; then
@@ -116,16 +123,18 @@ exec_run() {
 				:
 			done
 			# wait for user input or continue
-			if read -t 5 -p "INFO: Will restart Pantavisor in 5 sec. Press ENTER to abort"; then
-				echo "INFO: Exiting..."
+			if read -t 5 -p "$(pvtest_log INFO "Will restart Pantavisor in 5 sec. Press ENTER to abort")"; then
+				pvtest_log INFO "Exiting..."
 				break
 			fi
 		fi
 		if [ "$restart_delay" -gt 0 ] 2>/dev/null; then
-			echo "restarting in $restart_delay seconds..."
+			pvtest_log DEBUG "restarting in $restart_delay seconds..."
 			sleep "$restart_delay" || true
 		fi
 	done
+
+	pvtest_log INFO "Pantavisor stopped"
 
 	if [ -d @PV_INSTALL_FULL_STORAGEDIR@-ovl ]; then
 		umount /var/pantavisor/storage
@@ -139,10 +148,10 @@ while [ $# -gt 0 ]; do
 	-h)
 		usage
 		exit 0
-		;; 
+		;;
 	-i)
 		interrupt='true'
-		;; 
+		;;
 	-c)
 		shift
 		cmdline="$1"
@@ -150,7 +159,7 @@ while [ $# -gt 0 ]; do
 	-e)
 		shift
 		envs="$1"
-		;; 
+		;;
 	-V)
 		valgrind='true'
 		;;
@@ -164,6 +173,8 @@ while [ $# -gt 0 ]; do
 	esac
 	shift
 done
+
+if [ "${VERBOSE:-false}" = "true" ]; then set -x; fi
 
 # uninstall Pantavisor
 exec_run

--- a/appengine/pv-appengine.in
+++ b/appengine/pv-appengine.in
@@ -18,8 +18,8 @@ usage() {
 
 cleanup_cgroup() {
 	if [ -d /sys/fs/cgroup/lxc ]; then
-		find /sys/fs/cgroup/lxc/ -mindepth 1 -maxdepth 1 -type d -exec rmdir {} \; > /dev/null 2>&1
-		rmdir /sys/fs/cgroup/lxc* > /dev/null 2>&1
+		find /sys/fs/cgroup/lxc/ -mindepth 1 -maxdepth 1 -type d -exec rmdir {} \; > /dev/null 2>&1 || true
+		rmdir /sys/fs/cgroup/lxc* > /dev/null 2>&1 || true
 	fi
 }
 

--- a/ctrl/ctrl_caller.c
+++ b/ctrl/ctrl_caller.c
@@ -21,6 +21,7 @@
  */
 
 #include "ctrl_caller.h"
+#include "config.h"
 #include "pantavisor.h"
 #include "platforms.h"
 #include "socket.h"
@@ -29,6 +30,7 @@
 #include <event2/http.h>
 #include <event2/bufferevent.h>
 
+#include <ctype.h>
 #include <string.h>
 
 #define MODULE_NAME "ctrl-caller"
@@ -61,6 +63,26 @@ int pv_ctrl_caller_init(struct pv_ctrl_caller *caller,
 
 	struct pantavisor *pv = pv_get_instance();
 	caller->plat = pv_state_fetch_platform(pv->state, name);
+	if (!caller->plat && pv_config_get_system_init_mode() == IM_APPENGINE) {
+		/* In appengine mode LXC may append -N to a container name when
+		 * the cgroup slot is already taken by a parallel test run.
+		 * Strip the suffix and retry so pvr-sdk-1 resolves to pvr-sdk. */
+		char *base = strdup(name);
+		if (base) {
+			char *dash = strrchr(base, '-');
+			if (dash) {
+				const char *p = dash + 1;
+				while (*p && isdigit((unsigned char)*p))
+					p++;
+				if (*p == '\0') {
+					*dash = '\0';
+					caller->plat = pv_state_fetch_platform(
+						pv->state, base);
+				}
+			}
+			free(base);
+		}
+	}
 	if (!caller->plat && strncmp(name, "_pv_", strlen(name))) {
 		pv_log(WARN, "platform %s not found in current state", name);
 		goto out;

--- a/disk/disk.c
+++ b/disk/disk.c
@@ -221,6 +221,8 @@ static struct pv_disk_impl *get_disk_implementation(struct pv_disk *disk)
 			impl = &volume_impl;
 		break;
 	case DISK_DIR:
+		impl = &dir_impl;
+		break;
 	case DISK_UNKNOWN:
 	default:
 		pv_log(ERROR, "unknown disk type %d", disk->type);

--- a/disk/disk.c
+++ b/disk/disk.c
@@ -210,18 +210,12 @@ static struct pv_disk_impl *get_disk_implementation(struct pv_disk *disk)
 		break;
 	case DISK_VOLUME:
 		if (!disk->provision) {
-			pv_log(ERROR,
-			       "cannot use disk, must define a provision");
-			break;
-		}
-
-		if (!strcmp(disk->provision, "zram"))
+			impl = &volume_bind_impl;
+		} else if (!strcmp(disk->provision, "zram")) {
 			impl = &zram_impl;
-		else
+		} else {
 			impl = &volume_impl;
-		break;
-	case DISK_DIR:
-		impl = &dir_impl;
+		}
 		break;
 	case DISK_UNKNOWN:
 	default:

--- a/disk/disk.h
+++ b/disk/disk.h
@@ -222,6 +222,7 @@ static inline bool pv_disk_is_internal(struct pv_disk *d)
 	return d->name && d->name[0] == '_';
 }
 
+extern struct pv_disk_impl dir_impl;
 extern struct pv_disk_impl zram_impl;
 extern struct pv_disk_impl crypt_impl;
 extern struct pv_disk_impl volume_impl;

--- a/disk/disk.h
+++ b/disk/disk.h
@@ -31,7 +31,6 @@
 
 typedef enum {
 	DISK_UNKNOWN,
-	DISK_DIR,
 	DISK_DM_CRYPT_VERSATILE,
 	DISK_DM_CRYPT_CAAM,
 	DISK_DM_CRYPT_DCP,
@@ -148,8 +147,6 @@ static inline const char *pv_disk_type_to_str(pv_disk_t type)
 	switch (type) {
 	case DISK_UNKNOWN:
 		return "unknown";
-	case DISK_DIR:
-		return "dir";
 	case DISK_DM_CRYPT_VERSATILE:
 		return "versatile";
 	case DISK_DM_CRYPT_CAAM:
@@ -181,9 +178,7 @@ pv_disk_dm_crypt_str_to_mode(const char *mode_str)
 static inline pv_disk_t pv_disk_str_to_type(const char *type_str)
 {
 	if (type_str) {
-		if (!strcmp(type_str, "directory"))
-			return DISK_DIR;
-		else if (!strcmp(type_str, "dm-crypt-versatile"))
+		if (!strcmp(type_str, "dm-crypt-versatile"))
 			return DISK_DM_CRYPT_VERSATILE;
 		else if (!strcmp(type_str, "dm-crypt-caam"))
 			return DISK_DM_CRYPT_CAAM;
@@ -222,7 +217,7 @@ static inline bool pv_disk_is_internal(struct pv_disk *d)
 	return d->name && d->name[0] == '_';
 }
 
-extern struct pv_disk_impl dir_impl;
+extern struct pv_disk_impl volume_bind_impl;
 extern struct pv_disk_impl zram_impl;
 extern struct pv_disk_impl crypt_impl;
 extern struct pv_disk_impl volume_impl;

--- a/disk/disk_dir.c
+++ b/disk/disk_dir.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "disk.h"
+#include "disk_impl.h"
+#include "config.h"
+#include "utils/fs.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <linux/limits.h>
+
+#define MODULE_NAME "disk-dir"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#include "log.h"
+
+static int pv_disk_dir_init(struct pv_disk *disk)
+{
+	if (!disk->name) {
+		pv_log(ERROR, "disk definition error, name not defined");
+		return -1;
+	}
+
+	if (!disk->mount_target) {
+		char buf[PATH_MAX];
+		snprintf(buf, sizeof(buf), "%s/%s",
+			 pv_config_get_str(PV_DISK_VOLDIR), disk->name);
+		disk->mount_target = strdup(buf);
+		if (!disk->mount_target) {
+			pv_log(ERROR, "OOM allocating mount_target for %s",
+			       disk->name);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static pv_disk_status_t pv_disk_dir_status(struct pv_disk *disk)
+{
+	struct stat st;
+
+	if (!disk->mount_target)
+		return DISK_STATUS_ERROR;
+
+	if (stat(disk->mount_target, &st) == 0 && S_ISDIR(st.st_mode))
+		return DISK_STATUS_MOUNTED;
+
+	return DISK_STATUS_NOT_MOUNTED;
+}
+
+static int pv_disk_dir_format(struct pv_disk *disk)
+{
+	return 0;
+}
+
+static int pv_disk_dir_mount(struct pv_disk *disk)
+{
+	if (pv_fs_mkdir_p(disk->mount_target, 0755) != 0) {
+		pv_log(WARN, "cannot create directory %s: %s",
+		       disk->mount_target, strerror(errno));
+		return -1;
+	}
+
+	pv_log(DEBUG, "directory disk %s ready at %s", disk->name,
+	       disk->mount_target);
+	return 0;
+}
+
+static int pv_disk_dir_umount(struct pv_disk *disk)
+{
+	return 0;
+}
+
+struct pv_disk_impl dir_impl = {
+	.init = pv_disk_dir_init,
+	.status = pv_disk_dir_status,
+	.format = pv_disk_dir_format,
+	.mount = pv_disk_dir_mount,
+	.umount = pv_disk_dir_umount,
+};

--- a/disk/disk_volume_bind.c
+++ b/disk/disk_volume_bind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Pantacor Ltd.
+ * Copyright (c) 2026 Pantacor Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/disk/disk_volume_bind.c
+++ b/disk/disk_volume_bind.c
@@ -20,6 +20,16 @@
  * SOFTWARE.
  */
 
+/*
+ * volume-disk without a provision field: bind-mounts a persistent directory
+ * from /storage into the ephemeral tmpfs at /run/pantavisor/media/pv/dmcrypt/<name>.
+ *
+ * The mount target path uses the "dmcrypt" namespace because volumes.c hardcodes
+ * that namespace when building paths for disk-backed volumes.  The backing store
+ * lives under /storage (Docker bind-mount from the workspace) so it survives
+ * repeated pantavisor restarts within the same appengine container.
+ */
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
@@ -27,19 +37,21 @@
 #include "disk.h"
 #include "disk_impl.h"
 #include "config.h"
+#include "paths.h"
 #include "utils/fs.h"
 
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <linux/limits.h>
 
-#define MODULE_NAME "disk-dir"
+#define MODULE_NAME "disk-volume-bind"
 #define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
 #include "log.h"
 
-static int pv_disk_dir_init(struct pv_disk *disk)
+static int pv_disk_volume_bind_init(struct pv_disk *disk)
 {
 	if (!disk->name) {
 		pv_log(ERROR, "disk definition error, name not defined");
@@ -48,8 +60,8 @@ static int pv_disk_dir_init(struct pv_disk *disk)
 
 	if (!disk->mount_target) {
 		char buf[PATH_MAX];
-		snprintf(buf, sizeof(buf), "%s/%s",
-			 pv_config_get_str(PV_DISK_VOLDIR), disk->name);
+		pv_paths_storage_mounted_disk_path(buf, sizeof(buf), "dmcrypt",
+						   disk->name);
 		disk->mount_target = strdup(buf);
 		if (!disk->mount_target) {
 			pv_log(ERROR, "OOM allocating mount_target for %s",
@@ -61,7 +73,7 @@ static int pv_disk_dir_init(struct pv_disk *disk)
 	return 0;
 }
 
-static pv_disk_status_t pv_disk_dir_status(struct pv_disk *disk)
+static pv_disk_status_t pv_disk_volume_bind_status(struct pv_disk *disk)
 {
 	struct stat st;
 
@@ -74,33 +86,58 @@ static pv_disk_status_t pv_disk_dir_status(struct pv_disk *disk)
 	return DISK_STATUS_NOT_MOUNTED;
 }
 
-static int pv_disk_dir_format(struct pv_disk *disk)
+static int pv_disk_volume_bind_format(struct pv_disk *disk)
 {
 	return 0;
 }
 
-static int pv_disk_dir_mount(struct pv_disk *disk)
+static int pv_disk_volume_bind_mount(struct pv_disk *disk)
 {
+	char backing[PATH_MAX];
+	snprintf(backing, sizeof(backing), "%s/pv/volume-disk/%s",
+		 pv_config_get_str(PV_STORAGE_MNTPOINT), disk->name);
+
+	if (pv_fs_mkdir_p(backing, 0755) != 0) {
+		pv_log(WARN, "cannot create backing dir %s: %s", backing,
+		       strerror(errno));
+		return -1;
+	}
+
 	if (pv_fs_mkdir_p(disk->mount_target, 0755) != 0) {
-		pv_log(WARN, "cannot create directory %s: %s",
+		pv_log(WARN, "cannot create mount target %s: %s",
 		       disk->mount_target, strerror(errno));
 		return -1;
 	}
 
-	pv_log(DEBUG, "directory disk %s ready at %s", disk->name,
-	       disk->mount_target);
+	if (mount(backing, disk->mount_target, "none", MS_BIND, NULL) != 0) {
+		pv_log(WARN, "cannot bind-mount %s -> %s: %s", backing,
+		       disk->mount_target, strerror(errno));
+		return -1;
+	}
+
+	pv_log(DEBUG, "volume-disk %s bind-mounted %s -> %s", disk->name,
+	       backing, disk->mount_target);
 	return 0;
 }
 
-static int pv_disk_dir_umount(struct pv_disk *disk)
+static int pv_disk_volume_bind_umount(struct pv_disk *disk)
 {
+	if (!disk->mount_target)
+		return 0;
+
+	if (umount(disk->mount_target) != 0) {
+		pv_log(WARN, "cannot umount %s: %s", disk->mount_target,
+		       strerror(errno));
+		return -1;
+	}
+
 	return 0;
 }
 
-struct pv_disk_impl dir_impl = {
-	.init = pv_disk_dir_init,
-	.status = pv_disk_dir_status,
-	.format = pv_disk_dir_format,
-	.mount = pv_disk_dir_mount,
-	.umount = pv_disk_dir_umount,
+struct pv_disk_impl volume_bind_impl = {
+	.init = pv_disk_volume_bind_init,
+	.status = pv_disk_volume_bind_status,
+	.format = pv_disk_volume_bind_format,
+	.mount = pv_disk_volume_bind_mount,
+	.umount = pv_disk_volume_bind_umount,
 };

--- a/docs/overview/disks.md
+++ b/docs/overview/disks.md
@@ -70,22 +70,53 @@ Swap disks are mounted first during boot, before all other disk types.
 }
 ```
 
-### volume-disk (EXPERIMENTAL)
+### volume-disk
 
-> **WARNING**: volume-disk runs `mkfs` on every mount cycle —
-> **it reformats the block device every boot**. This is safe for zram
-> backends (ephemeral RAM) but **will destroy data on real block
-> devices**. Do not use with persistent block devices until a
-> `format` policy (`auto`/`no`) is implemented. See TODO section.
+A `volume-disk` entry has two distinct behaviours depending on whether a
+`provision` field is present.
+
+#### Without `provision` — bind-mount backend
+
+No block device, no loop device, no dm-crypt. Pantavisor bind-mounts a
+persistent directory from `/storage/pv/volume-disk/<name>` (the Docker
+workspace bind-mount, or the real storage partition on hardware) into the
+ephemeral tmpfs at `/run/pantavisor/media/pv/dmcrypt/<name>`. Because the
+backing store lives under `/storage`, data survives repeated pantavisor
+restarts within the same appengine container.
+
+The bind mount target uses the `dmcrypt` namespace because `volumes.c`
+resolves disk-backed volume paths under that namespace regardless of the
+actual disk type.
+
+- `provision`: absent
+- `path`, `format`, `mount_target`: not required
+
+This is the recommended mode for appengine and CI test environments where
+dm-crypt hardware (CAAM, DCP) is unavailable.
+
+```json
+{
+    "name": "dm-internal-secrets",
+    "type": "volume-disk",
+    "aliases": ["dm-versatile"]
+}
+```
+
+#### With `provision` — block device / zram backend (EXPERIMENTAL)
+
+> **WARNING**: volume-disk with a provision runs `mkfs` on every mount
+> cycle — **it reformats the block device every boot**. This is safe for
+> zram backends (ephemeral RAM) but **will destroy data on real block
+> devices**. Do not use with persistent block devices until a `format`
+> policy (`auto`/`no`) is implemented.
 
 Plain (unencrypted) ext4/ext3 volume mounted at a specified target.
 
 - `format`: required — `"ext4"` or `"ext3"`
 - `mount_target`: required — where to mount the filesystem
 - `path`: required — block device path (ignored when `provision` is `"zram"`)
-- `provision`: required by the dispatcher — set to `"zram"` for
-  compressed RAM backend (see Zram section). For block device backed
-  disks, set to any non-zram value (e.g. `"block"`).
+- `provision`: set to `"zram"` for compressed RAM backend (see Zram section);
+  any other non-empty value selects block device mode.
 - `format_ops`: optional — passed to `mkfs.<format>`
 - `mount_ops`: optional — comma-separated mount flags:
   `MS_NOATIME`, `MS_NODEV`, `MS_NOEXEC`, `MS_NOSUID`, `MS_RDONLY`,
@@ -100,6 +131,7 @@ Plain (unencrypted) ext4/ext3 volume mounted at a specified target.
     "format": "ext4",
     "path": "/dev/mmcblk0p5",
     "mount_target": "/data",
+    "provision": "block",
     "mount_options": "MS_NOATIME,MS_NOSUID"
 }
 ```
@@ -321,41 +353,6 @@ If power is lost during `copy-once-to-primary`:
 3. Next boot: `copy-once-to-primary` sees no dual marker → re-runs copy
 4. Primary image exists → idempotent init (no recreation) → mounts →
    copy → verify → touches dual marker
-
-### directory
-
-A plain host directory. No loop device, no dm-crypt, no block device — just
-`mkdir -p` at boot time. Intended for workloads that need a persistent, writable
-directory shared between containers or accessible from the host, without the
-overhead or hardware requirements of a block-backed disk.
-
-**How it works:**
-
-- `init`: derives `mount_target` from `PV_DISK_VOLDIR/<name>` when no explicit
-  `mount_target` is set (`PV_DISK_VOLDIR` defaults to `/volumes`).
-- `format`: no-op — no filesystem to create.
-- `mount`: creates the directory with `mkdir -p` and returns. No `mount(2)` call.
-- `umount`: no-op — the directory lives on the host tmpfs or storage volume and
-  is left in place across pantavisor restarts.
-- `status`: `MOUNTED` if `stat(mount_target)` succeeds and returns a directory;
-  `NOT_MOUNTED` otherwise.
-
-**`device.json` example:**
-
-```json
-{
-  "name": "my-secrets",
-  "type": "directory",
-  "aliases": ["dm-versatile"]
-}
-```
-
-No `path` field is needed. The directory is created at `/volumes/my-secrets`
-(or the custom path set via `mount_target`).
-
-**When to use:** appengine and CI test environments where dm-crypt hardware
-(CAAM, DCP) is unavailable. Also suitable for any deployment that needs a
-simple shared directory without encryption.
 
 ## Internal Disks
 

--- a/docs/overview/disks.md
+++ b/docs/overview/disks.md
@@ -322,9 +322,40 @@ If power is lost during `copy-once-to-primary`:
 4. Primary image exists → idempotent init (no recreation) → mounts →
    copy → verify → touches dual marker
 
-### directory (not implemented)
+### directory
 
-Defined in the type enum but has no implementation. Will fail at runtime.
+A plain host directory. No loop device, no dm-crypt, no block device — just
+`mkdir -p` at boot time. Intended for workloads that need a persistent, writable
+directory shared between containers or accessible from the host, without the
+overhead or hardware requirements of a block-backed disk.
+
+**How it works:**
+
+- `init`: derives `mount_target` from `PV_DISK_VOLDIR/<name>` when no explicit
+  `mount_target` is set (`PV_DISK_VOLDIR` defaults to `/volumes`).
+- `format`: no-op — no filesystem to create.
+- `mount`: creates the directory with `mkdir -p` and returns. No `mount(2)` call.
+- `umount`: no-op — the directory lives on the host tmpfs or storage volume and
+  is left in place across pantavisor restarts.
+- `status`: `MOUNTED` if `stat(mount_target)` succeeds and returns a directory;
+  `NOT_MOUNTED` otherwise.
+
+**`device.json` example:**
+
+```json
+{
+  "name": "my-secrets",
+  "type": "directory",
+  "aliases": ["dm-versatile"]
+}
+```
+
+No `path` field is needed. The directory is created at `/volumes/my-secrets`
+(or the custom path set via `mount_target`).
+
+**When to use:** appengine and CI test environments where dm-crypt hardware
+(CAAM, DCP) is unavailable. Also suitable for any deployment that needs a
+simple shared directory without encryption.
 
 ## Internal Disks
 

--- a/docs/reference/pantavisor-state-format-v2.md
+++ b/docs/reference/pantavisor-state-format-v2.md
@@ -100,7 +100,7 @@ examples.
 | `name` | string | **Mandatory** | Unique name used in `run.json` storage keys and mount paths. |
 | `aliases` | string array | empty | Additional names this disk answers to. Volumes referring to any alias resolve to this disk. Aliases must not shadow another disk's `name` or be claimed by more than one disk; conflicts make the state refuse to boot. See [Aliases](../overview/disks.md#aliases) in the overview. |
 | `type` | enum | **Mandatory** | `dm-crypt-caam`, `dm-crypt-dcp`, `dm-crypt-versatile`, `swap-disk`, `volume-disk`, `dual`, `directory`. |
-| `path` | string | **Mandatory** (crypt, swap, vol) | Device/image path. CAAM v2: `-v2 <img>,<size>,<key>`. DCP/versatile: `<img>,<size>,<key>`. |
+| `path` | string | **Mandatory** (crypt, swap, vol) | Device/image path. CAAM v2: `-v2 <img>,<size>,<key>`. DCP/versatile: `<img>,<size>,<key>`. Not used by `directory`. |
 | `mode` | enum | **Mandatory** (crypt) | `mainline` or `nxp`. Selects key subsystem. |
 | `format` | enum | `ext4` | Filesystem format: `ext4`, `ext3`, or `swap`. |
 | `provision` | string | empty | Backend provisioning: `zram`, `file`, or a custom value. Required for swap and volume types. |

--- a/docs/reference/pantavisor-state-format-v2.md
+++ b/docs/reference/pantavisor-state-format-v2.md
@@ -99,11 +99,11 @@ examples.
 |:---|:---|:---:|:---|
 | `name` | string | **Mandatory** | Unique name used in `run.json` storage keys and mount paths. |
 | `aliases` | string array | empty | Additional names this disk answers to. Volumes referring to any alias resolve to this disk. Aliases must not shadow another disk's `name` or be claimed by more than one disk; conflicts make the state refuse to boot. See [Aliases](../overview/disks.md#aliases) in the overview. |
-| `type` | enum | **Mandatory** | `dm-crypt-caam`, `dm-crypt-dcp`, `dm-crypt-versatile`, `swap-disk`, `volume-disk`, `dual`, `directory`. |
-| `path` | string | **Mandatory** (crypt, swap, vol) | Device/image path. CAAM v2: `-v2 <img>,<size>,<key>`. DCP/versatile: `<img>,<size>,<key>`. Not used by `directory`. |
+| `type` | enum | **Mandatory** | `dm-crypt-caam`, `dm-crypt-dcp`, `dm-crypt-versatile`, `swap-disk`, `volume-disk`, `dual`. |
+| `path` | string | **Mandatory** (crypt, swap, vol with provision) | Device/image path. CAAM v2: `-v2 <img>,<size>,<key>`. DCP/versatile: `<img>,<size>,<key>`. Not required for `volume-disk` without `provision`. |
 | `mode` | enum | **Mandatory** (crypt) | `mainline` or `nxp`. Selects key subsystem. |
 | `format` | enum | `ext4` | Filesystem format: `ext4`, `ext3`, or `swap`. |
-| `provision` | string | empty | Backend provisioning: `zram`, `file`, or a custom value. Required for swap and volume types. |
+| `provision` | string | empty | Backend provisioning: `zram`, `file`, or a custom value. Required for swap; optional for `volume-disk` (absent → bind-mount backend). |
 | `provision_ops` | string | empty | Backend-specific options (e.g. `disksize=128M comp_algorithm=lz4`). |
 | `mount_target` | path | empty | Where to mount the disk on the host. Required for `volume-disk`. |
 | `mount_options` | string | empty | Comma-separated mount flags (e.g. `MS_NOATIME,MS_NOSUID`). |

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+PVTEST_LOG_SOURCE=pvtest-run
 source @CMAKE_INSTALL_FULL_DATADIR@/@PROJECT_NAME@/pvtest/utils
 
 usage() {
@@ -11,7 +12,7 @@ usage() {
 parse_test() {
 	json_path="$test_path/test.json"
 	if [ ! -e "$json_path" ]; then
-		echo "Error: '$json_path' not found"
+		pvtest_log ERROR "'$json_path' not found"
 		exit 1
 	fi
 
@@ -33,7 +34,7 @@ trap cleanup EXIT
 
 initial_setup() {
 	if ! cat /proc/mounts | awk '{ print $2}' | grep -q '^@PV_INSTALL_FULL_STORAGEDIR@$'; then
-		echo "ERROR: @PV_INSTALL_FULL_STORAGEDIR@ must be a mountpoint."
+		pvtest_log ERROR "@PV_INSTALL_FULL_STORAGEDIR@ must be a mountpoint."
 		sleep 10
 		exit 1
 	fi
@@ -44,14 +45,14 @@ initial_setup() {
 	fi
 
 	if [ ! -f "$test_path/$test_script" ]; then
-		echo "Error: '$test_path/$test_script' does not exist"
+		pvtest_log ERROR "'$test_path/$test_script' does not exist"
 		exit 1
 	fi
 
 	if [ "$netsim" = "true" ]; then
 		wait_for_status "ip link set wlan1 name wlan0" 0 5 > /dev/null 2>&1
 		if [ $? -ne 0 ]; then
-			echo "Error: could not setup wlan0 interface for tester"
+			pvtest_log ERROR "could not setup wlan0 interface for tester"
 			exit 1
 		fi
 	fi
@@ -71,7 +72,7 @@ initial_setup() {
 	# copy rev to pvtxdir
 	mkdir -p @PV_INSTALL_FULL_PVTXDIR@
 	for tarball in $tarballs; do
-		if [ ! -e "$test_path/$tarball" ]; then echo "Error: '$test_path/$tarball' does not exist"; exit 1; fi
+		if [ ! -e "$test_path/$tarball" ]; then pvtest_log ERROR "'$test_path/$tarball' does not exist"; exit 1; fi
 		cp -f "$test_path/$tarball" @PV_INSTALL_FULL_PVTXDIR@/
 	done
 	rm -f @PV_INSTALL_FULL_STORAGEDIR@/.pvtx-done
@@ -83,12 +84,12 @@ exec_interactive() {
 	echo ""
 
 	if [ "$manual" = "true" ]; then
-		echo "Info: Pantavisor is not running."
+		pvtest_log INFO "Pantavisor is not running."
 		echo "To run Pantavisor with stdout logs:"
 		echo "pv-appengine -e \"PV_LOG_SERVER_OUTPUTS=filetree,stdout\""
 		echo ""
 	else
-		echo "Info: Pantavisor is already running."
+		pvtest_log INFO "Pantavisor is already running."
 		echo "To run your test:"
 		echo "$test_path/$test_script"
 		echo ""
@@ -97,6 +98,7 @@ exec_interactive() {
 	sh -c "bash"
 }
 stop_pv() {
+	pvtest_log DEBUG "stopping Pantavisor"
 	if [ -f "@CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/device-id" ]; then
 		device_id=`cat @CMAKE_INSTALL_FULL_RUNSTATEDIR@/pantavisor/pv/device-id`
 	fi
@@ -115,11 +117,11 @@ stop_pv() {
 		eval "pvcontrol commands poweroff" > /dev/null 2>&1
 		wait_for_process " pantavisor$" "120" "-d"
 		if [ $? -ne 0 ]; then
-			echo "Warn: Pantavisor still running. Shutting it down..."
+			pvtest_log WARN "Pantavisor still running. Shutting it down..."
 			kill "$pv_pid"
 			wait_for_process " pantavisor$" "30" "-d"
 			if [ $? -ne 0 ]; then
-				echo "Error: Pantavisor still running. Exiting..."
+				pvtest_log ERROR "Pantavisor still running. Exiting..."
 				kill -SIGKILL "$pv_pid"
 			fi
 		fi
@@ -127,7 +129,7 @@ stop_pv() {
 }
 
 int_handler() {
-	echo "Debug: Stopping Pantavisor...."
+	pvtest_log DEBUG "Stopping Pantavisor..."
 	stop_pv
 	exit 2
 }
@@ -136,19 +138,22 @@ start_pv() {
 	local valgrind_opt=""
 	if [ "$valgrind" = "true" ]; then
 		valgrind_opt="-V"
+		pvtest_log DEBUG "valgrind enabled"
 	fi
 	pv_cmd="pv-appengine $valgrind_opt -d 0 -c \"$cmdline\""
 
+	pvtest_log INFO "starting Pantavisor"
 	eval "$pv_cmd &"
 
 	trap 'int_handler' INT
 
 	wait_for_process " pantavisor$" "30" "-a"
 	if [ $? != 0 ]; then
-		echo "Error: timed out waiting for Pantavisor PID"
+		pvtest_log ERROR "timed out waiting for Pantavisor PID"
 		stop_pv
 		exit 1
 	fi
+	pvtest_log INFO "Pantavisor running"
 
 	if [ -n "$ready_script" ]; then
 		sh -c "$test_path/$ready_script"
@@ -156,24 +161,26 @@ start_pv() {
 
 	wait_for_value "pvcontrol devmeta ls | jq -r .'[\"pantavisor.status\"]'" "READY" "120"
 	if [ $? != 0 ]; then
-		echo "Error: timed out waiting for pantavisor.status READY"
+		pvtest_log ERROR "timed out waiting for pantavisor.status READY"
 		stop_pv
 		exit 1
 	fi
+	pvtest_log INFO "Pantavisor status: READY"
 
 	wait_for_status "LD_LIBRARY_PATH=/lib:/usr/lib curl -s X GET http://localhost:12368/cgi-bin/pvtx/status > /dev/null 2>&1" 0 120
 	if [ $? -ne 0 ]; then
-		echo "Error: timed out waiting for $control_container pvr endpoint to be online"
+		pvtest_log ERROR "timed out waiting for $control_container pvr endpoint to be online"
 		stop_pv
 		exit 1
 	fi
+	pvtest_log DEBUG "pvr endpoint online"
 
 	if [ "$self_claim" = "true" ]; then
 		pvr -u "$PH_USER" -p "$PH_PASS" login > /dev/null 2>&1
 
 		wait_for_pantahub_state "$control_container" "claim"
 		if [ $? -ne 0 ]; then
-			echo "Error: timed out waiting for pantahub.state claim"
+			pvtest_log ERROR "timed out waiting for pantahub.state claim"
 			stop_pv
 			exit 1
 		fi
@@ -183,14 +190,14 @@ start_pv() {
 
 		pvr claim -c "$challenge" "$device_id"
 		if [ $? -ne 0 ]; then
-			echo "Error: pvr claim failed"
+			pvtest_log ERROR "pvr claim failed"
 			stop_pv
 			exit 1
 		fi
 
 		wait_for_pantahub_state "$control_container" "idle"
 		if [ $? -ne 0 ]; then
-			echo "Error: timed out waiting for pantahub.state idle after claim"
+			pvtest_log ERROR "timed out waiting for pantahub.state idle after claim"
 			stop_pv
 			exit 1
 		fi
@@ -199,15 +206,17 @@ start_pv() {
 
 exec_test() {
 	tmp_script_path=$(mktemp /tmp/pv_appengine_script.XXXXXX)
-	sed '5iset -x' "$test_path/$test_script" > "$tmp_script_path"
+	sed '5iexport PS4='"'"'[pvtest] $(date +%s) DEBUG -- [test-script]: '"'"'; set -x' "$test_path/$test_script" > "$tmp_script_path"
 	chmod +x "$tmp_script_path"
 
 	tmp_out_path=$(mktemp /tmp/pv_appengine_output.XXXXXX)
 	# we use script to get stdout and stderr in the same order we do in console
 	# tee shows output in real-time while saving it for later comparison
-	script -q -c "sh -c \"$tmp_script_path\"" | tee $tmp_out_path
+	script -q -c "bash -c \"$tmp_script_path\"" | tee $tmp_out_path
+	pvtest_log INFO "test script complete"
 
 	if [ "$overwrite" = "true" ]; then
+		pvtest_log INFO "overwriting expected output"
 		cat $tmp_out_path > $test_path/output
 	fi
 	rm -f "$tmp_script_path"
@@ -215,7 +224,7 @@ exec_test() {
 
 eval_test() {
 	if [ "$overwrite" != "true" ]; then
-		diff <(grep -vE '^(\+|\$)' $test_path/output) <(grep -vE '^(\+|\$)' "$tmp_out_path") | tee /var/pantavisor/storage/diff
+		diff <(grep -vE '^(\+|\$|\[+pvtest\] [0-9]+ DEBUG -- \[test-script\]:)' $test_path/output) <(grep -vE '^(\+|\$|\[+pvtest\] [0-9]+ DEBUG -- \[test-script\]:)' "$tmp_out_path") | tee /var/pantavisor/storage/diff
 		if [ "${PIPESTATUS[0]}" -ne 0 ]; then
 			stop_pv
 			exit 1
@@ -235,7 +244,7 @@ daemon=${7:-$DAEMON}
 valgrind=${8:-$VALGRIND}
 
 if [ -z "$test_path" ] || [ -z "$interactive" ] || [ -z "$manual" ] || [ -z "$overwrite" ] || [ -z "$verbose" ] || [ -z "$netsim" ]; then
-	echo "Error: missing arguments / envs"
+	pvtest_log ERROR "missing arguments / envs"
 	usage
 fi
 if [ "$verbose" = "true" ]; then set -x; fi
@@ -254,11 +263,12 @@ parse_test
 
 if [ "$self_claim" = "true" ]; then
 	if [ -z "$PH_USER" ] || [ -z "$PH_PASS" ]; then
-		echo "Error: you need to set PH_USER and PH_PASS to execute the test"
+		pvtest_log ERROR "you need to set PH_USER and PH_PASS to execute the test"
 		exit 1
 	fi
 fi
 
+pvtest_log INFO "setting up test: $test_path"
 initial_setup
 
 if [ "$manual" = "false" ]; then
@@ -272,6 +282,7 @@ fi
 if [ "$daemon" = "true" ]; then
 	sleep 100000
 elif [ "$interactive" = "false" ]; then
+	pvtest_log INFO "running test script"
 	exec_test
 fi
 stop_pv

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -139,11 +139,7 @@ start_pv() {
 	fi
 	pv_cmd="pv-appengine $valgrind_opt -d 0 -c \"$cmdline\""
 
-	if [ "$verbose" = "false" ]; then
-		eval "$pv_cmd > /dev/null 2>&1 &"
-	else
-		eval "$pv_cmd &"
-	fi
+	eval "$pv_cmd &"
 
 	trap 'int_handler' INT
 
@@ -155,11 +151,7 @@ start_pv() {
 	fi
 
 	if [ -n "$ready_script" ]; then
-		if [ "$verbose" = "false" ]; then
-			sh -c "$test_path/$ready_script" > /dev/null 2>&1
-		else
-			sh -c "$test_path/$ready_script"
-		fi
+		sh -c "$test_path/$ready_script"
 	fi
 
 	wait_for_value "pvcontrol devmeta ls | jq -r .'[\"pantavisor.status\"]'" "READY" "120"

--- a/pvtest/utils.in
+++ b/pvtest/utils.in
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+pvtest_log() { local level=$1; shift; printf '[pvtest] %s %s -- [%s]: %s\n' "$(date +%s)" "$level" "${PVTEST_LOG_SOURCE:-pvtest}" "$*"; }
+
 # wait for a cmd stdout
 wait_for_value() {
 	local cmd="$1"


### PR DESCRIPTION
## Summary

### disk: volume-disk bind-mount backend
- Add \`disk_volume_bind.c\` with \`volume_bind_impl\`: when a \`volume-disk\` entry has no \`provision\` field, bind-mount a persistent directory from \`/storage/pv/volume-disk/<name>\` into the ephemeral tmpfs at \`/run/pantavisor/media/pv/dmcrypt/<name>\` on each startup
- The backing store lives under \`/storage\` (the persistent Docker bind-mount), so volume data survives repeated pantavisor restarts
- Remove the \`directory\` disk type (DISK_DIR); update docs to document the two \`volume-disk\` modes: bind-mount (no provision) and block/zram (with provision)
- Remove dm-crypt cleanup and loop device setup from \`pv-appengine.in\`: \`cleanup_cryptdisk()\`, \`setup_loop()\`, \`teardown_loop()\` and all call sites are no longer needed

### appengine fixes
- Suppress \`cleanup_cgroup\` exit code under \`set -e\` to avoid spurious test failures
- Resolve LXC-suffixed platform names in appengine mode (ctrl)

### pvtest: structured logging format
- Standardise log format across \`pvtest-run.in\` and \`pv-appengine.in\`: \`[pvtest] <epoch> LEVEL -- [source]: message\`
- Add lifecycle log messages (first boot, storage init, SIGINT received, Pantavisor stopped)
- Add verbose mode: \`VERBOSE=true\` enables \`set -x\` in \`pv-appengine.in\`
- Inject PS4 trace into test scripts: structured \`[pvtest] \$(date +%s) DEBUG -- [test-script]: command\` format
- Fix \`eval_test\` filter to handle bash's nested PS4 bracket replication
- Always capture pantavisor logs in \`test.log\` even when pantavisor exits early