### PR TITLE
fix(ci): scope on-push workflow to master/pull_request, exclude tag pushes

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -2,6 +2,15 @@ name: "On push: Raspberry Pi ARMv8"
 
 on:
   push:
+    branches:
+      - master
+    paths:
+      - "**"
+      - ".github/configs/**"
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - "*"
     paths:
       - "**"
       - ".github/configs/**"


### PR DESCRIPTION
The `on-push.yaml` workflow was triggering on **every** push, including tag pushes (which also trigger the `ontag` changelog workflow) and pushes to any branch.

**Changes:**
- `push:` is now scoped to `branches: [master]` — tag pushes no longer trigger this workflow
- Added `pull_request: types: [opened, synchronize]` — triggers on PR open and new commits to the PR branch, but not on the initial branch push (avoids the double trigger when creating a PR)

**Trigger behavior:**

| Event | Before | After |
|-------|--------|-------|
| Push to feature branch | ✅ triggers | ❌ no trigger |
| PR opened | ❌ no trigger | ✅ triggers once |
| New commits to PR branch | ✅ triggers | ✅ triggers (`synchronize`) |
| Push to master | ✅ triggers | ✅ triggers |
| Tag push (ontag) | ✅ triggers (unwanted) | ❌ no trigger |