### PR TITLE
feat(ctrl): add synchronous /storage/gc and unclaim commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ add_executable(pantavisor
 			ctrl/ctrl_objects_ep.c
 			ctrl/ctrl_signal_ep.c
 			ctrl/ctrl_steps_ep.c
+			ctrl/ctrl_storage_ep.c
 			ctrl/ctrl_upload.c
 			ctrl/ctrl_upload.h
 			ctrl/ctrl_usrmeta_ep.c

--- a/ctrl/ctrl.c
+++ b/ctrl/ctrl.c
@@ -282,6 +282,7 @@ static void ctrl_add_endpoints()
 	pv_ctrl_endpoints_config_init();
 	pv_ctrl_endpoints_xconnect_graph_init();
 	pv_ctrl_endpoints_daemons_init();
+	pv_ctrl_endpoints_storage_init();
 }
 
 int pv_ctrl_start()

--- a/ctrl/ctrl_cmd.c
+++ b/ctrl/ctrl_cmd.c
@@ -107,7 +107,7 @@ struct pv_ctrl_cmd_add_result pv_ctrl_cmd_add(struct pv_ctrl_cmd *cmd)
 	    ((cmd->op == CMD_REBOOT_DEVICE) ||
 	     (cmd->op == CMD_POWEROFF_DEVICE) || (cmd->op == CMD_LOCAL_RUN) ||
 	     (cmd->op == CMD_LOCAL_RUN_COMMIT) ||
-	     (cmd->op == CMD_MAKE_FACTORY))) {
+	     (cmd->op == CMD_MAKE_FACTORY) || (cmd->op == CMD_UNCLAIM))) {
 		return (struct pv_ctrl_cmd_add_result){
 			false,
 			HTTP_SERVUNAVAIL,
@@ -154,6 +154,15 @@ struct pv_ctrl_cmd_add_result pv_ctrl_cmd_add(struct pv_ctrl_cmd *cmd)
 			HTTP_NOCONTENT,
 			-1,
 			"Already in remote mode",
+		};
+	}
+
+	if (pv->unclaimed && cmd->op == CMD_UNCLAIM) {
+		return (struct pv_ctrl_cmd_add_result){
+			false,
+			HTTP_NOCONTENT,
+			-1,
+			"Device is already unclaimed",
 		};
 	}
 

--- a/ctrl/ctrl_cmd.h
+++ b/ctrl/ctrl_cmd.h
@@ -44,6 +44,7 @@ enum pv_ctrl_cmd_op {
 	CMD_LOCAL_RUN_COMMIT = 12,
 	CMD_LOCAL_APPLY = 13,
 	CMD_XCONNECT_GRAPH = 14,
+	CMD_UNCLAIM = 15,
 	MAX_CMD_OP
 };
 
@@ -77,6 +78,7 @@ static inline const char *pv_ctrl_cmd_op_to_str(const enum pv_ctrl_cmd_op op)
 		"LOCAL_RUN_COMMIT",
 		"LOCAL_APPLY",
 		"XCONNECT_GRAPH",
+		"UNCLAIM",
 	};
 	return strings[op];
 }

--- a/ctrl/ctrl_endpoints.h
+++ b/ctrl/ctrl_endpoints.h
@@ -36,5 +36,6 @@ int pv_ctrl_endpoints_commands_init(void);
 int pv_ctrl_endpoints_config_init(void);
 int pv_ctrl_endpoints_xconnect_graph_init(void);
 int pv_ctrl_endpoints_daemons_init(void);
+int pv_ctrl_endpoints_storage_init(void);
 
 #endif

--- a/ctrl/ctrl_storage_ep.c
+++ b/ctrl/ctrl_storage_ep.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ctrl_endpoints.h"
+#include "ctrl.h"
+#include "ctrl_util.h"
+#include "storage.h"
+
+#include <event2/http.h>
+#include <event2/buffer.h>
+
+#define MODULE_NAME "storage-ep"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#include "log.h"
+
+static void ctrl_storage_gc(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0) {
+		pv_ctrl_utils_drain_req(req);
+		return;
+	}
+
+	int reclaimed = pv_storage_gc_run();
+	if (reclaimed < 0) {
+		pv_ctrl_utils_send_error(req, HTTP_INTERNAL,
+					 "Error running garbage collector");
+		return;
+	}
+
+	struct evbuffer *buf = evhttp_request_get_output_buffer(req);
+	if (!buf) {
+		pv_log(WARN, "couldn't get output buffer");
+		pv_ctrl_utils_send_error(
+			req, HTTP_INTERNAL,
+			"Error sending garbage collector result");
+		return;
+	}
+
+	evhttp_add_header(evhttp_request_get_output_headers(req),
+			  "Content-Type", "application/json");
+	evbuffer_add_printf(buf, "{\"reclaimed\": %d}", reclaimed);
+	evhttp_send_reply(req, HTTP_OK, NULL, NULL);
+}
+
+int pv_ctrl_endpoints_storage_init()
+{
+	pv_ctrl_add_endpoint("/storage/gc", EVHTTP_REQ_POST, true,
+			     ctrl_storage_gc);
+
+	return 0;
+}

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -136,6 +136,17 @@ These are the different commands that are supported. You can test them by substi
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
 
+## /storage
+
+This endpoint groups [storage](../overview/storage.md) related operations.
+
+To run the [garbage collector](../overview/storage.md#garbage-collector) synchronously. Unlike the RUN_GC [command](#commands), which is queued and executed at some later point by the state machine, the response is sent back once the collection has finished and reports the number of bytes reclaimed from orphaned objects:
+
+```
+$ curl -X POST --unix-socket /pantavisor/pv-ctrl "http://localhost/storage/gc"
+{"reclaimed": 8646656}
+```
+
 ## /objects
 
 This endpoint can be used to list, send and receive objects to and from Pantavisor. Bear in mind that objects are the artifacts that form a Pantavisor revision.

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -135,6 +135,7 @@ These are the different commands that are supported. You can test them by substi
 | LOCAL_RUN_COMMIT | revision | transition to revision and commit it automatically |
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
+| UNCLAIM | N/A | remove Pantacor Hub credentials so the device registers and becomes claimable again, without a reboot |
 
 ## /storage
 

--- a/docs/reference/pantavisor-tools.md
+++ b/docs/reference/pantavisor-tools.md
@@ -94,6 +94,9 @@ pvcontrol cmd poweroff [message]
 pvcontrol cmd run-gc                 # trigger garbage collection
 pvcontrol cmd enable-ssh             # start SSH server until next reboot
 
+# Garbage collector (synchronous, reports reclaimed bytes)
+pvcontrol storage gc
+
 # Metadata
 pvcontrol devmeta ls
 pvcontrol devmeta save <key> <value>

--- a/docs/reference/pantavisor-tools.md
+++ b/docs/reference/pantavisor-tools.md
@@ -93,6 +93,7 @@ pvcontrol cmd reboot [message]
 pvcontrol cmd poweroff [message]
 pvcontrol cmd run-gc                 # trigger garbage collection
 pvcontrol cmd enable-ssh             # start SSH server until next reboot
+pvcontrol cmd unclaim                # remove Hub credentials, device becomes claimable again
 
 # Garbage collector (synchronous, reports reclaimed bytes)
 pvcontrol storage gc

--- a/docs/reference/pvcontrol.md
+++ b/docs/reference/pvcontrol.md
@@ -284,6 +284,7 @@ pvcontrol cmd disable-ssh
 
 # Remote / debug
 pvcontrol cmd go-remote                    # go remote from a locals/ revision (if config allows)
+pvcontrol cmd unclaim                      # remove Hub credentials; device re-registers and becomes claimable again
 pvcontrol cmd defer-reboot <new_timeout>   # defer a pending debug-shell reboot
 ```
 

--- a/docs/reference/pvcontrol.md
+++ b/docs/reference/pvcontrol.md
@@ -295,6 +295,20 @@ already in progress.
 
 ---
 
+## Storage
+
+`pvcontrol storage gc` runs the garbage collector synchronously via
+`POST /storage/gc`. Unlike `cmd run-gc` — which only queues the command for
+the state machine — the call returns once the collection has finished,
+reporting the bytes reclaimed from orphaned objects:
+
+```console
+$ pvcontrol storage gc
+{"reclaimed": 8646656}
+```
+
+---
+
 ## Objects
 
 Content-addressed blobs in the object store, keyed by SHA256.
@@ -454,6 +468,7 @@ On a platform without managed drivers these are effectively no-ops returning
 | `graph ls` | GET | `/xconnect-graph` |
 | `signal ready\|alive` | POST | `/signal` |
 | `cmd <subcommand>` | POST | `/commands` |
+| `storage gc` | POST | `/storage/gc` |
 | `devmeta ls` | GET | `/device-meta` |
 | `devmeta save\|delete <key>` | PUT / DELETE | `/device-meta/{key}` |
 | `usrmeta ls` | GET | `/user-meta` |

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -678,6 +678,31 @@ static pv_state_t _pv_command(struct pantavisor *pv)
 		pv->remote_mode = true;
 		pv_metadata_add_devmeta(DEVMETA_KEY_PV_MODE, "remote");
 		break;
+	case CMD_UNCLAIM:
+		if (pv->unclaimed) {
+			pv_log(WARN,
+			       "ignoring unclaim command because device is already unclaimed");
+			goto out;
+		}
+
+		if (pv->update) {
+			pv_log(WARN,
+			       "ignoring unclaim command because an update is in progress");
+			goto out;
+		}
+
+		pv_log(DEBUG,
+		       "unclaim command received. Removing credentials...");
+		pv_config_set_creds_prn("");
+		pv_config_set_creds_id("");
+		pv_config_set_creds_secret("");
+		// still claimed at this point, so this saves to pantahub.config
+		if (pv_config_save_creds())
+			pv_log(WARN, "could not remove credentials from disk");
+		pv->unclaimed = true;
+		pv_pantahub_stop();
+		pv_metadata_rm_devmeta("pantahub.claimed");
+		break;
 	case CMD_DEFER_REBOOT:
 		if (!pv_config_get_bool(PV_DEBUG_SHELL)) {
 			pv_log(WARN,

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -42,7 +42,7 @@ OUTPUT=""
 MESSAGE=""
 
 usage() {
-	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons> [arguments]"
+	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons|storage> [arguments]"
 	echo "Control Pantavisor from your container"
 	echo "options:"
 	echo "       -h           show help"
@@ -104,6 +104,12 @@ usage_usrmeta() {
 usage_buildinfo() {
 	echo "Usage: pvcontrol buildinfo"
 	echo "Dump Pantavisor build info"
+}
+
+usage_storage() {
+	echo "Usage: pvcontrol storage <gc>"
+	echo "Storage related operations"
+	echo "       pvcontrol storage gc - run garbage collector synchronously and report reclaimed bytes"
 }
 
 usage_objects() {
@@ -317,6 +323,20 @@ parse_buildinfo_args() {
 		;;
 	*)
 		usage_buildinfo; exit 1
+		;;
+	esac
+}
+
+parse_storage_args() {
+	case "$1" in
+	gc)
+		cmd='storagegc'
+		;;
+	--help)
+		usage_storage; exit 0
+		;;
+	*)
+		usage_storage; exit 1
 		;;
 	esac
 }
@@ -557,6 +577,9 @@ parse_args() {
 	daemons)
 		parse_daemons_args "$2" "$3"
 		;;
+	storage)
+		parse_storage_args "$2"
+		;;
 	--help)
 		usage; exit 0
 		;;
@@ -715,6 +738,9 @@ exec_cmd() {
 			;;
 		dumpbuildinfo)
 			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/buildinfo"`
+			;;
+		storagegc)
+			response=`$CURL -X POST --unix-socket "$SOCKET" "http://localhost/storage/gc"`
 			;;
 		putobject)
 			put_object "$path" "$sha"

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -71,7 +71,7 @@ usage_signal() {
 }
 
 usage_command() {
-	echo "Usage: pvcontrol cmd <run|poweroff|reboot|run-gc|make-factory|enable-ssh|disable-ssh|go-remote> [arguments]"
+	echo "Usage: pvcontrol cmd <run|poweroff|reboot|run-gc|make-factory|enable-ssh|disable-ssh|go-remote|unclaim> [arguments]"
 	echo "Send command to the Pantavisor state machine"
 	echo "       pvcontrol cmd run <locals/revision|revision> 			- runs an installed step"
 	echo "       pvcontrol cmd run-commit <locals/revision|revision>		- runs and commit an installed step"
@@ -82,6 +82,7 @@ usage_command() {
 	echo "       pvcontrol cmd enable-ssh                     			- start SSH server ignoring config until reboot"
 	echo "       pvcontrol cmd disable-ssh                    			- stops SSH server ignoring config until reboot"
 	echo "       pvcontrol cmd go-remote                      			- go remote when running on a locals/ revision if allowed by config"
+	echo "       pvcontrol cmd unclaim                        			- remove Pantacor Hub credentials and make the device claimable again"
 	echo "       pvcontrol cmd defer-reboot [new_timeout]     			- when debug shell is enabled and a reboot is issue, it will defer reboot to a new timeout"
 }
 
@@ -248,6 +249,9 @@ parse_command_args() {
 		;;
 	go-remote)
 		cmd='goremote'
+		;;
+	unclaim)
+		cmd='unclaim'
 		;;
 	defer-reboot)
 		if [ -z "$2" ]; then usage_command; exit 1; fi
@@ -714,6 +718,9 @@ exec_cmd() {
 			;;
 		goremote)
 			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"GO_REMOTE\",\"payload\":\"\"}" --unix-socket "$SOCKET" http://localhost/commands`
+			;;
+		unclaim)
+			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"UNCLAIM\",\"payload\":\"\"}" --unix-socket "$SOCKET" http://localhost/commands`
 			;;
 		deferreboot)
 			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"DEFER_REBOOT\",\"payload\":\"$timeout\"}" --unix-socket "$SOCKET" http://localhost/commands`


### PR DESCRIPTION
## Summary
Two small ctrl API additions, pulled out of the pvtest-device-target work where they're used, since they're generic and independently useful.

## Changes
- `POST /storage/gc`: synchronous garbage-collect endpoint (`ctrl_storage_ep.c`), plus `pvcontrol storage gc`
- `cmd unclaim`: strips Hub credentials from the live config so the device walks idle→register→claim on its own, no reboot required; plus `pvcontrol cmd unclaim`