### PR TITLE
fix(pvtest): pre-create loop nodes so appengine tests don't reboot-loop on loaded hosts

### DIFF
--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -33,6 +33,25 @@ cleanup() {
 trap cleanup EXIT
 
 initial_setup() {
+	# Pre-create loop device nodes. The tester container has /dev/loop-control,
+	# CAP_MKNOD and a 'b 7:* rmw' device-cgroup rule, but no devtmpfs/udev — so
+	# LOOP_CTL_GET_FREE hands out a free index while the matching /dev/loopN node
+	# is never created, and losetup (for the dm-crypt disk or container
+	# squashfs) fails with "failed to set up loop device: No such file or
+	# directory". Creating the nodes up front makes losetup work for whatever
+	# index the kernel picks, no matter how loaded the host is. This is
+	# parallel-safe: LOOP_CTL_GET_FREE is host-global and atomic so concurrent
+	# tester containers get distinct backing indices, and each container has its
+	# own /dev so the nodes never collide. Idempotent and harmless where the
+	# nodes already exist (real devices with devtmpfs).
+	if [ -e /dev/loop-control ]; then
+		i=0
+		while [ "$i" -lt 1024 ]; do
+			[ -e "/dev/loop$i" ] || mknod "/dev/loop$i" b 7 "$i" 2>/dev/null
+			i=$((i + 1))
+		done
+	fi
+
 	if ! cat /proc/mounts | awk '{ print $2}' | grep -q '^@PV_INSTALL_FULL_STORAGEDIR@$'; then
 		pvtest_log ERROR "@PV_INSTALL_FULL_STORAGEDIR@ must be a mountpoint."
 		sleep 10


### PR DESCRIPTION
## Problem

Appengine pvtests reboot-loop on loaded hosts: the dm-crypt test disk's `losetup` fails with `failed to set up loop device: No such file or directory`, the BSP volume mount fails, and the revision rolls back — repeatedly.

## Root cause

The tester container is non-privileged and has `/dev/loop-control`, `CAP_MKNOD` and a `b 7:* rmw` device-cgroup rule, but **no devtmpfs/udev**. `LOOP_CTL_GET_FREE` hands out a free loop *index*, but the matching `/dev/loopN` *node* is never created (and `losetup` doesn't `mknod` it), so the attach fails with `ENOENT`. It only worked when the host's free index happened to be low (matching a pre-existing node); once low indices are consumed by other long-running containers or parallel runs, the index climbs past the available nodes and every multi-loop test fails. Not `max_loop` (loop-control is dynamic), not loop exhaustion.

Reproduced:
```
loop-control free index: 37
losetup /dev/loop37 img → failed to set up loop device: No such file or directory
mknod /dev/loop37 b 7 37; losetup /dev/loop37 img → OK
```

## Fix

`pvtest-run` pre-creates the loop device nodes at container startup. `losetup` then works for whatever index the kernel picks, regardless of host load.

- **Parallel-safe**: `LOOP_CTL_GET_FREE` is host-global and atomic (distinct backing indices per container) and each container has its own `/dev` (nodes never collide).
- **Idempotent / harmless** where the nodes already exist (real devices with devtmpfs).

Measured on a loaded host (daemons pvtest): **240 losetup failures / 482 rollbacks / 145s reboot-loop → 0 / 0 / clean 27s**.
