### PR TITLE
fix(drivers): unload modules in reverse of load order

### DIFF
--- a/drivers.c
+++ b/drivers.c
@@ -144,18 +144,25 @@ static int _pv_drivers_modprobe(char **modules, mod_action_t action)
 {
 	int ret = 0, status;
 	char cmd[PATH_MAX];
-	char **module, *tmp, *mod;
+	char *tmp, *mod;
 
 	if (!modules)
 		return ret;
 
-	module = modules;
-	while (*module) {
-		tmp = _sub_meta_values(*module);
+	int count = pv_str_count_list(modules);
+	int i;
+
+	for (i = 0; i < count; i++) {
+		/* load in list order; unload in reverse so that dependent
+		 * modules are removed before the dependencies they were
+		 * built on */
+		int idx = (action == MOD_UNLOAD) ? (count - 1 - i) : i;
+
+		tmp = _sub_meta_values(modules[idx]);
 		if (!tmp) {
-			pv_log(WARN, "illegal module value '%s'", *module);
+			pv_log(WARN, "illegal module value '%s'", modules[idx]);
 			ret++;
-			goto next;
+			continue;
 		}
 
 		if (action == MOD_UNLOAD)
@@ -169,11 +176,8 @@ static int _pv_drivers_modprobe(char **modules, mod_action_t action)
 		tsh_run(cmd, 1, &status);
 		if (WEXITSTATUS(status) == 0)
 			ret++;
-		;
-	next:
-		module++;
-		if (tmp)
-			free(tmp);
+
+		free(tmp);
 		tmp = NULL;
 	}
 


### PR DESCRIPTION
## Problem

`_pv_drivers_modprobe` walked the module list in the same direction for both load and unload. Unloading in list order can fail when a later module depends on an earlier one — the dependency is removed (or attempted) while the dependent module is still loaded.

## Fix

- Iterate the module list in **reverse** for `MOD_UNLOAD` so dependent modules are removed before the dependencies they were built on. Load order is unchanged.
- Replace the `goto next` pointer-walk with an index loop based on `pv_str_count_list`, and always free the substituted value.

## Notes

Isolated from the xconnect hosted-systembus work; no functional dependency on it.