### PR TITLE
docs(overview): point remote-control's object-download step at a size example

### DIFF
--- a/docs/overview/remote-control.md
+++ b/docs/overview/remote-control.md
@@ -46,6 +46,10 @@ The client state can be consulted at any moment via [device metadata](../referen
 * **prep download**: a new update (same as a new state JSON) has been received and the device will now download the object metadata information for each of its objects. This includes object size, sha and download URL.
 * **download**: all object metadata is now on memory and we can proceed dowloading all objects that are not already installed in disk. Then we will continue with progressing to the new revision.
 
+Only object hashes that changed are downloaded — for a sense of scale, see
+[meta-pantavisor's firmware-size guide](https://docs.pantavisor.io/development/meta-pantavisor/getting-started/solutions/firmware-size)
+for an illustrative example (not a measured benchmark).
+
 ## Other Remote Controllers
 
 It is also possible to control Pantavisor using any other server. For that, it is necessary to implement a container that performs the communication between the server itself and [Pantavisor](local-control.md).


### PR DESCRIPTION
## Origin

Draft fix for one finding from docs-eval persona 02 (Buildroot engineer, no
Yocto, no containers) prompt B, run 2026-08-04:
[`answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptB-claude-sonnet-5-development.md`](https://github.com/pantavisor/docs-framework/blob/master/answers/02-buildroot-no-yocto-no-containers/2026-08-04-promptB-claude-sonnet-5-development.md)
in the `docs-framework` repo — the first finding this pack has routed to
`pantavisor` rather than `meta-pantavisor`.

## What blocked the reader

*"This page (which I followed into from meta-pantavisor's glossary, since
the wire mechanism is the runtime's) tells me an update downloads 'object
metadata... including object size, sha and download URL' — that's the
mechanism — but it never gives me an actual number for how big a typical
field update is on the wire."* (S3, `no-example`)

## What changed and why

`overview/remote-control.md`'s "prep download"/"download" states describe
pulling only changed-object metadata but give no sense of scale. There's no
real measured number to publish here, and I'm not going to fabricate one —
added a one-line pointer to the illustrative (explicitly labeled
not-measured) example that already exists on the `meta-pantavisor` side
(`getting-started/solutions/firmware-size`) instead.

## Status

**This is a draft for human review** — opened from an automated docs-eval
fix pass.