### PR TITLE
fix(config,metadata): honor user-metadata deletions

### DIFF
--- a/config.c
+++ b/config.c
@@ -126,6 +126,16 @@ struct pv_config_entry {
 		int i;
 		char *s;
 	} value;
+	// snapshot of value/level as it was right before the first META
+	// (user metadata) override, so the override can be reverted when the
+	// usermeta key is deleted.
+	bool meta_saved;
+	level_t base_modified;
+	struct {
+		bool b;
+		int i;
+		char *s;
+	} base_value;
 };
 
 // configuration lookup table
@@ -1000,6 +1010,17 @@ static int _set_config_by_entry(struct pv_config_entry *entry,
 		}
 	}
 
+	// snapshot the pre-metadata value/level on the first META override so
+	// it can be restored when the user metadata key is later deleted.
+	if ((modified == META) && !entry->meta_saved) {
+		entry->base_modified = entry->modified;
+		entry->base_value.b = entry->value.b;
+		entry->base_value.i = entry->value.i;
+		entry->base_value.s =
+			entry->value.s ? strdup(entry->value.s) : NULL;
+		entry->meta_saved = true;
+	}
+
 	entry->modified = modified;
 
 	switch (entry->type) {
@@ -1339,11 +1360,38 @@ void pv_config_override_value(const char *key, const char *value)
 	_set_config_by_key(key, value, (void *)&level);
 }
 
+void pv_config_unset_value(const char *key)
+{
+	struct pv_config_entry *entry = _search_config_entry_by_key(key);
+	if (!entry)
+		entry = _search_config_entry_by_alias(key);
+	if (!entry || !entry->meta_saved)
+		return;
+
+	// restore the value/level captured before the META override
+	if (entry->type == STR) {
+		if (entry->value.s)
+			free(entry->value.s);
+		entry->value.s = entry->base_value.s;
+		entry->base_value.s = NULL;
+	} else {
+		entry->value.b = entry->base_value.b;
+		entry->value.i = entry->base_value.i;
+	}
+	entry->modified = entry->base_modified;
+	entry->meta_saved = false;
+
+	pv_log(DEBUG, "reverted '%s' to level '%s' after metadata removal",
+	       entry->key, _get_mod_level_str(entry->modified));
+}
+
 void pv_config_free()
 {
 	for (config_index_t ci = 0; ci < PV_MAX; ci++) {
-		if (entries[ci].type == STR)
+		if (entries[ci].type == STR) {
 			free(entries[ci].value.s);
+			free(entries[ci].base_value.s);
+		}
 	}
 }
 

--- a/config.h
+++ b/config.h
@@ -227,6 +227,7 @@ int pv_config_save_creds(void);
 int pv_config_unload_creds(void);
 
 void pv_config_override_value(const char *key, const char *value);
+void pv_config_unset_value(const char *key);
 
 void pv_config_free(void);
 

--- a/metadata.c
+++ b/metadata.c
@@ -655,6 +655,8 @@ int pv_metadata_rm_usermeta(const char *key)
 		dl_list_del(&meta->list);
 		pv_storage_rm_usermeta(meta->key);
 		pv_metadata_free(meta);
+		// revert any config value this user metadata key had overridden
+		pv_config_unset_value(key);
 		return 0;
 	}
 
@@ -691,10 +693,16 @@ static int pv_usermeta_parse(struct pantavisor *pv, char *buf)
 		strncpy(value, buf + (*key_i + 1)->start, n);
 		pv_str_unescape_to_ascii(value, n);
 
-		// add or update metadata
-		// primitives with value 'null' have value NULL
-		if ((*key_i + 1)->type != JSMN_PRIMITIVE ||
-		    strcmp("null", value))
+		// A 'null' primitive or an empty string value means the key has
+		// been cleared on the Hub. Treat it as a deletion: remove the
+		// user metadata pair so any config override it held is reverted
+		// to the previous value, instead of storing an empty value that
+		// would coerce numeric config keys to 0.
+		bool is_null = ((*key_i + 1)->type == JSMN_PRIMITIVE) &&
+			       !strcmp("null", value);
+		if (is_null || value[0] == '\0')
+			pv_metadata_rm_usermeta(key);
+		else
 			pv_metadata_add_usermeta(key, value);
 
 		// free intermediates


### PR DESCRIPTION
Treat an empty or `null` user-metadata value from the Hub as a **deletion**, and revert a config value that user metadata had overridden back to its baseline when the key is removed. Without this, clearing a usermeta key left the override in place — and an empty value coerced numeric config keys to `0` — so the device-metadata pvtests behaved non-deterministically.

## What changed

- **config.c / config.h** — on the first `META`-level override of a config entry, snapshot its prior value and level (`base_value`, `base_modified`, `meta_saved`). New `pv_config_unset_value()` restores that snapshot; `pv_config_free()` frees the snapshot string.
- **metadata.c** — `pv_usermeta_parse()` treats a `null` primitive or an empty string as a deletion: it calls `pv_metadata_rm_usermeta()` instead of storing an empty value. `pv_metadata_rm_usermeta()` now calls `pv_config_unset_value()` so any config override the key held is reverted.

Split out of #727 so it can land on its own; #727 rebases on top once this merges.
