### PR TITLE
Feature/logserver json input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,10 @@ add_executable(pantavisor
 			logserver/logserver_out.h
 			logserver/proto/logserver_binary.c
 			logserver/proto/logserver_binary.h
+			logserver/proto/logserver_json.c
+			logserver/proto/logserver_json.h
+			logserver/proto/logserver_proto.c
+			logserver/proto/logserver_proto.h
 			logserver/proto/logserver_rfc.c
 			logserver/proto/logserver_rfc.h
 			logserver/proto/logserver_rfc5424.c

--- a/docs/overview/storage.md
+++ b/docs/overview/storage.md
@@ -161,7 +161,7 @@ pvcontrol conf ls | grep -i log      # e.g. PV_LOG_SERVER_OUTPUTS, PV_LOG_LEVEL,
 * [pv-ctrl-log](../reference/logserver-sockets.md#pv-ctrl-log): to send log traces.
 * [pv-fd-log](../reference/logserver-sockets.md#pv-fd-log): to suscribe file descriptors.
 
-Containers can also log using the standard syslog protocol by writing to `/dev/log`. Both [RFC 3164](../reference/logserver-sockets.md#rfc-3164) and [RFC 5424](../reference/logserver-sockets.md#rfc-5424) are supported and auto-detected per message — no configuration is needed. From inside a container, the quickest way to emit a message is the standard `logger` command:
+Containers can also log using the standard syslog protocol by writing to `/dev/log`. Both [RFC 3164](../reference/logserver-sockets.md#rfc-3164) and [RFC 5424](../reference/logserver-sockets.md#rfc-5424) are supported and auto-detected per message — no configuration is needed. See the [/dev/log section](../reference/logserver-sockets.md#devlog) for message formats, priority mapping, and per-language library examples. Applications can also send a [JSON-formatted message](../reference/logserver-sockets.md#json-protocol) directly to `pv-ctrl-log`.
 
 ```bash
 logger -t myapp "hello from myapp"

--- a/docs/reference/logserver-sockets.md
+++ b/docs/reference/logserver-sockets.md
@@ -10,7 +10,9 @@ The Pantavisor logging system uses two Unix sockets for inter-process log manage
 
 ## pv-ctrl-log
 
-This socket is used by applications and containers to send log messages directly to the Pantavisor Log Server. All messages must follow the `logserver_msg` structure:
+This socket is used by applications and containers to send log messages directly to the Pantavisor Log Server. The wire format is auto-detected per message: the binary `logserver_msg` structure below, RFC 3164/RFC 5424 syslog text (also reachable via [`/dev/log`](#devlog)), or [JSON](#json-protocol).
+
+Messages using the binary structure must follow the `logserver_msg` structure:
 
 ```C
 struct logserver_msg {
@@ -39,7 +41,45 @@ The supported log levels are:
 * `2`: WARN
 * `3`: INFO
 * `4`: DEBUG
-* `5`: ALL
+* `5`: TRACE
+
+### JSON Protocol
+
+`pv-ctrl-log` also accepts log messages formatted as a single JSON object. Unlike the Legacy Protocol, JSON messages are sent as-is on the wire — they are not wrapped in the `logserver_msg` structure. Any datagram that parses as a valid JSON object is auto-detected as JSON (see the [protocol detection table](#devlog) for how this fits together with the binary and syslog formats).
+
+**Message format:**
+
+```json
+{
+  "version": "0",
+  "level": "INFO",
+  "src": "myapp",
+  "message": "Connection established"
+}
+```
+
+* **version**: Protocol version. Must be `"0"` — the only version currently supported. Messages with any other value, or missing the field, are rejected.
+* **level**: Log level name, case-insensitive. See the level table below.
+* **src**: The specific source of the log (e.g., a process name or module) — equivalent to `source` in the [Legacy Protocol](#legacy-protocol-code--0).
+* **message**: The actual log message content.
+
+:::note
+There is no `platform` field. The platform (the folder name under the log directory) is always derived automatically from the cgroup of the process that sent the message, the same way it is for the [Legacy](#legacy-protocol-code--0), [RFC 3164](#rfc-3164), and [RFC 5424](#rfc-5424) protocols.
+:::
+
+The supported log levels are:
+* `FATAL`
+* `ERROR`
+* `WARN`
+* `INFO`
+* `DEBUG`
+* `TRACE`
+
+:::note
+`ALL` is a valid threshold for [`PV_LOG_LEVEL`](pantavisor-configuration.md#summary), but it is not accepted as a per-message `level` here — a JSON message with `"level": "ALL"` is silently dropped.
+:::
+
+A message that fails to parse (invalid JSON, wrong `version`, unrecognized `level`, or missing `src`/`message`) is dropped; Pantavisor logs a `WARN` and continues.
 
 ## pv-fd-log
 
@@ -100,6 +140,7 @@ The parser is selected at runtime based on the first bytes of each datagram:
 |-------------|-------------------|
 | `<NNN>1 …` (digit `1` immediately after the closing `>`) | RFC 5424 |
 | `<NNN>…` (any other character after the closing `>`) | RFC 3164 |
+| Valid JSON object (e.g. `{ "version": ...`) | [JSON](#json-protocol) |
 | Binary `struct logserver_msg` with `code` header | [Legacy binary](#pv-ctrl-log) |
 
 ### RFC 3164

--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -83,7 +83,7 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_LOG_DIR_MAXSIZE` | integer with optional suffix `B`(default),`K`,`KB`,`M`,`MB`,`G`,`GB`,`T`,`TB`,`%`; `0` for auto 10% (100% if tmpfs) | `16777216` | max size of log directory |
 | `PV_LOG_FILETREE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for filetree logs |
 | `PV_LOG_HYSTERESIS_FACTOR` | positive integer | `4` | controls the gap between high and low watermarks for [log directory cleanup](../overview/storage.md#log-directory-size-management) |
-| `PV_LOG_LEVEL` | `0` to `5` | `0` | set Pantavisor log level (0: FATAL to 5: ALL) |
+| `PV_LOG_LEVEL` | `0` to `5` | `0` | set Pantavisor log level (0: FATAL to 5: TRACE) |
 | `PV_LOG_LOGGERS` | `0` or `1` | `1` | enable loggers for containers |
 | `PV_LOG_PUSH` | `0` or `1` | `1` | push logs to [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PV_LOG_ROTATE_FACTOR` | integer | `5` | determines per-file rotation threshold for [log directory cleanup](../overview/storage.md#log-directory-size-management) |

--- a/log.c
+++ b/log.c
@@ -147,6 +147,16 @@ const char *pv_log_level_name(int level)
 	return level_names[level].name;
 }
 
+int pv_log_level_value(const char *name)
+{
+	for (int i = 0; i < ALL; i++) {
+		if (!strncmp(name, level_names[i].name,
+			     strlen(level_names[i].name)))
+			return level_names[i].log_level;
+	}
+	return -1;
+}
+
 void pv_log_umount(void)
 {
 	char path[PATH_MAX];

--- a/log.h
+++ b/log.h
@@ -71,6 +71,7 @@ void __log(char *module, int level, const char *fmt, ...);
  * Don't free the return value!
  */
 const char *pv_log_level_name(int level);
+int pv_log_level_value(const char *name);
 
 void pv_log_umount(void);
 

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -399,7 +399,6 @@ static int logserver_handle_msg(int fd)
 	char *upd = logserver.updated_rev;
 
 	struct logserver_conninfo *ci = logserver_conninfo_search(fd);
-
 	char *cgroup = NULL;
 
 	if (!ci)

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -35,8 +35,9 @@
 #include <stdarg.h>
 #include <fcntl.h>
 
-#include "proto/logserver_rfc.h"
 #include "proto/logserver_binary.h"
+#include "proto/logserver_rfc.h"
+#include "proto/logserver_proto.h"
 #include "logserver_rotation.h"
 #include "logserver_out.h"
 #include "logserver_utils.h"
@@ -386,35 +387,26 @@ static struct buffer *logserver_get_log_data(int fd)
 
 static int logserver_handle_msg(int fd)
 {
-	struct logserver_log log;
 	int ret = -1;
 
 	struct buffer *buffer = logserver_get_log_data(fd);
 	if (!buffer)
 		goto out;
 
-	log_protocol_code_t type = logserver_rfc_get_type(buffer->buf);
-
-	char *run = logserver.running_rev;
-	char *upd = logserver.updated_rev;
-
 	struct logserver_conninfo *ci = logserver_conninfo_search(fd);
-	char *cgroup = NULL;
 
 	if (!ci)
 		pv_log(DEBUG, "couldn't found current fd information");
-	else
-		cgroup = ci->cgroup;
 
-	if (type == LOG_PROTOCOL_RFC5424)
-		ret = logserver_rfc5424_to_log(buffer->buf, cgroup, run, upd,
-					       &log);
-	else if (type == LOG_PROTOCOL_RFC3164)
-		ret = logserver_rfc3164_to_log(buffer->buf, cgroup, run, upd,
-					       &log);
-	else
-		ret = logserver_bin_to_log(buffer->buf, run, upd, &log);
+	struct logserver_log_data data = {
+		.rev = logserver.running_rev,
+		.upd = logserver.updated_rev,
+		.cgroup = ci->cgroup,
+		.buf = buffer->buf,
+	};
 
+	struct logserver_log log = { 0 };
+	ret = logserver_proto_to_log(&data, &log);
 	if (ret != 0) {
 		pv_log(WARN, "logserver message could not be handled");
 		goto out;
@@ -424,6 +416,7 @@ static int logserver_handle_msg(int fd)
 	case LOG_PROTOCOL_LEGACY:
 	case LOG_PROTOCOL_RFC5424:
 	case LOG_PROTOCOL_RFC3164:
+	case LOG_PROTOCOL_JSON:
 		ret = logserver_log_msg_data(&log, 0);
 		break;
 	case LOG_PROTOCOL_CMD:

--- a/logserver/logserver_out.h
+++ b/logserver/logserver_out.h
@@ -51,16 +51,8 @@ struct logserver_data {
 	int len;
 };
 
-typedef enum {
-	LOG_PROTOCOL_LEGACY = 0,
-	LOG_PROTOCOL_UNKNOWN,
-	LOG_PROTOCOL_RFC5424,
-	LOG_PROTOCOL_RFC3164,
-	LOG_PROTOCOL_CMD = 256
-} log_protocol_code_t;
-
 struct logserver_log {
-	log_protocol_code_t code;
+	int code;
 	int lvl;
 	uint64_t tsec;
 	uint32_t tnano;

--- a/logserver/logserver_utils.c
+++ b/logserver/logserver_utils.c
@@ -26,6 +26,7 @@
 
 #include "logserver_utils.h"
 #include "logserver_timestamp.h"
+#include "proto/logserver_proto.h"
 #include "config.h"
 #include "utils/fs.h"
 #include "log.h"
@@ -35,7 +36,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
-#include <inttypes.h>
 #include <fcntl.h>
 #include <glob.h>
 #include <sys/stat.h>
@@ -211,8 +211,7 @@ int logserver_utils_print_raw(int fd, const struct logserver_log *log)
 	else
 		strcpy(tmpl, "[%s] %.*s");
 
-	if (log->code == LOG_PROTOCOL_RFC3164 ||
-	    log->code == LOG_PROTOCOL_RFC5424)
+	if (log->code != LOG_PROTOCOL_LEGACY)
 		strcat(tmpl, "\n");
 
 	if (!ts_fmt)

--- a/logserver/proto/logserver_binary.c
+++ b/logserver/proto/logserver_binary.c
@@ -27,8 +27,8 @@
 #include <string.h>
 #include <time.h>
 
-int logserver_bin_parse_msg(struct logserver_msg *msg,
-			    struct logserver_log *log)
+static int logserver_bin_parse_msg(struct logserver_msg *msg,
+				   struct logserver_log *log)
 {
 	const char *end = msg->buf + msg->len;
 	int bytes_read = 0;
@@ -75,14 +75,24 @@ int logserver_bin_parse_msg(struct logserver_msg *msg,
 	return 0;
 }
 
-int logserver_bin_to_log(const char *buf, const char *rev, const char *upd_rev,
-			 struct logserver_log *log)
+log_protocol_code_t logserver_bin_check_type(const char *buf)
 {
 	struct logserver_msg *msg = (struct logserver_msg *)buf;
 
+	if (msg->code == LOG_PROTOCOL_LEGACY || msg->code == LOG_PROTOCOL_CMD)
+		return msg->code;
+
+	return LOG_PROTOCOL_UNKNOWN;
+}
+
+int logserver_bin_to_log(struct logserver_log_data *data,
+			 struct logserver_log *log)
+{
+	struct logserver_msg *msg = (struct logserver_msg *)data->buf;
+
 	log->code = msg->code;
-	log->running_rev = (char *)rev;
-	log->updated_rev = (char *)upd_rev;
+	log->running_rev = data->rev;
+	log->updated_rev = data->upd;
 
 	int ret = 0;
 

--- a/logserver/proto/logserver_json.c
+++ b/logserver/proto/logserver_json.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_json.h"
+#include "utils/json.h"
+#include "log.h"
+#include "logserver/logserver_timestamp.h"
+
+#include <string.h>
+#include <ctype.h>
+
+#define LOGSERVER_JSON_VER "0"
+
+#define LOGSERVER_JSON_FLD_VER "version"
+#define LOGSERVER_JSON_FLD_LVL "level"
+#define LOGSERVER_JSON_FLD_SRC "src"
+#define LOGSERVER_JSON_FLD_MSG "message"
+
+log_protocol_code_t logserver_json_check_type(const char *buf)
+{
+	if (!pv_json_is_valid(buf))
+		return LOG_PROTOCOL_UNKNOWN;
+	return LOG_PROTOCOL_JSON;
+}
+
+static bool logserver_json_version_ok(const char *buf, jsmntok_t *tokv,
+				      int tokc)
+{
+	char *ver = pv_json_get_value(buf, LOGSERVER_JSON_FLD_VER, tokv, tokc);
+	if (!ver)
+		return false;
+
+	bool ret =
+		!strncmp(ver, LOGSERVER_JSON_VER, strlen(LOGSERVER_JSON_VER));
+	free(ver);
+
+	return ret;
+}
+
+static int logserver_json_get_level(const char *buf, jsmntok_t *tokv, int tokc)
+{
+	char *name = pv_json_get_value(buf, LOGSERVER_JSON_FLD_LVL, tokv, tokc);
+	if (!name)
+		return -1;
+
+	for (size_t i = 0; i < strlen(name); i++)
+		name[i] = toupper(name[i]);
+
+	int lvl = pv_log_level_value(name);
+	free(name);
+
+	return lvl;
+}
+
+int logserver_json_to_log(struct logserver_log_data *data,
+			  struct logserver_log *log)
+{
+	int ret = -1;
+	int tokc = 0;
+	jsmntok_t *tokv = NULL;
+
+	if (jsmnutil_parse_json(data->buf, &tokv, &tokc) < 0)
+		goto out;
+
+	if (!logserver_json_version_ok(data->buf, tokv, tokc))
+		goto out;
+
+	log->lvl = logserver_json_get_level(data->buf, tokv, tokc);
+	if (log->lvl == -1)
+		goto out;
+
+	if (logserver_proto_set_platform_name(data->cgroup, log->plat) != 0)
+		goto out;
+
+	int src_len = 0;
+	log->src = (char *)pv_json_get_value_ref(
+		data->buf, LOGSERVER_JSON_FLD_SRC, tokv, tokc, &src_len);
+	if (!log->src)
+		goto out;
+
+	log->data.buf = (char *)pv_json_get_value_ref(
+		data->buf, LOGSERVER_JSON_FLD_MSG, tokv, tokc, &log->data.len);
+
+	if (!log->data.buf)
+		goto out;
+
+	log->code = LOG_PROTOCOL_JSON;
+	log->tnano = 0;
+	log->time = time(NULL);
+	log->tsec = logserver_timestamp_get_tsec(log->time);
+	log->running_rev = data->rev;
+	log->updated_rev = data->upd;
+
+	// Add null terminators after processing the buffer
+	log->src[src_len] = '\0';
+	log->data.buf[log->data.len] = '\0';
+
+	ret = 0;
+out:
+	if (tokv)
+		free(tokv);
+
+	return ret;
+}

--- a/logserver/proto/logserver_json.h
+++ b/logserver/proto/logserver_json.h
@@ -20,21 +20,13 @@
  * SOFTWARE.
  */
 
-#ifndef LOGSERVER_BINARY_H
-#define LOGSERVER_BINARY_H
+#ifndef LOGSERVER_JSON_H
+#define LOGSERVER_JSON_H
 
 #include "logserver_proto.h"
 
-#include <stdbool.h>
-
-struct logserver_msg {
-	log_protocol_code_t code;
-	int len;
-	char buf[0];
-};
-
-log_protocol_code_t logserver_bin_check_type(const char *buf);
-int logserver_bin_to_log(struct logserver_log_data *data,
-			 struct logserver_log *log);
+log_protocol_code_t logserver_json_check_type(const char *buf);
+int logserver_json_to_log(struct logserver_log_data *data,
+			  struct logserver_log *log);
 
 #endif

--- a/logserver/proto/logserver_proto.c
+++ b/logserver/proto/logserver_proto.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_proto.h"
+#include "logserver_rfc.h"
+#include "logserver_binary.h"
+#include "logserver_json.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#define LOGSERVER_PROTO_PV "_pv_"
+#define LOGSERVER_PROTO_MAIN_PLAT "pantavisor"
+#define LOGSERVER_PROTO_UNK_PLAT "unknown-platform"
+
+typedef log_protocol_code_t (*check_proto_fn)(const char *buf);
+typedef int (*to_log_fn)(struct logserver_log_data *data,
+			 struct logserver_log *log);
+
+struct logserver_proto {
+	log_protocol_code_t type;
+	to_log_fn to_log;
+};
+
+static check_proto_fn proto_type[] = {
+	logserver_rfc_check_type,
+	logserver_json_check_type,
+	logserver_bin_check_type,
+};
+
+static struct logserver_proto proto[] = {
+	{ LOG_PROTOCOL_LEGACY, logserver_bin_to_log },
+	{ LOG_PROTOCOL_CMD, logserver_bin_to_log },
+	{ LOG_PROTOCOL_RFC3164, logserver_rfc3164_to_log },
+	{ LOG_PROTOCOL_RFC5424, logserver_rfc5424_to_log },
+	{ LOG_PROTOCOL_JSON, logserver_json_to_log },
+	{ LOG_PROTOCOL_UNKNOWN, NULL }
+};
+
+log_protocol_code_t logserver_proto_get(const char *buf)
+{
+	size_t size = sizeof(proto_type) / sizeof(proto_type[0]);
+	for (size_t i = 0; i < size; i++) {
+		if (!proto_type[i])
+			continue;
+
+		log_protocol_code_t code = proto_type[i](buf);
+		if (code != LOG_PROTOCOL_UNKNOWN)
+			return code;
+	}
+	return LOG_PROTOCOL_UNKNOWN;
+}
+
+int logserver_proto_to_log(struct logserver_log_data *data,
+			   struct logserver_log *log)
+{
+	log_protocol_code_t code = logserver_proto_get(data->buf);
+
+	if (code == LOG_PROTOCOL_UNKNOWN)
+		return 0;
+
+	int ret = -1;
+
+	size_t size = sizeof(proto) / sizeof(proto[0]);
+	for (size_t i = 0; i < size; i++) {
+		if (proto[i].type != code || !proto[i].to_log)
+			continue;
+
+		ret = proto[i].to_log(data, log);
+		break;
+	}
+
+	return ret;
+}
+
+int logserver_proto_set_platform_name(const char *cgroup, char *name)
+{
+	if (!name)
+		return -1;
+
+	memset(name, 0, LOGSERVER_PLAT_MAX_LEN);
+
+	if (!cgroup) {
+		memcpy(name, LOGSERVER_PROTO_UNK_PLAT,
+		       strlen(LOGSERVER_PROTO_UNK_PLAT));
+		return 0;
+	}
+
+	if (!strcmp(cgroup, LOGSERVER_PROTO_PV)) {
+		memcpy(name, LOGSERVER_PROTO_MAIN_PLAT,
+		       strlen(LOGSERVER_PROTO_MAIN_PLAT));
+		return 0;
+	}
+
+	memccpy(name, cgroup, 0, LOGSERVER_PLAT_MAX_LEN - 1);
+
+	return 0;
+}

--- a/logserver/proto/logserver_proto.h
+++ b/logserver/proto/logserver_proto.h
@@ -20,21 +20,30 @@
  * SOFTWARE.
  */
 
-#ifndef LOGSERVER_BINARY_H
-#define LOGSERVER_BINARY_H
+#ifndef LOGSERVER_PROTO_H
+#define LOGSERVER_PROTO_H
 
-#include "logserver_proto.h"
+#include "logserver/logserver_out.h"
 
-#include <stdbool.h>
+typedef enum {
+	LOG_PROTOCOL_LEGACY = 0,
+	LOG_PROTOCOL_UNKNOWN,
+	LOG_PROTOCOL_RFC5424,
+	LOG_PROTOCOL_RFC3164,
+	LOG_PROTOCOL_JSON,
+	LOG_PROTOCOL_CMD = 256
+} log_protocol_code_t;
 
-struct logserver_msg {
-	log_protocol_code_t code;
-	int len;
-	char buf[0];
+struct logserver_log_data {
+	char *rev;
+	char *upd;
+	char *cgroup;
+	char *buf;
 };
 
-log_protocol_code_t logserver_bin_check_type(const char *buf);
-int logserver_bin_to_log(struct logserver_log_data *data,
-			 struct logserver_log *log);
+log_protocol_code_t logserver_proto_get(const char *buf);
+int logserver_proto_to_log(struct logserver_log_data *data,
+			   struct logserver_log *log);
+int logserver_proto_set_platform_name(const char *cgroup, char *name);
 
 #endif

--- a/logserver/proto/logserver_rfc.c
+++ b/logserver/proto/logserver_rfc.c
@@ -32,26 +32,6 @@
 #include <unistd.h>
 
 #define LOGSERVER_RFC_SOCKET "/dev/log"
-#define LOGSERVER_RFC_PV "_pv_"
-#define LOGSERVER_RFC_MAIN_PLAT "pantavisor"
-#define LOGSERVER_RFC_UNK_PLAT "unknown-platform"
-
-static void logserver_rfc_set_platform_name(const char *cgroup, char *name)
-{
-	if (!cgroup) {
-		memccpy(name, LOGSERVER_RFC_UNK_PLAT, 0,
-			strlen(LOGSERVER_RFC_UNK_PLAT) + 1);
-		return;
-	}
-
-	if (!strncmp(cgroup, LOGSERVER_RFC_PV, strlen(LOGSERVER_RFC_PV))) {
-		memccpy(name, LOGSERVER_RFC_MAIN_PLAT, 0,
-			strlen(LOGSERVER_RFC_MAIN_PLAT) + 1);
-		return;
-	}
-	memccpy(name, cgroup, 0, LOGSERVER_PLAT_MAX_LEN);
-	name[LOGSERVER_PLAT_MAX_LEN - 1] = '\0';
-}
 
 int logserver_rfc_level_to_pv(int prival)
 {
@@ -147,9 +127,9 @@ int logserver_rfc_create_socket(const char *cur_sock)
 	return symlink(cur_sock, LOGSERVER_RFC_SOCKET);
 }
 
-log_protocol_code_t logserver_rfc_get_type(const char *buf)
+log_protocol_code_t logserver_rfc_check_type(const char *buf)
 {
-	if (buf[0] != '<')
+	if (!buf || !buf[0] || buf[0] != '<')
 		return LOG_PROTOCOL_UNKNOWN;
 
 	int i = 1;
@@ -171,7 +151,8 @@ int logserver_rfc_to_log(struct logserver_rfc *rfc, const char *cgroup,
 	if (!rfc || !log)
 		return -1;
 
-	logserver_rfc_set_platform_name(cgroup, log->plat);
+	if (logserver_proto_set_platform_name(cgroup, log->plat) != 0)
+		return -1;
 
 	log->code = rfc->code;
 	log->lvl = logserver_rfc_level_to_pv(rfc->prival);

--- a/logserver/proto/logserver_rfc.h
+++ b/logserver/proto/logserver_rfc.h
@@ -23,7 +23,7 @@
 #ifndef LOGSERVER_RFC_H
 #define LOGSERVER_RFC_H
 
-#include "logserver/logserver_out.h"
+#include "logserver_proto.h"
 
 #include <time.h>
 #include <stdbool.h>
@@ -40,13 +40,13 @@ int logserver_rfc_level_to_pv(int prival);
 char *logserver_rfc_get_facility(int prival);
 int logserver_rfc_get_prival(const char *buf);
 int logserver_rfc_create_socket(const char *cur_sock);
-log_protocol_code_t logserver_rfc_get_type(const char *buf);
+log_protocol_code_t logserver_rfc_check_type(const char *buf);
 int logserver_rfc_to_log(struct logserver_rfc *rfc, const char *cgroup,
 			 const char *rev, const char *upd_rev,
 			 struct logserver_log *log);
-int logserver_rfc5424_to_log(char *buf, const char *cgroup, const char *rev,
-			     const char *upd_rev, struct logserver_log *log);
-int logserver_rfc3164_to_log(char *buf, const char *cgroup, const char *rev,
-			     const char *upd_rev, struct logserver_log *log);
+int logserver_rfc5424_to_log(struct logserver_log_data *data,
+			     struct logserver_log *log);
+int logserver_rfc3164_to_log(struct logserver_log_data *data,
+			     struct logserver_log *log);
 
 #endif

--- a/logserver/proto/logserver_rfc3164.c
+++ b/logserver/proto/logserver_rfc3164.c
@@ -92,12 +92,16 @@ static int logserver_rfc3164_parse(char *buf, struct logserver_rfc *rfc)
 	return 0;
 }
 
-int logserver_rfc3164_to_log(char *buf, const char *cgroup, const char *rev,
-			     const char *upd_rev, struct logserver_log *log)
+int logserver_rfc3164_to_log(struct logserver_log_data *data,
+			     struct logserver_log *log)
 {
-	struct logserver_rfc rfc = { .code = logserver_rfc_get_type(buf) };
-	if (logserver_rfc3164_parse(buf, &rfc) != 0)
+	struct logserver_rfc rfc = {
+		.code = logserver_rfc_check_type(data->buf),
+	};
+
+	if (logserver_rfc3164_parse(data->buf, &rfc) != 0)
 		return -1;
 
-	return logserver_rfc_to_log(&rfc, cgroup, rev, upd_rev, log);
+	return logserver_rfc_to_log(&rfc, data->cgroup, data->rev, data->upd,
+				    log);
 }

--- a/logserver/proto/logserver_rfc5424.c
+++ b/logserver/proto/logserver_rfc5424.c
@@ -116,12 +116,16 @@ static int logserver_rfc5424_parse(char *buf, struct logserver_rfc *rfc)
 	return 0;
 }
 
-int logserver_rfc5424_to_log(char *buf, const char *cgroup, const char *rev,
-			     const char *upd_rev, struct logserver_log *log)
+int logserver_rfc5424_to_log(struct logserver_log_data *data,
+			     struct logserver_log *log)
 {
-	struct logserver_rfc rfc = { .code = logserver_rfc_get_type(buf) };
-	if (logserver_rfc5424_parse(buf, &rfc) != 0)
+	struct logserver_rfc rfc = {
+		.code = logserver_rfc_check_type(data->buf),
+	};
+
+	if (logserver_rfc5424_parse(data->buf, &rfc) != 0)
 		return -1;
 
-	return logserver_rfc_to_log(&rfc, cgroup, rev, upd_rev, log);
+	return logserver_rfc_to_log(&rfc, data->cgroup, data->rev, data->upd,
+				    log);
 }

--- a/utils/json.c
+++ b/utils/json.c
@@ -157,28 +157,42 @@ int pv_json_get_value_int(const char *buf, const char *key, jsmntok_t *tok,
 	return val;
 }
 
+const char *pv_json_get_value_ref(const char *buf, const char *key,
+                                 jsmntok_t *tok, int tokc, int *len)
+{
+      int i;
+      int t = -1;
+
+      for (i = 0; i < tokc; i++) {
+              int n = tok[i].end - tok[i].start;
+              int m = strlen(key);
+              if (n == m && tok[i].type == JSMN_STRING &&
+                  !strncmp(buf + tok[i].start, key, n)) {
+                      t = 1;
+              } else if (t == 1) {
+                      *len = n;
+                      return buf + tok[i].start;
+              }
+      }
+
+      *len = 0;
+      return NULL;
+}
+
 char *pv_json_get_value(const char *buf, const char *key, jsmntok_t *tok,
 			int tokc)
 {
-	int i;
-	int t = -1;
+	int len = 0;
+	const char *ref = pv_json_get_value_ref(buf, key, tok, tokc, &len);
+	if (!ref)
+		return NULL;
 
-	for (i = 0; i < tokc; i++) {
-		int n = tok[i].end - tok[i].start;
-		int m = strlen(key);
-		if (n == m && tok[i].type == JSMN_STRING &&
-		    !strncmp(buf + tok[i].start, key, n)) {
-			t = 1;
-		} else if (t == 1) {
-			char *idval = malloc(n + 1);
-			idval[n] = 0;
-			strncpy(idval, buf + tok[i].start, n);
-			return idval;
-		} else if (t == 1) {
-			return NULL;
-		}
-	}
-	return NULL;
+	char *val = calloc(len + 1, sizeof(char));
+	if (!val)
+		return NULL;
+
+	memcpy(val, ref, len);
+	return val;
 }
 
 char *pv_json_format(const char *buf, int len)

--- a/utils/json.h
+++ b/utils/json.h
@@ -37,6 +37,9 @@ int pv_json_get_value_int(const char *buf, const char *key, jsmntok_t *tok,
 			  int tokc);
 char *pv_json_get_value(const char *buf, const char *key, jsmntok_t *tok,
 			int tokc);
+const char *pv_json_get_value_ref(const char *buf, const char *key,
+				  jsmntok_t *tok, int tokc, int *len);
+
 char *pv_json_array_get_one_str(const char *buf, int *n, jsmntok_t **tok);
 
 bool pv_json_is_valid(const char *json);


### PR DESCRIPTION
**IMPORTANT:** https://github.com/pantavisor/pantavisor/pull/779 is required to merge this one!

Now logserver support JSON formatted messages on its log socket. The message it's composed by 4 fields:
   
```json
    {
      "version": "",  # Always "0" for now
      "level": "",    # could be FATAL, ERROR, WARN, INFO, DEBUG or TRACE
      "src": "",      # source, platform internal component
      "message": ""   # the log message itself
    }
```
To consider: 
1. The `level` field is case-insensitive.
2. 'src` field is used as file name in the platform folder at `/pv/logs/current/<platform>/`.
3. The platform is inferred from the cgroup of the process which originate the log

## Test
To test the protocol `netcat` (BSD-like) or `socat` can be used:
* netcat (from pantavisor):
```bash
echo '{"version": "0","level":"info","src":"my-src","message":"hello from json!"}' | nc -U /pv/pv-ctrl-log
```
* socat (from a platform like pvr-sdk:
```bash
echo '{"version": "0","level":"info","src":"my-src","message":"hello from json!"}' | socat - UNIX-CONNECT:/pantavisor/pv-ctrl-log
```
