### PR TITLE
feat(ctrl): add synchronous /storage/gc endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ add_executable(pantavisor
 			ctrl/ctrl_objects_ep.c
 			ctrl/ctrl_signal_ep.c
 			ctrl/ctrl_steps_ep.c
+			ctrl/ctrl_storage_ep.c
 			ctrl/ctrl_upload.c
 			ctrl/ctrl_upload.h
 			ctrl/ctrl_usrmeta_ep.c

--- a/ctrl/ctrl.c
+++ b/ctrl/ctrl.c
@@ -282,6 +282,7 @@ static void ctrl_add_endpoints()
 	pv_ctrl_endpoints_config_init();
 	pv_ctrl_endpoints_xconnect_graph_init();
 	pv_ctrl_endpoints_daemons_init();
+	pv_ctrl_endpoints_storage_init();
 }
 
 int pv_ctrl_start()

--- a/ctrl/ctrl_endpoints.h
+++ b/ctrl/ctrl_endpoints.h
@@ -36,5 +36,6 @@ int pv_ctrl_endpoints_commands_init(void);
 int pv_ctrl_endpoints_config_init(void);
 int pv_ctrl_endpoints_xconnect_graph_init(void);
 int pv_ctrl_endpoints_daemons_init(void);
+int pv_ctrl_endpoints_storage_init(void);
 
 #endif

--- a/ctrl/ctrl_storage_ep.c
+++ b/ctrl/ctrl_storage_ep.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ctrl_endpoints.h"
+#include "ctrl.h"
+#include "ctrl_util.h"
+#include "storage.h"
+
+#include <event2/http.h>
+#include <event2/buffer.h>
+
+#define MODULE_NAME "storage-ep"
+#define pv_log(level, msg, ...) vlog(MODULE_NAME, level, msg, ##__VA_ARGS__)
+#include "log.h"
+
+static void ctrl_storage_gc(struct evhttp_request *req, void *ctx)
+{
+	if (pv_ctrl_utils_is_req_ok(req, ctx, NULL) != 0) {
+		pv_ctrl_utils_drain_req(req);
+		return;
+	}
+
+	int reclaimed = pv_storage_gc_run();
+	if (reclaimed < 0) {
+		pv_ctrl_utils_send_error(req, HTTP_INTERNAL,
+					 "Error running garbage collector");
+		return;
+	}
+
+	struct evbuffer *buf = evhttp_request_get_output_buffer(req);
+	if (!buf) {
+		pv_log(WARN, "couldn't get output buffer");
+		pv_ctrl_utils_send_error(
+			req, HTTP_INTERNAL,
+			"Error sending garbage collector result");
+		return;
+	}
+
+	evhttp_add_header(evhttp_request_get_output_headers(req),
+			  "Content-Type", "application/json");
+	evbuffer_add_printf(buf, "{\"reclaimed\": %d}", reclaimed);
+	evhttp_send_reply(req, HTTP_OK, NULL, NULL);
+}
+
+int pv_ctrl_endpoints_storage_init()
+{
+	pv_ctrl_add_endpoint("/storage/gc", EVHTTP_REQ_POST, true,
+			     ctrl_storage_gc);
+
+	return 0;
+}

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -136,6 +136,17 @@ These are the different commands that are supported. You can test them by substi
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
 
+## /storage
+
+This endpoint groups [storage](../overview/storage.md) related operations.
+
+To run the [garbage collector](../overview/storage.md#garbage-collector) synchronously. Unlike the RUN_GC [command](#commands), which is queued and executed at some later point by the state machine, the response is sent back once the collection has finished and reports the number of bytes reclaimed from orphaned objects:
+
+```
+$ curl -X POST --unix-socket /pantavisor/pv-ctrl "http://localhost/storage/gc"
+{"reclaimed": 8646656}
+```
+
 ## /objects
 
 This endpoint can be used to list, send and receive objects to and from Pantavisor. Bear in mind that objects are the artifacts that form a Pantavisor revision.

--- a/docs/reference/pantavisor-tools.md
+++ b/docs/reference/pantavisor-tools.md
@@ -94,6 +94,9 @@ pvcontrol cmd poweroff [message]
 pvcontrol cmd run-gc                 # trigger garbage collection
 pvcontrol cmd enable-ssh             # start SSH server until next reboot
 
+# Garbage collector (synchronous, reports reclaimed bytes)
+pvcontrol storage gc
+
 # Metadata
 pvcontrol devmeta ls
 pvcontrol devmeta save <key> <value>

--- a/docs/reference/pvcontrol.md
+++ b/docs/reference/pvcontrol.md
@@ -295,6 +295,20 @@ already in progress.
 
 ---
 
+## Storage
+
+`pvcontrol storage gc` runs the garbage collector synchronously via
+`POST /storage/gc`. Unlike `cmd run-gc` — which only queues the command for
+the state machine — the call returns once the collection has finished,
+reporting the bytes reclaimed from orphaned objects:
+
+```console
+$ pvcontrol storage gc
+{"reclaimed": 8646656}
+```
+
+---
+
 ## Objects
 
 Content-addressed blobs in the object store, keyed by SHA256.
@@ -454,6 +468,7 @@ On a platform without managed drivers these are effectively no-ops returning
 | `graph ls` | GET | `/xconnect-graph` |
 | `signal ready\|alive` | POST | `/signal` |
 | `cmd <subcommand>` | POST | `/commands` |
+| `storage gc` | POST | `/storage/gc` |
 | `devmeta ls` | GET | `/device-meta` |
 | `devmeta save\|delete <key>` | PUT / DELETE | `/device-meta/{key}` |
 | `usrmeta ls` | GET | `/user-meta` |

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -42,7 +42,7 @@ OUTPUT=""
 MESSAGE=""
 
 usage() {
-	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons> [arguments]"
+	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons|storage> [arguments]"
 	echo "Control Pantavisor from your container"
 	echo "options:"
 	echo "       -h           show help"
@@ -104,6 +104,12 @@ usage_usrmeta() {
 usage_buildinfo() {
 	echo "Usage: pvcontrol buildinfo"
 	echo "Dump Pantavisor build info"
+}
+
+usage_storage() {
+	echo "Usage: pvcontrol storage <gc>"
+	echo "Storage related operations"
+	echo "       pvcontrol storage gc - run garbage collector synchronously and report reclaimed bytes"
 }
 
 usage_objects() {
@@ -317,6 +323,20 @@ parse_buildinfo_args() {
 		;;
 	*)
 		usage_buildinfo; exit 1
+		;;
+	esac
+}
+
+parse_storage_args() {
+	case "$1" in
+	gc)
+		cmd='storagegc'
+		;;
+	--help)
+		usage_storage; exit 0
+		;;
+	*)
+		usage_storage; exit 1
 		;;
 	esac
 }
@@ -557,6 +577,9 @@ parse_args() {
 	daemons)
 		parse_daemons_args "$2" "$3"
 		;;
+	storage)
+		parse_storage_args "$2"
+		;;
 	--help)
 		usage; exit 0
 		;;
@@ -715,6 +738,9 @@ exec_cmd() {
 			;;
 		dumpbuildinfo)
 			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/buildinfo"`
+			;;
+		storagegc)
+			response=`$CURL -X POST --unix-socket "$SOCKET" "http://localhost/storage/gc"`
 			;;
 		putobject)
 			put_object "$path" "$sha"


### PR DESCRIPTION
## Summary
Small ctrl API addition, pulled out of the pvtest-device-target work where it's used, since it's generic and independently useful.

## Changes
- `POST /storage/gc`: synchronous garbage-collect endpoint (`ctrl_storage_ep.c`) inspired by drivers load/unload, replies only once collection has finished
- `pvcontrol storage gc`