### PR TITLE
fix(appengine): reboot instead of poweroff on SIGTERM

### DIFF
--- a/init.c
+++ b/init.c
@@ -199,7 +199,12 @@ static void shell_handler(int signal)
 	if (!pv)
 		return;
 
-	pv_issue_poweroff();
+	// appengine: SIGTERM means "crash, reboot" (not poweroff) so the wrapper relaunches cleanly
+	if (signal == SIGTERM &&
+	    pv_config_get_system_init_mode() == IM_APPENGINE)
+		pv_issue_reboot();
+	else
+		pv_issue_poweroff();
 }
 
 static void early_spawns()


### PR DESCRIPTION
This allows triggering artificial crashes from pvtest framework and get appengine containers back again for post-mortem inspection.

SIGTERM is used specifically so Pantavisor leniently shuts down and we get clean Valgrind results.