### PR TITLE
fix(ctrl): log rejected go-remote command when already in remote mode

### DIFF
--- a/ctrl/ctrl_cmd.c
+++ b/ctrl/ctrl_cmd.c
@@ -149,6 +149,9 @@ struct pv_ctrl_cmd_add_result pv_ctrl_cmd_add(struct pv_ctrl_cmd *cmd)
 	}
 
 	if (pv->remote_mode && cmd->op == CMD_GO_REMOTE) {
+		pv_log(WARN,
+		       "rejecting go-remote command: already in remote mode");
+
 		return (struct pv_ctrl_cmd_add_result){
 			false,
 			HTTP_NOCONTENT,


### PR DESCRIPTION
## Summary
A rejected go-remote command (already in remote mode) was silent — no log line to explain the 503. Adds a WARN so it's visible when triaging pvtest runs.