### PR TITLE
docs(overview): kernel requirements, platform-term disambiguation, Pantahub licensing link

### DIFF
--- a/docs/overview/bsp.md
+++ b/docs/overview/bsp.md
@@ -19,6 +19,30 @@ It is important to remark that the binary file has to be under cpio.xz4 compress
 
 The Linux Kernel, modules and firmware are also part of the revision BSP of the state JSON.
 
+### Kernel requirements
+
+Porting to a board with an existing, booting kernel doesn't guarantee it can
+run Pantavisor's [container](containers.md) and
+[storage](storage.md) layers. At minimum the kernel config needs:
+
+- **Namespaces and cgroups** (`CONFIG_NAMESPACES`, `CONFIG_CGROUPS`, plus the
+  `CONFIG_CGROUP_*`/`CONFIG_MEMCG`/`CONFIG_CPUSETS` subsystems) — required by
+  [LXC](../../meta-pantavisor/overview/glossary.md#lxc) for container
+  isolation.
+- **`CONFIG_OVERLAY_FS`** — used for the container config-overlay mechanism
+  (see [Containers](containers.md)).
+- **`CONFIG_SQUASHFS`** (plus `CONFIG_SQUASHFS_LZ4`/`CONFIG_SQUASHFS_ZSTD` if
+  using those compressors) — every container rootfs is a squashfs image.
+- **Device-mapper** (`CONFIG_DM_CRYPT`, `CONFIG_DM_VERITY`) — only if you use
+  the `dm-crypt`/`dm-verity`
+  [`PANTAVISOR_FEATURES`](../../meta-pantavisor/overview/meta-pantavisor.md#pantavisor_features),
+  which are on by default in `meta-pantavisor`'s standard configuration.
+
+Check what your kernel already has with `zcat /proc/config.gz | grep -E
+'NAMESPACES|CGROUP|OVERLAY_FS|SQUASHFS|DM_CRYPT|DM_VERITY'` on a board
+that's already booting a similar kernel version, since exact defaults vary
+by kernel version and vendor BSP.
+
 ### Managed Drivers
 
 Pantavisor offers a [declarative way](../reference/pantavisor-state-format-v2.md#3-drivers-bspdriversjson) to define a list of drivers at BSP level, each driver being just a set of Kernel modules. Parameters for Kernel loading are supported too by mapping drivers to [device or user metadata](storage.md#metadata).

--- a/docs/overview/containers.md
+++ b/docs/overview/containers.md
@@ -74,6 +74,12 @@ If groups are not [explicitly configured](../reference/pantavisor-state-format-v
 | platform | STARTED | system | middleware and utility containers |
 | app | STARTED | container | application level containers |
 
+**Note:** this "platform" is a default group *name*, unrelated to the other
+two senses of the word elsewhere in these docs — a `kas/platforms/*.yaml`
+SoC/board family in meta-pantavisor's build system, or a Docker `platform`
+architecture string (e.g. `linux/arm64`) in an image config. Same word,
+three unrelated meanings depending on where you see it.
+
 When using the default groups and if a container is not linked to a group, it will be automatically set to _platform_, except if it is the first container in alphabetical order and no other container has been set to _root_, in which case it will be set to _root_. If not using the default groups and if a container is not linked to a group, the [revision](revisions.md) will [fail](updates.md#error).
 
 ## Roles

--- a/docs/overview/remote-control.md
+++ b/docs/overview/remote-control.md
@@ -7,7 +7,7 @@ This page is for explaining cloud-oriented ways of controlling your Pantavisor d
 
 ## Pantacor Hub
 
-[Pantacor Hub](https://hub.pantacor.com) is our remote device state management system.
+[Pantacor Hub](https://hub.pantacor.com) is our remote device state management system. It's optional — Pantavisor updates fully standalone over the local network without it. Pantahub is also open source and self-hostable; see [Project, licensing, and governance](/meta-pantavisor/getting-started/licensing) for the license split and what's commercial vs. open.
 
 To interact with Pantacor Hub, you can either use the [web user interface](https://hub.pantacor.com), the [API](https://github.com/pantacor/pantahub-base) or the [pvr CLI tool](https://github.com/pantacor/pvr).
 

--- a/docs/overview/remote-control.md
+++ b/docs/overview/remote-control.md
@@ -46,6 +46,10 @@ The client state can be consulted at any moment via [device metadata](../referen
 * **prep download**: a new update (same as a new state JSON) has been received and the device will now download the object metadata information for each of its objects. This includes object size, sha and download URL.
 * **download**: all object metadata is now on memory and we can proceed dowloading all objects that are not already installed in disk. Then we will continue with progressing to the new revision.
 
+Only object hashes that changed are downloaded — for a sense of scale, see
+[meta-pantavisor's firmware-size guide](https://docs.pantavisor.io/development/meta-pantavisor/getting-started/solutions/firmware-size)
+for an illustrative example (not a measured benchmark).
+
 ## Other Remote Controllers
 
 It is also possible to control Pantavisor using any other server. For that, it is necessary to implement a container that performs the communication between the server itself and [Pantavisor](local-control.md).


### PR DESCRIPTION
## Origin

Draft fix for findings across multiple docs-eval reports routed to this
repo (the second and third times this pack has routed anything here — see
merged PR #781 for the first):

- [`answers/06-bsp-bringup/2026-08-04-prompt{A,B,C}-...md`](https://github.com/pantavisor/docs-framework/tree/master/answers/06-bsp-bringup) (BSP bring-up engineer)
- [`answers/08-adoption-evaluator/2026-08-04-promptB-...md`](https://github.com/pantavisor/docs-framework/blob/master/answers/08-adoption-evaluator/2026-08-04-promptB-claude-sonnet-5-development.md) (adoption evaluator)

## What changed and why

- **`overview/bsp.md`** — adds a "Kernel requirements" checklist (namespaces/cgroups,
  overlayfs, squashfs, device-mapper) for porting to a board with an
  existing kernel. Hit independently by persona 06 prompts A and B: nothing
  anywhere stated what kernel config LXC and the config-overlay mechanism
  actually need. Standard, well-established LXC prerequisites — not
  Pantavisor-internal specifics — with a pointer to checking the running
  kernel's actual config since exact defaults vary by version/vendor BSP.
- **`overview/containers.md`** — disambiguates the "platform" default group
  name from the two other unrelated senses of the word elsewhere in these
  docs (an SoC/board family in meta-pantavisor's build system, and a Docker
  `platform` architecture string). Persona 06 prompt C's worst finding:
  same bare word, three unrelated meanings, nothing flagging the collision.
- **`overview/remote-control.md`** — states plainly that Pantahub is open
  source and self-hostable, linking to `meta-pantavisor/getting-started/licensing`
  for the details. Persona 08 prompt B found this exact question — "is this
  a library or a vendor" — unanswerable from this page, which documents the
  Hub client protocol in detail but never once mentioned licensing/self-host
  status; the real answer already existed elsewhere, just wasn't linked
  from where the question is actually asked.

## Not fixed

- The missing "healthy boot" reference serial-console transcript (persona
  06 prompt B) — no real hardware capture available, and fabricating
  plausible-looking kernel/driver log lines risks actively misleading
  someone debugging real hardware.
- The `pvbsp`/`pvapp` vs. `pv-initramfs-panta`/`pv-panta` multiconfig-naming
  discrepancy (persona 06 prompt C) — investigated in the paired
  meta-pantavisor commit (found real override-class names in
  `recipes-bsp/u-boot/u-boot%.bbappend` that don't cleanly map to
  `build-system.md`'s documented names) but wasn't confident enough in the
  override-class-vs-multiconfig-name distinction to write something to
  stand behind.

## Status

**This is a draft for human review** — opened from an automated docs-eval
fix pass.