### PR TITLE
fix(platforms): kill container before unmounting its volumes on force stop

### DIFF
--- a/platforms.c
+++ b/platforms.c
@@ -1446,13 +1446,15 @@ void pv_platform_stop_with_callback(struct pv_platform *p,
 void pv_platform_force_stop(struct pv_platform *p)
 {
 	pv_log(DEBUG, "force stopping platform '%s'", p->name);
+
+	// Kill and drain the cgroup before STOPPED unmounts the volumes,
+	// otherwise the rootfs is still busy (dm-verity close fails).
+	if (p->init_pid > 0) {
+		kill(p->init_pid, SIGKILL);
+		pv_cgroup_destroy(p->name);
+	}
+
 	pv_platform_set_status(p, PLAT_STOPPED);
-
-	if (p->init_pid <= 0)
-		return;
-
-	kill(p->init_pid, SIGKILL);
-	pv_cgroup_destroy(p->name);
 }
 
 void pv_platform_set_installed(struct pv_platform *p)


### PR DESCRIPTION
## Problem

On force stop (reboot/shutdown, crash recovery, failed start), `pv_platform_force_stop` transitioned the platform to `PLAT_STOPPED` **first** — which unmounts the platform's volumes via `pv_platform_set_status` — and only **then** sent `SIGKILL` and destroyed the cgroup.

Unmounting the rootfs while the container's processes are still alive leaves the backing device busy. For dm-verity-backed `root.squashfs` this shows up as a ~5s storm of:

```
device-mapper: remove ioctl on pv--dmverity--<container>-root failed: Resource busy
...
Device pv--dmverity--<container>-root is still in use.
```

It's timing-dependent (only when a container is still alive at force-stop time), so it doesn't reproduce on every reboot.

## Fix

Kill `init_pid` and drain the cgroup **before** transitioning to `STOPPED`. `pv_cgroup_destroy` already retries cgroup removal until it's empty, so it doubles as a wait for all processes (not just `init_pid`) to exit. The volume unmount then runs against a dead container.

Covers all `pv_platform_force_stop` callers. No change to the existing grace period or signalling.