### PR TITLE
fix(ci): checkout the PR's actual head commit, not GitHub's synthetic merge SHA

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -44,7 +44,7 @@ jobs:
           repository: pantavisor/meta-pantavisor
 
       - name: debug
-        run: echo "Pantavisor ref - ${{ github.sha }}"
+        run: echo "Pantavisor ref - ${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: chown
         run: chown -R builder:builder $RUNNER_WORKSPACE
@@ -56,7 +56,7 @@ jobs:
       - name: Build Kas
         run:
           su - builder -c "cd $GITHUB_WORKSPACE && kas shell ${{ env.configs }}  -c 'devtool modify pantavisor &&
-          cd workspace/sources/pantavisor && git fetch && git checkout ${{ github.sha }} && bitbake -c compile pantavisor' "
+          cd workspace/sources/pantavisor && git fetch && git checkout ${{ github.event.pull_request.head.sha || github.sha }} && bitbake -c compile pantavisor' "
 
   summary:
     needs: build


### PR DESCRIPTION
## Summary
Every pull_request-triggered build in this repo fails at "Build Kas" with `fatal: reference is not a tree: <sha>`. `github.sha` on a `pull_request` event is GitHub's synthetic merge-commit SHA (`refs/pull/N/merge`), not a commit on the PR branch — and the devtool-cloned pantavisor source tree's plain `git fetch` never pulls that ref, so the checkout always fails. Regression from #754, which added the `pull_request` trigger to this workflow without updating the checkout step for it; `push` builds (to master) are unaffected since `github.sha` there is a real, fetchable commit.

## Changes
- Use `github.event.pull_request.head.sha || github.sha` for the checkout target, so PR builds check out the actual branch tip while push-to-master builds are unchanged.