### PR TITLE
fix(update): report download progress on the mainloop heartbeat, not per object

### DIFF
--- a/event/event_rest.c
+++ b/event/event_rest.c
@@ -452,11 +452,15 @@ int pv_event_rest_recv_buffer(struct evhttp_request *req, char **buf,
 	return ret;
 }
 
-int pv_event_rest_recv_chunk_path(struct evhttp_request *req, const char *path)
+int pv_event_rest_recv_chunk_path(struct evhttp_request *req, const char *path,
+				  size_t *written)
 {
 	int fd;
 	size_t total_written = 0, blen;
 	struct evbuffer *evbuf;
+
+	if (written)
+		*written = 0;
 
 	evbuf = evhttp_request_get_input_buffer(req);
 	blen = evbuffer_get_length(evbuf);
@@ -500,15 +504,18 @@ int pv_event_rest_recv_chunk_path(struct evhttp_request *req, const char *path)
 	pv_log(TRACE, "recv chunk '%s': wrote %zu/%zu bytes", path,
 	       total_written, blen);
 	close(fd);
+	if (written)
+		*written = total_written;
 	return 0;
 }
 
-int pv_event_rest_recv_done_path(struct evhttp_request *req, const char *path)
+int pv_event_rest_recv_done_path(struct evhttp_request *req, const char *path,
+				 size_t *written)
 {
 	int ret;
 	off_t size;
 
-	if (pv_event_rest_recv_chunk_path(req, path)) {
+	if (pv_event_rest_recv_chunk_path(req, path, written)) {
 		pv_log(WARN, "could not finish transfer to path %s", path);
 		return -1;
 	}

--- a/event/event_rest.h
+++ b/event/event_rest.h
@@ -41,7 +41,9 @@ int pv_event_rest_send_by_url(enum evhttp_cmd_type op, const char *url,
 int pv_event_rest_recv_buffer(struct evhttp_request *req, char **buf,
 			      size_t max_len);
 
-int pv_event_rest_recv_chunk_path(struct evhttp_request *req, const char *path);
-int pv_event_rest_recv_done_path(struct evhttp_request *req, const char *path);
+int pv_event_rest_recv_chunk_path(struct evhttp_request *req, const char *path,
+				  size_t *written);
+int pv_event_rest_recv_done_path(struct evhttp_request *req, const char *path,
+				 size_t *written);
 
 #endif

--- a/pantahub/pantahub.c
+++ b/pantahub/pantahub.c
@@ -53,6 +53,8 @@
 #include "metadata.h"
 #include "updater.h"
 
+#include "update/update.h"
+
 #include "event/event.h"
 #include "event/event_rest.h"
 
@@ -811,6 +813,10 @@ static void _download_objects_cb(evutil_socket_t fd, short event, void *arg)
 		_next_state(PH_STATE_IDLE);
 		return;
 	}
+
+	// push the current byte counter to the trail-dir file and Hub, ~every
+	// REQ_INTERVAL seconds; skipped internally if no bytes moved
+	pv_update_report_download_progress();
 }
 
 static void _run_state_download()

--- a/pantahub/pantahub_proto.c
+++ b/pantahub/pantahub_proto.c
@@ -64,6 +64,7 @@ struct pv_progress {
 struct pv_object_transfer {
 	const char *id_ref;
 	bool active;
+	off_t received; // bytes received so far for this object
 	struct dl_list list; // struct pv_object_transfer
 };
 
@@ -756,40 +757,62 @@ int pv_pantahub_proto_get_objects_metadata()
 static void _recv_get_object_chunk_cb(struct evhttp_request *req, void *ctx)
 {
 	char path[PATH_MAX];
-	int res;
+	size_t written = 0;
 	const char *id_ref = (char *)ctx;
+	struct pv_object_transfer *o;
 
 	pv_log(TRACE, "run event: cb=%p", (void *)_recv_get_object_chunk_cb);
 
 	pv_storage_set_object_download_path(path, PATH_MAX, id_ref);
-	pv_event_rest_recv_chunk_path(req, path);
+	if (pv_event_rest_recv_chunk_path(req, path, &written))
+		return;
+
+	o = _search_object_transfer(id_ref);
+	if (o)
+		o->received += written;
+	pv_update_add_downloaded((off_t)written);
 }
 
 static void _recv_get_object_done_cb(struct evhttp_request *req, void *ctx)
 {
 	char path[PATH_MAX];
+	size_t written = 0;
 	int res;
 	const char *id_ref = (char *)ctx;
+	struct pv_object_transfer *o;
+	off_t received = 0;
 
 	pv_log(TRACE, "run event: cb=%p", (void *)_recv_get_object_done_cb);
 
+	pv_storage_set_object_download_path(path, PATH_MAX, id_ref);
+	res = pv_event_rest_recv_done_path(req, path, &written);
+
+	// account the final flush; read received before _remove frees the transfer
+	o = _search_object_transfer(id_ref);
+	if (o) {
+		o->received += written;
+		received = o->received;
+	}
+	pv_update_add_downloaded((off_t)written);
+
 	_remove_object_transfer(id_ref);
 
-	pv_storage_set_object_download_path(path, PATH_MAX, id_ref);
-	res = pv_event_rest_recv_done_path(req, path);
 	if (res == 401) {
-		pv_log(WARN, "GET object unauthorized", res);
+		pv_log(WARN, "GET object unauthorized");
 		_free_token();
+		pv_update_add_downloaded(-received); // roll back partial
 		goto out;
 	}
 	if (res != 200) {
 		pv_log(WARN, "GET object returned %d", res);
+		pv_update_add_downloaded(-received); // roll back partial
 		goto out;
 	}
 	pv_log(DEBUG, "object downloaded from Hub");
 
 	if (pv_update_install_object(path)) {
 		pv_log(WARN, "object download failed");
+		pv_update_add_downloaded(-received); // roll back partial
 		goto out;
 	}
 out:

--- a/update/update.c
+++ b/update/update.c
@@ -485,8 +485,6 @@ int pv_update_install_object(const char *in_path)
 		goto out;
 	}
 
-	pv_update_progress_add_downloaded(&u->progress, o->size);
-
 	ret = 0;
 
 	if (!pv_state_are_all_objects_installed(s))
@@ -500,6 +498,24 @@ out:
 	if (pv_update_is_final())
 		pv_update_finish();
 	return ret;
+}
+
+void pv_update_add_downloaded(off_t downloaded)
+{
+	struct pv_update *u = _get_update_instance();
+	if (!u)
+		return;
+
+	pv_update_progress_add_downloaded(&u->progress, downloaded);
+}
+
+void pv_update_report_download_progress(void)
+{
+	struct pv_update *u = _get_update_instance();
+	if (!u)
+		return;
+
+	pv_update_progress_report(&u->progress);
 }
 
 void pv_update_pre_install(const char *rev)

--- a/update/update.h
+++ b/update/update.h
@@ -35,6 +35,8 @@ void pv_update_set_object_metadata(const char *sha256sum, off_t size,
 void pv_update_get_unavailable_objects(char ***objects);
 char *pv_update_get_object_geturl(const char *sha256sum);
 int pv_update_install_object(const char *path);
+void pv_update_add_downloaded(off_t downloaded);
+void pv_update_report_download_progress(void);
 
 // LOCAL UPDATE
 

--- a/update/update_progress.c
+++ b/update/update_progress.c
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "config.h"
@@ -188,15 +189,17 @@ static void _set_progress(struct pv_update_progress *p)
 	}
 }
 
-static void _call_report_cb(struct pv_update_progress *p)
+static void _report(struct pv_update_progress *p, bool reload_logs)
 {
 	char *progress_str = NULL;
 
 	if (!p || !p->report_cb)
 		return;
 
-	// adding update logs from disk
-	_load_logs(p);
+	// adding update logs from disk (only change on failure paths, so the
+	// byte-progress cadence reuses the in-memory copy)
+	if (reload_logs)
+		_load_logs(p);
 	// this progress int does not mean anything, but it is still sent to Hub
 	_set_progress(p);
 
@@ -415,7 +418,7 @@ void pv_update_progress_set(struct pv_update_progress *p,
 		free(p->msg);
 	p->msg = _ser_update_progress_msg(p, code);
 
-	_call_report_cb(p);
+	_report(p, true);
 }
 
 void pv_update_progress_set_str(struct pv_update_progress *p,
@@ -442,7 +445,7 @@ void pv_update_progress_set_str(struct pv_update_progress *p,
 		free(p->msg);
 	p->msg = msg;
 
-	_call_report_cb(p);
+	_report(p, true);
 }
 
 void pv_update_progress_start_record(struct pv_update_progress *p)
@@ -459,7 +462,7 @@ void pv_update_progress_start_record(struct pv_update_progress *p)
 
 	p->total.size = 0;
 
-	_call_report_cb(p);
+	_report(p, true);
 }
 
 void pv_update_progress_add_size(struct pv_update_progress *p, off_t size)
@@ -491,10 +494,11 @@ void pv_update_progress_start_download(struct pv_update_progress *p)
 		p, PV_UPDATE_PROGRESS_MSG_DOWNLOAD_PROGRESS);
 
 	p->total.downloaded = 0;
+	p->total.reported = 0;
 	p->total.start_time = time(NULL);
 	p->total.current_time = time(NULL);
 
-	_call_report_cb(p);
+	_report(p, true);
 }
 
 void pv_update_progress_add_downloaded(struct pv_update_progress *p,
@@ -503,10 +507,24 @@ void pv_update_progress_add_downloaded(struct pv_update_progress *p,
 	if (!p)
 		return;
 
+	// pure in-memory accounting; reporting is driven by the periodic
+	// download heartbeat via pv_update_progress_report()
 	p->total.downloaded += downloaded;
 	p->total.current_time = time(NULL);
+}
 
-	_call_report_cb(p);
+void pv_update_progress_report(struct pv_update_progress *p)
+{
+	if (!p)
+		return;
+
+	// nothing new since last push
+	if (p->total.downloaded == p->total.reported)
+		return;
+
+	p->total.reported = p->total.downloaded;
+	// reuse in-memory logs; they only change on failure paths
+	_report(p, false);
 }
 
 void pv_update_progress_reload_logs(struct pv_update_progress *p)
@@ -520,5 +538,5 @@ void pv_update_progress_reload_logs(struct pv_update_progress *p)
 	if (!pv_fs_path_exist(path))
 		return;
 
-	_call_report_cb(p);
+	_report(p, true);
 }

--- a/update/update_progress.h
+++ b/update/update_progress.h
@@ -43,6 +43,7 @@ off_t pv_update_progress_get_size(struct pv_update_progress *p);
 void pv_update_progress_start_download(struct pv_update_progress *p);
 void pv_update_progress_add_downloaded(struct pv_update_progress *p,
 				       off_t downloaded);
+void pv_update_progress_report(struct pv_update_progress *p);
 
 void pv_update_progress_reload_logs(struct pv_update_progress *p);
 

--- a/update/update_struct.h
+++ b/update/update_struct.h
@@ -76,6 +76,7 @@ typedef enum {
 struct pv_download_info {
 	off_t size;
 	off_t downloaded;
+	off_t reported;
 	off_t start_time;
 	off_t current_time;
 };


### PR DESCRIPTION
## Problem

Pantavisor reports OTA download progress to Pantacor Hub (and the local trail-dir
`.pv/progress` file) via the step `progress` JSON. In the Hub UI the download bar
barely moves — it updates only 2–3 times over an entire multi-minute download,
then jumps to done.

**Root cause:** byte-accounting was coupled to *whole-object completion*, not to
bytes arriving. `_recv_get_object_chunk_cb` wrote each chunk to disk but reported
nothing; only `_recv_get_object_done_cb` (once per object) added the whole object
size via `pv_update_progress_add_downloaded(o->size)`. A pantavisor update is
dominated by a few large objects, so a big object downloading for minutes produced
**zero** intermediate updates.

## Change: decouple accounting from reporting

- **Accounting** (per chunk) is a pure in-memory increment — no serialize, no
  disk, no PUT on the hot path. Bytes are tracked **per transfer** in
  `pantahub_proto` and **rolled back** if an object fails/retries, so the counter
  can never exceed `total_size`.
- **Reporting** (serialize → trail-dir file → coalesced Hub PUT) is driven by the
  existing 6s download heartbeat (`REQ_INTERVAL`) in `_download_objects_cb` via
  `pv_update_report_progress()`, and is skipped when no bytes moved. Status-change
  reports still reload logs; the byte cadence reuses the in-memory copy.
- The whole-object add in `pv_update_install_object` is **removed** — per-chunk
  received bytes already sum to the object size, so keeping it would double count.
- `event_rest` recv helpers gain a `size_t *written` out-param so callers can feed
  arriving bytes into accounting.

No new config key or on-disk structure: `downloads.total.total_downloaded` already
rides in the one shared progress blob written to both the trail-dir file and the Hub.

## Result

`total_downloaded` now climbs smoothly (~every 6s) through even a single large
object, and is accurate across retries.

**Validated on device (opi3_hyena):** a 73.6 MB multi-object update reported
continuous progress instead of jumping only at object boundaries:

```
dl=0 → 20.8MB → 42.7MB → 53.9MB → 63.7MB → 71.6MB  (of 73.6MB), ~6–7s apart → DONE
```

## Touched files

`event/event_rest.{c,h}`, `pantahub/pantahub.c`, `pantahub/pantahub_proto.c`,
`update/update.{c,h}`, `update/update_progress.{c,h}`, `update/update_struct.h`
