### PR TITLE
fix(ph_logger): chunk cloud log push and correct transport error reporting

### DIFF
--- a/ph_logger.c
+++ b/ph_logger.c
@@ -72,6 +72,18 @@
 #define PH_LOGGER_FLAG_STOP (1 << 0)
 #define USER_AGENT_LEN (128)
 
+/*
+ * Caps for a single POST /logs/ request. Accumulated log fragments are
+ * flushed in chunks bounded by these limits and the file is drained
+ * across successive chunks. A single oversized POST is silently dropped
+ * by pantahub and can also exceed the on-device HTTP timeout, so we keep
+ * each request comfortably below the doubled log buffer size (the reader
+ * block is PV_LOG_BUF_NITEMS * 1024, 128K by default; the doubled buffer
+ * used for formatting is 256K).
+ */
+#define PH_LOGGER_PUSH_MAX_BYTES (256 * 1024)
+#define PH_LOGGER_PUSH_MAX_FRAGS (200)
+
 #define MODULE_NAME "ph_logger"
 #define pv_log(level, msg, ...)                                                \
 	vlog(MODULE_NAME, level, "(%s:%d) " msg, __FUNCTION__, __LINE__,       \
@@ -88,6 +100,12 @@ static struct pantavisor *pv_global;
 struct ph_logger_fragment {
 	struct dl_list list;
 	char *json_frag;
+	/*
+	 * File position just past the log line this fragment was built
+	 * from. Used to advance the saved log-file position only for
+	 * fragments that were actually pushed successfully.
+	 */
+	off_t pos;
 };
 
 static DEFINE_DL_LIST(frag_list);
@@ -201,9 +219,17 @@ auth:
 	if (!res) {
 		pv_log(WARN,
 		       "HTTP request POST /logs/ could not be initialized");
-	} else if (!res->code && res->status != TREST_AUTH_STATUS_OK) {
+	} else if (!res->code) {
+		/*
+		 * res->code == 0 means no HTTP response was received at
+		 * all (transport-level timeout or hangup). Auth already
+		 * succeeded above via trest_update_auth(), so this is NOT
+		 * an auth failure. We cannot tell timeout from hangup here
+		 * without a libthttp change, so report it as a generic
+		 * transport error and surface the trest status for context.
+		 */
 		pv_log(WARN,
-		       "HTTP request POST /logs/ could not auth (status=%d)",
+		       "POST /logs/ got no HTTP response (transport error/timeout), trest_status=%d",
 		       res->status);
 	} else if (res->code != THTTP_STATUS_OK) {
 		pv_log(WARN,
@@ -341,8 +367,6 @@ static int ph_logger_push_from_file(const char *filename, char *platform,
 	int fd = -1;
 	char *buf = NULL;
 	int bytes_read = 0;
-	int nr_frags = 0;
-	int len_frags = 0;
 	struct buffer *log_buff = NULL;
 	struct buffer *large_buff = NULL;
 
@@ -482,10 +506,15 @@ static int ph_logger_push_from_file(const char *filename, char *platform,
 				if (shrinked)
 					__json_frag = shrinked;
 				frag = ph_logger_alloc_frag(__json_frag);
-				dl_list_add_tail(&frag_list, &frag->list);
-				nr_frags++;
-				len_frags += strlen(frag->json_frag);
 				pos = read_pos + offset;
+				/*
+				 * Remember the file position just past this
+				 * line so a partially-flushed backlog only
+				 * advances the saved position for fragments
+				 * actually sent.
+				 */
+				frag->pos = pos;
+				dl_list_add_tail(&frag_list, &frag->list);
 			} else {
 				/*Bail out on the first error*/
 				pv_log(ERROR, "alloc error for filename %s",
@@ -508,60 +537,124 @@ static int ph_logger_push_from_file(const char *filename, char *platform,
 	}
 close_fd:
 	close(fd);
-	if (!dl_list_empty(&frag_list)) {
+	/*
+	 * Drain the accumulated fragments in chunks capped by
+	 * PH_LOGGER_PUSH_MAX_BYTES / PH_LOGGER_PUSH_MAX_FRAGS. Each chunk is
+	 * a single "[...]" POST. The saved log-file position is only advanced
+	 * for fragments that were actually pushed successfully, so on a push
+	 * failure we stop and leave the position where it is for retry.
+	 */
+	while (!dl_list_empty(&frag_list)) {
 		struct ph_logger_fragment *item, *tmp;
 		char *json_frag_array = NULL;
+		int chunk_frags = 0;
+		int chunk_len = 0;
+		off_t chunk_pos = 0;
 		int off = 0;
 		int avail = 0;
 		int written = 0;
-		/*
-		 * Each fragment will need to be separated by ',' thus
-		 * we'll need nr_frags - 1 bytes in addition to size
-		 * of each of the frags. The whole bundle needs to be
-		 * inside '[' ']'. Thus
-		 * bytes_reqd = nr_frags - 1 + 2 + len_frags + 1 (for null).
-		 */
-		avail = nr_frags + len_frags + 2;
-		json_frag_array = calloc(avail, sizeof(char));
-		if (json_frag_array) {
-			off = snprintf(json_frag_array, 2, "[");
-			avail -= off;
-		}
+		int n = 0;
 
+		/*
+		 * First pass: figure out how many leading fragments fit into
+		 * this chunk. Always include at least one fragment so an
+		 * oversized single line still makes progress.
+		 */
 		dl_list_for_each_safe(item, tmp, &frag_list,
 				      struct ph_logger_fragment, list)
 		{
-			if (json_frag_array) {
-				written = snprintf(json_frag_array + off, avail,
-						   "%s", item->json_frag);
-				avail -= written;
-				off += written;
-			}
-			dl_list_del(&item->list);
-			/*
-			 * Is there another item if so add , in
-			 * json.
-			 */
-			if (!dl_list_empty(&frag_list) && json_frag_array) {
+			int this_len = strlen(item->json_frag);
+
+			if (chunk_frags > 0 &&
+			    (chunk_frags >= PH_LOGGER_PUSH_MAX_FRAGS ||
+			     chunk_len + this_len + 1 >
+				     PH_LOGGER_PUSH_MAX_BYTES))
+				break;
+
+			chunk_frags++;
+			chunk_len += this_len;
+			chunk_pos = item->pos;
+		}
+
+		/*
+		 * Each fragment needs a ',' separator (chunk_frags - 1 of
+		 * them), the whole bundle is wrapped in '[' ']' and we need a
+		 * trailing null. Thus:
+		 * bytes_reqd = (chunk_frags - 1) + 2 + chunk_len + 1.
+		 */
+		avail = chunk_frags + chunk_len + 2;
+		json_frag_array = calloc(avail, sizeof(char));
+		if (!json_frag_array) {
+			pv_log(ERROR, "alloc error for filename %s", filename);
+			ret = -1;
+			break;
+		}
+
+		off = snprintf(json_frag_array, 2, "[");
+		avail -= off;
+
+		n = 0;
+		dl_list_for_each_safe(item, tmp, &frag_list,
+				      struct ph_logger_fragment, list)
+		{
+			if (n >= chunk_frags)
+				break;
+
+			written = snprintf(json_frag_array + off, avail, "%s",
+					   item->json_frag);
+			avail -= written;
+			off += written;
+			n++;
+			/* Separate fragments within this chunk with ','. */
+			if (n < chunk_frags) {
 				written = snprintf(json_frag_array + off, avail,
 						   ",");
 				avail -= written;
 				off += written;
 			}
+		}
+		SNPRINTF_WTRUNC(json_frag_array + off, avail, "]");
+
+		if (ph_logger_push_logs_endpoint(&ph_logger, json_frag_array)) {
+			/*
+			 * Push failed: leave the unsent fragments and the
+			 * saved position untouched so they are retried later.
+			 */
+			free(json_frag_array);
+			ret = -1;
+			break;
+		}
+		free(json_frag_array);
+
+		/* Chunk sent: advance the saved position and drop it. */
+		_save_log_file_pos(chunk_pos, filename);
+		ret = 1;
+
+		n = 0;
+		dl_list_for_each_safe(item, tmp, &frag_list,
+				      struct ph_logger_fragment, list)
+		{
+			if (n >= chunk_frags)
+				break;
+			dl_list_del(&item->list);
 			free(item->json_frag);
 			free(item);
+			n++;
 		}
-		if (json_frag_array) {
-			SNPRINTF_WTRUNC(json_frag_array + off, avail, "]");
-			// set ret to 1, something pending to be sent
-			ret = 1;
-			if (!ph_logger_push_logs_endpoint(&ph_logger,
-							  json_frag_array))
-				_save_log_file_pos(pos, filename);
-			// in case of error while sending, we return -1
-			else
-				ret = -1;
-			free(json_frag_array);
+	}
+
+	/*
+	 * Free any fragments left over (push failure or alloc error). Their
+	 * position was not saved, so they will be re-read on the next pass.
+	 */
+	{
+		struct ph_logger_fragment *item, *tmp;
+		dl_list_for_each_safe(item, tmp, &frag_list,
+				      struct ph_logger_fragment, list)
+		{
+			dl_list_del(&item->list);
+			free(item->json_frag);
+			free(item);
 		}
 	}
 out:

--- a/ph_logger.c
+++ b/ph_logger.c
@@ -191,9 +191,23 @@ static void sigchld_handler(int signum)
 		;
 }
 
+/*
+ * Result of a POST /logs/ push, used by the drain loop to decide whether to
+ * retry the batch or to give up on it. A REJECTED batch will never be accepted
+ * no matter how often it is resent (definitive 4xx / bad content), so the
+ * caller isolates and drops the offending fragment instead of wedging the
+ * whole log stream on it. TRANSIENT covers transport errors, 5xx and
+ * backpressure (429/408), which a later retry of the same batch can clear.
+ */
+enum ph_logger_push_result {
+	PH_LOGGER_PUSH_OK = 0,
+	PH_LOGGER_PUSH_TRANSIENT = -1,
+	PH_LOGGER_PUSH_REJECTED = -2,
+};
+
 static int ph_logger_push_logs_endpoint(struct ph_logger *ph_logger, char *logs)
 {
-	int ret = -1;
+	int ret = PH_LOGGER_PUSH_TRANSIENT;
 	trest_auth_status_enum status = TREST_AUTH_STATUS_NOTAUTH;
 	trest_request_ptr req = NULL;
 	trest_response_ptr res = NULL;
@@ -231,12 +245,35 @@ auth:
 		pv_log(WARN,
 		       "POST /logs/ got no HTTP response (transport error/timeout), trest_status=%d",
 		       res->status);
-	} else if (res->code != THTTP_STATUS_OK) {
+	} else if (res->code == THTTP_STATUS_OK) {
+		ret = PH_LOGGER_PUSH_OK;
+	} else if (res->code == 429 /* Too Many Requests */ ||
+		   res->code == 408 /* Request Timeout */ ||
+		   res->code == 401 /* Unauthorized */ ||
+		   res->code == 403 /* Forbidden */ ||
+		   res->code >= 500 /* server-side error */) {
+		/*
+		 * Retryable: backpressure, an auth hiccup or a server-side
+		 * error. Resending the same batch later can still succeed.
+		 */
 		pv_log(WARN,
-		       "HTTP request POST /logs/ returned HTTP error (code=%d; body='%s')",
+		       "POST /logs/ transient HTTP error (code=%d; body='%s')",
 		       res->code, res->body);
+	} else if (res->code >= 400) {
+		/*
+		 * Definitive client/content rejection (400 bad request, 413
+		 * payload too large, 422, ...): the server will never accept
+		 * this batch, so resending it forever would stall the log
+		 * stream. Tell the caller to isolate and drop the offender.
+		 */
+		pv_log(WARN,
+		       "POST /logs/ rejected batch content (code=%d; body='%s')",
+		       res->code, res->body);
+		ret = PH_LOGGER_PUSH_REJECTED;
 	} else {
-		ret = 0;
+		/* Unexpected 1xx/3xx: be conservative and retry. */
+		pv_log(WARN, "POST /logs/ unexpected HTTP status (code=%d)",
+		       res->code);
 	}
 
 out:
@@ -367,6 +404,7 @@ static int ph_logger_push_from_file(const char *filename, char *platform,
 	int fd = -1;
 	char *buf = NULL;
 	int bytes_read = 0;
+	int isolate = 0;
 	struct buffer *log_buff = NULL;
 	struct buffer *large_buff = NULL;
 
@@ -546,6 +584,7 @@ close_fd:
 	 */
 	while (!dl_list_empty(&frag_list)) {
 		struct ph_logger_fragment *item, *tmp;
+		struct ph_logger_fragment *head = NULL;
 		char *json_frag_array = NULL;
 		int chunk_frags = 0;
 		int chunk_len = 0;
@@ -574,6 +613,16 @@ close_fd:
 			chunk_frags++;
 			chunk_len += this_len;
 			chunk_pos = item->pos;
+			if (!head)
+				head = item;
+
+			/*
+			 * When narrowing a rejected batch, push exactly one
+			 * fragment so the offending line can be pinned down
+			 * (and dropped if the server still refuses it).
+			 */
+			if (isolate)
+				break;
 		}
 
 		/*
@@ -615,20 +664,54 @@ close_fd:
 		}
 		SNPRINTF_WTRUNC(json_frag_array + off, avail, "]");
 
-		if (ph_logger_push_logs_endpoint(&ph_logger, json_frag_array)) {
+		int push_res = ph_logger_push_logs_endpoint(&ph_logger,
+							    json_frag_array);
+		free(json_frag_array);
+
+		if (push_res == PH_LOGGER_PUSH_REJECTED) {
+			if (chunk_frags > 1) {
+				/*
+				 * Server refused this batch on content grounds.
+				 * Retry the head as a single fragment to pin
+				 * down the offending line before dropping it.
+				 */
+				isolate = 1;
+				continue;
+			}
 			/*
-			 * Push failed: leave the unsent fragments and the
+			 * A single fragment the server will never accept: drop
+			 * it (drop-and-log) and advance past it so the rest of
+			 * the backlog and all newer logs still upload, instead
+			 * of wedging the whole stream on one poison line.
+			 */
+			pv_log(ERROR,
+			       "dropping log fragment POST /logs/ refused; advancing past pos %jd: %.256s",
+			       (intmax_t)chunk_pos,
+			       head ? head->json_frag : "");
+			_save_log_file_pos(chunk_pos, filename);
+			ret = 1;
+			isolate = 0;
+			if (head) {
+				dl_list_del(&head->list);
+				free(head->json_frag);
+				free(head);
+			}
+			continue;
+		}
+
+		if (push_res != PH_LOGGER_PUSH_OK) {
+			/*
+			 * Transient failure: leave the unsent fragments and the
 			 * saved position untouched so they are retried later.
 			 */
-			free(json_frag_array);
 			ret = -1;
 			break;
 		}
-		free(json_frag_array);
 
 		/* Chunk sent: advance the saved position and drop it. */
 		_save_log_file_pos(chunk_pos, filename);
 		ret = 1;
+		isolate = 0;
 
 		n = 0;
 		dl_list_for_each_safe(item, tmp, &frag_list,


### PR DESCRIPTION
## Summary

The device cloud log push (forked push/range services in `ph_logger.c`)
POSTs accumulated log fragments to pantahub `POST /logs/`. This fixes two
bugs in that path.

## Problems & fixes

### A. Oversized single POST — now chunked (highest value)
`ph_logger_push_from_file()` accumulated **every** fragment from a log
block into one `[...]` JSON array and posted it in a single request. On a
device with a backlog this produces a huge POST body that (a) pantahub
silently drops and (b) can exceed the on-device HTTP timeout, yielding a
no-response failure.

Fix: the drain now flushes in chunks capped by
`PH_LOGGER_PUSH_MAX_BYTES` (256K) and `PH_LOGGER_PUSH_MAX_FRAGS` (200),
looping until the block is drained. Caps are sized to stay below the
doubled log buffer (`PV_LOG_BUF_NITEMS * 1024`, 128K default; doubled
buffer 256K).

**Position bookkeeping preserved:** each fragment now records the file
position just past its source line (`frag->pos`). After a chunk is
pushed successfully we `_save_log_file_pos()` the last sent fragment's
position; on a push failure we stop immediately and leave the saved
position untouched so unsent data is retried on the next pass. Remaining
fragments are freed without advancing the position. Return-value
semantics are kept: `1` = something was sent, `-1` = push error
(triggers the existing backoff), `0` = nothing to send.

### B. Misleading "could not auth" message — now reports transport error
The branch that fired on `res->code == 0` logged
`"...could not auth (status=%d)"`. But `res->code == 0` means **no HTTP
response was received** (transport-level timeout/hangup), and
`trest_update_auth()` has already succeeded by that point — it is not an
auth failure. Reworded to:
`"POST /logs/ got no HTTP response (transport error/timeout), trest_status=%d"`.
The three genuine cases stay distinct: `res == NULL` (request could not
be initialized), `res->code == 0` (no response / transport), and a real
non-2xx HTTP code. Timeout-vs-hangup is intentionally **not**
distinguished here — that needs a separate libthttp change (follow-up
PR #744); this keeps building against current libthttp.

## Testing
- `clang-format-21` applied to changed files.
- Builds green in CI (docker-x86_64, raspberrypi-armv8, sunxi-bpi-m2b scarthgap).
