### PR TITLE
fix(ph_logger): report transport error reason (timeout vs hangup) for failed log push

### DIFF
--- a/ph_logger.c
+++ b/ph_logger.c
@@ -236,14 +236,28 @@ auth:
 	} else if (!res->code) {
 		/*
 		 * res->code == 0 means no HTTP response was received at
-		 * all (transport-level timeout or hangup). Auth already
-		 * succeeded above via trest_update_auth(), so this is NOT
-		 * an auth failure. We cannot tell timeout from hangup here
-		 * without a libthttp change, so report it as a generic
-		 * transport error and surface the trest status for context.
+		 * all. Auth already succeeded above via trest_update_auth(),
+		 * so this is NOT an auth failure. libthttp !52 exposes the
+		 * underlying transport error via res->transport_error, which
+		 * lets us tell a timeout from a peer hangup from a generic
+		 * transport/TLS error.
 		 */
-		pv_log(WARN,
-		       "POST /logs/ got no HTTP response (transport error/timeout), trest_status=%d",
+		const char *reason;
+		switch (res->transport_error) {
+		case THTTP_TRANSPORT_TIMEOUT:
+			reason = "timed out waiting for connect/response";
+			break;
+		case THTTP_TRANSPORT_EOF:
+			reason = "server closed connection without responding";
+			break;
+		case THTTP_TRANSPORT_ERROR:
+			reason = "transport/TLS error";
+			break;
+		default:
+			reason = "no HTTP response";
+			break;
+		}
+		pv_log(WARN, "POST /logs/ failed: %s (trest_status=%d)", reason,
 		       res->status);
 	} else if (res->code == THTTP_STATUS_OK) {
 		ret = PH_LOGGER_PUSH_OK;


### PR DESCRIPTION
## What

Follow-up to #743. When a cloud log push gets no HTTP response (`res->code == 0`), report *why*: timeout vs. server hangup vs. generic transport/TLS error, instead of a single generic message.

In `ph_logger_push_logs_endpoint()` the `!res->code` branch now switches on the new `res->transport_error` field:

- `THTTP_TRANSPORT_TIMEOUT` -> "timed out waiting for connect/response"
- `THTTP_TRANSPORT_EOF` -> "server closed connection without responding"
- `THTTP_TRANSPORT_ERROR` -> "transport/TLS error"
- default -> "no HTTP response"

The `res == NULL`, non-2xx HTTP-code, and success branches are unchanged.

## Dependency

Consumes the new `trest_response_t.transport_error` field / `thttp_transport_error_t` enum from **libthttp !52** (not yet merged/released). This PR therefore **will not compile against the currently released SDK** — that is expected. Landing it also requires a **libthttp recipe/SRCREV bump** in the BSP layer once !52 merges. Being validated separately via a workspace testbuild.

## Stacking

Stacked on `fix/ph-logger-chunk-and-transport-errors` (#743). Base this PR against that branch; retarget to master after #743 merges.