### PR TITLE
feat(pvtx): support explicit commit revision name

### DIFF
--- a/pvtx/include/pvtx/txn.h
+++ b/pvtx/include/pvtx/txn.h
@@ -31,7 +31,7 @@ int pv_pvtx_txn_add_from_disk(const char *path, struct pv_pvtx_error *err);
 int pv_pvtx_txn_add_tar_from_fd(int fd, struct pv_pvtx_error *err);
 
 int pv_pvtx_txn_abort(struct pv_pvtx_error *err);
-char *pv_pvtx_txn_commit(struct pv_pvtx_error *err);
+char *pv_pvtx_txn_commit(const char *name, struct pv_pvtx_error *err);
 char *pv_pvtx_txn_get_json(struct pv_pvtx_error *err);
 int pv_pvtx_txn_deploy(const char *path, struct pv_pvtx_error *err);
 int pv_pvtx_txn_remove(const char *part, struct pv_pvtx_error *err);

--- a/pvtx/src/pvtx.c
+++ b/pvtx/src/pvtx.c
@@ -157,11 +157,10 @@ static int cmd_abort(int argc, char **argv)
 }
 static int cmd_commit(int argc, char **argv)
 {
-	(void)argc;
-	(void)argv;
+	const char *name = (argc > 2) ? argv[2] : NULL;
 
 	struct pv_pvtx_error err = { 0 };
-	char *rev = pv_pvtx_txn_commit(&err);
+	char *rev = pv_pvtx_txn_commit(name, &err);
 	if (!rev) {
 		pv_pvtx_error_print(&err, "commit");
 	} else {
@@ -251,12 +250,14 @@ static int cmd_help(int argc, char **argv)
 	printf("Discard the current transaction, deleting the in-progress\n");
 	printf("%-32s%s\n", " ", "state JSON and transaction status file.");
 
-	printf("  %-30s", "commit");
+	printf("  %-30s", "commit [name]");
 	printf("Finalize a remote transaction by sending the state JSON to\n");
 	printf("%-32s%s\n", " ",
-	       "Pantavisor via the pv-ctrl socket. Generates and prints a");
+	       "Pantavisor via the pv-ctrl socket. Prints the revision name.");
 	printf("%-32s%s\n", " ",
-	       "revision name (locals/pvtx-<timestamp>-<hash>-<rand>).");
+	       "With [name], uses it verbatim (e.g. \"locals/my-rev\");");
+	printf("%-32s%s\n", " ",
+	       "otherwise generates locals/pvtx-<timestamp>-<hash>-<rand>.");
 	printf("%-32s%s\n", " ",
 	       "Only valid for remote transactions (begun without [object]).");
 

--- a/pvtx/src/pvtx_ctrl.c
+++ b/pvtx/src/pvtx_ctrl.c
@@ -43,6 +43,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
+#define PVTX_CTRL_RUN_SOCK "/run/pantavisor/pv/pv-ctrl"
 #define PVTX_CTRL_ROOT_SOCK "/pv/pv-ctrl"
 #define PVTX_CTRL_CONTAINER_SOCK "/pantavisor/pv-ctrl"
 
@@ -146,15 +147,18 @@ static int connect_sock(struct pv_pvtx_ctrl *ctrl, const char *path,
 	pv_pvtx_error_clear(err);
 
 	if (!path) {
-		// checking both paths
-		if (pv_fs_path_exist(PVTX_CTRL_ROOT_SOCK))
+		// try the known socket locations (same order as pvcontrol)
+		if (pv_fs_path_exist(PVTX_CTRL_RUN_SOCK))
+			path = PVTX_CTRL_RUN_SOCK;
+		else if (pv_fs_path_exist(PVTX_CTRL_ROOT_SOCK))
 			path = PVTX_CTRL_ROOT_SOCK;
 		else if (pv_fs_path_exist(PVTX_CTRL_CONTAINER_SOCK))
 			path = PVTX_CTRL_CONTAINER_SOCK;
 		else {
 			pv_pvtx_error_set(
 				err, -1,
-				"pv-ctrl socket not found (tried /pv/pv-ctrl and "
+				"pv-ctrl socket not found (tried "
+				"/run/pantavisor/pv/pv-ctrl, /pv/pv-ctrl and "
 				"/pantavisor/pv-ctrl)");
 			return -1;
 		}

--- a/pvtx/src/pvtx_txn.c
+++ b/pvtx/src/pvtx_txn.c
@@ -1182,7 +1182,7 @@ int pv_pvtx_txn_abort(struct pv_pvtx_error *err)
 	return err->code;
 }
 
-char *pv_pvtx_txn_commit(struct pv_pvtx_error *err)
+char *pv_pvtx_txn_commit(const char *name, struct pv_pvtx_error *err)
 {
 	char *json = NULL;
 	char *rev = NULL;
@@ -1220,7 +1220,8 @@ char *pv_pvtx_txn_commit(struct pv_pvtx_error *err)
 		goto out;
 	}
 
-	rev = get_rev_name(json, json_len);
+	// caller-supplied name used verbatim; else auto-generate
+	rev = (name && name[0]) ? strdup(name) : get_rev_name(json, json_len);
 
 	if (!rev) {
 		pv_pvtx_error_set(err, -1, "couldn't build revision string");


### PR DESCRIPTION
## Summary
- Adds an optional `[name]` argument to `pvtx commit`, letting the caller supply the revision name verbatim instead of always auto-generating `locals/pvtx-<timestamp>-<hash>-<rand>`
- Fixes pv-ctrl socket lookup to also try `/run/pantavisor/pv/pv-ctrl` first, matching pvcontrol's search order

## Changes
- `pv_pvtx_txn_commit()` now takes a `name` param; uses it verbatim if non-empty, else falls back to auto-generated name
- `cmd_commit` parses optional `argv[2]` as the name
- Updated `commit` help text to document `[name]`
- `connect_sock()` tries `/run/pantavisor/pv/pv-ctrl` before `/pv/pv-ctrl` and `/pantavisor/pv-ctrl`; error message updated accordingly