### PR TITLE
feat(ctrl): add unclaim command

### DIFF
--- a/ctrl/ctrl_cmd.c
+++ b/ctrl/ctrl_cmd.c
@@ -107,7 +107,7 @@ struct pv_ctrl_cmd_add_result pv_ctrl_cmd_add(struct pv_ctrl_cmd *cmd)
 	    ((cmd->op == CMD_REBOOT_DEVICE) ||
 	     (cmd->op == CMD_POWEROFF_DEVICE) || (cmd->op == CMD_LOCAL_RUN) ||
 	     (cmd->op == CMD_LOCAL_RUN_COMMIT) ||
-	     (cmd->op == CMD_MAKE_FACTORY))) {
+	     (cmd->op == CMD_MAKE_FACTORY) || (cmd->op == CMD_UNCLAIM))) {
 		return (struct pv_ctrl_cmd_add_result){
 			false,
 			HTTP_SERVUNAVAIL,
@@ -154,6 +154,16 @@ struct pv_ctrl_cmd_add_result pv_ctrl_cmd_add(struct pv_ctrl_cmd *cmd)
 			HTTP_NOCONTENT,
 			-1,
 			"Already in remote mode",
+		};
+	}
+
+	if (pv->unclaimed && cmd->op == CMD_UNCLAIM) {
+		pv_log(WARN, "rejecting unclaim command: already unclaimed");
+		return (struct pv_ctrl_cmd_add_result){
+			false,
+			HTTP_NOCONTENT,
+			-1,
+			"Device is already unclaimed",
 		};
 	}
 

--- a/ctrl/ctrl_cmd.h
+++ b/ctrl/ctrl_cmd.h
@@ -44,6 +44,7 @@ enum pv_ctrl_cmd_op {
 	CMD_LOCAL_RUN_COMMIT = 12,
 	CMD_LOCAL_APPLY = 13,
 	CMD_XCONNECT_GRAPH = 14,
+	CMD_UNCLAIM = 15,
 	MAX_CMD_OP
 };
 
@@ -77,6 +78,7 @@ static inline const char *pv_ctrl_cmd_op_to_str(const enum pv_ctrl_cmd_op op)
 		"LOCAL_RUN_COMMIT",
 		"LOCAL_APPLY",
 		"XCONNECT_GRAPH",
+		"UNCLAIM",
 	};
 	return strings[op];
 }

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -135,6 +135,7 @@ These are the different commands that are supported. You can test them by substi
 | LOCAL_RUN_COMMIT | revision | transition to revision and commit it automatically |
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
+| UNCLAIM | N/A | remove Pantacor Hub credentials so the device registers and becomes claimable again, without a reboot |
 
 ## /objects
 

--- a/docs/reference/pantavisor-tools.md
+++ b/docs/reference/pantavisor-tools.md
@@ -93,6 +93,7 @@ pvcontrol cmd reboot [message]
 pvcontrol cmd poweroff [message]
 pvcontrol cmd run-gc                 # trigger garbage collection
 pvcontrol cmd enable-ssh             # start SSH server until next reboot
+pvcontrol cmd unclaim                # remove Hub credentials, device becomes claimable again
 
 # Metadata
 pvcontrol devmeta ls

--- a/docs/reference/pvcontrol.md
+++ b/docs/reference/pvcontrol.md
@@ -284,6 +284,7 @@ pvcontrol cmd disable-ssh
 
 # Remote / debug
 pvcontrol cmd go-remote                    # go remote from a locals/ revision (if config allows)
+pvcontrol cmd unclaim                      # remove Hub credentials; device re-registers and becomes claimable again
 pvcontrol cmd defer-reboot <new_timeout>   # defer a pending debug-shell reboot
 ```
 

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -678,6 +678,31 @@ static pv_state_t _pv_command(struct pantavisor *pv)
 		pv->remote_mode = true;
 		pv_metadata_add_devmeta(DEVMETA_KEY_PV_MODE, "remote");
 		break;
+	case CMD_UNCLAIM:
+		if (pv->unclaimed) {
+			pv_log(WARN,
+			       "ignoring unclaim command because device is already unclaimed");
+			goto out;
+		}
+
+		if (pv->update) {
+			pv_log(WARN,
+			       "ignoring unclaim command because an update is in progress");
+			goto out;
+		}
+
+		pv_log(DEBUG,
+		       "unclaim command received. Removing credentials...");
+		pv_config_set_creds_prn("");
+		pv_config_set_creds_id("");
+		pv_config_set_creds_secret("");
+		// still claimed at this point, so this saves to pantahub.config
+		if (pv_config_save_creds())
+			pv_log(WARN, "could not remove credentials from disk");
+		pv->unclaimed = true;
+		pv_pantahub_stop();
+		pv_metadata_rm_devmeta("pantahub.claimed");
+		break;
 	case CMD_DEFER_REBOOT:
 		if (!pv_config_get_bool(PV_DEBUG_SHELL)) {
 			pv_log(WARN,

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -71,7 +71,7 @@ usage_signal() {
 }
 
 usage_command() {
-	echo "Usage: pvcontrol cmd <run|poweroff|reboot|run-gc|make-factory|enable-ssh|disable-ssh|go-remote> [arguments]"
+	echo "Usage: pvcontrol cmd <run|poweroff|reboot|run-gc|make-factory|enable-ssh|disable-ssh|go-remote|unclaim> [arguments]"
 	echo "Send command to the Pantavisor state machine"
 	echo "       pvcontrol cmd run <locals/revision|revision> 			- runs an installed step"
 	echo "       pvcontrol cmd run-commit <locals/revision|revision>		- runs and commit an installed step"
@@ -82,6 +82,7 @@ usage_command() {
 	echo "       pvcontrol cmd enable-ssh                     			- start SSH server ignoring config until reboot"
 	echo "       pvcontrol cmd disable-ssh                    			- stops SSH server ignoring config until reboot"
 	echo "       pvcontrol cmd go-remote                      			- go remote when running on a locals/ revision if allowed by config"
+	echo "       pvcontrol cmd unclaim                        			- remove Pantacor Hub credentials and make the device claimable again"
 	echo "       pvcontrol cmd defer-reboot [new_timeout]     			- when debug shell is enabled and a reboot is issue, it will defer reboot to a new timeout"
 }
 
@@ -242,6 +243,9 @@ parse_command_args() {
 		;;
 	go-remote)
 		cmd='goremote'
+		;;
+	unclaim)
+		cmd='unclaim'
 		;;
 	defer-reboot)
 		if [ -z "$2" ]; then usage_command; exit 1; fi
@@ -691,6 +695,9 @@ exec_cmd() {
 			;;
 		goremote)
 			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"GO_REMOTE\",\"payload\":\"\"}" --unix-socket "$SOCKET" http://localhost/commands`
+			;;
+		unclaim)
+			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"UNCLAIM\",\"payload\":\"\"}" --unix-socket "$SOCKET" http://localhost/commands`
 			;;
 		deferreboot)
 			response=`$CURL -X POST --header "Content-Type: application/json" --data "{\"op\":\"DEFER_REBOOT\",\"payload\":\"$timeout\"}" --unix-socket "$SOCKET" http://localhost/commands`


### PR DESCRIPTION
## Summary
Small ctrl API addition, pulled out of the pvtest-device-target work where it's used, since it's generic and independently useful.

## Changes
- `cmd unclaim`: strips Hub credentials from the live config so the device walks idle→register→claim on its own, no reboot required
- `pvcontrol cmd unclaim`