### PR TITLE
Feature/logserver kv input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,8 @@ add_executable(pantavisor
 			logserver/proto/logserver_binary.h
 			logserver/proto/logserver_json.c
 			logserver/proto/logserver_json.h
+			logserver/proto/logserver_kv.c
+			logserver/proto/logserver_kv.h
 			logserver/proto/logserver_proto.c
 			logserver/proto/logserver_proto.h
 			logserver/proto/logserver_rfc.c

--- a/docs/overview/storage.md
+++ b/docs/overview/storage.md
@@ -161,7 +161,7 @@ pvcontrol conf ls | grep -i log      # e.g. PV_LOG_SERVER_OUTPUTS, PV_LOG_LEVEL,
 * [pv-ctrl-log](../reference/logserver-sockets.md#pv-ctrl-log): to send log traces.
 * [pv-fd-log](../reference/logserver-sockets.md#pv-fd-log): to suscribe file descriptors.
 
-Containers can also log using the standard syslog protocol by writing to `/dev/log`. Both [RFC 3164](../reference/logserver-sockets.md#rfc-3164) and [RFC 5424](../reference/logserver-sockets.md#rfc-5424) are supported and auto-detected per message — no configuration is needed. See the [/dev/log section](../reference/logserver-sockets.md#devlog) for message formats, priority mapping, and per-language library examples. Applications can also send a [JSON-formatted message](../reference/logserver-sockets.md#json-protocol) directly to `pv-ctrl-log`.
+Containers can also log using the standard syslog protocol by writing to `/dev/log`. Both [RFC 3164](../reference/logserver-sockets.md#rfc-3164) and [RFC 5424](../reference/logserver-sockets.md#rfc-5424) are supported and auto-detected per message — no configuration is needed. See the [/dev/log section](../reference/logserver-sockets.md#devlog) for message formats, priority mapping, and per-language library examples. Applications can also send a [JSON-formatted message](../reference/logserver-sockets.md#json-protocol) or a [key-value formatted message](../reference/logserver-sockets.md#key-value-protocol) directly to `pv-ctrl-log`.
 
 ```bash
 logger -t myapp "hello from myapp"

--- a/docs/reference/logserver-sockets.md
+++ b/docs/reference/logserver-sockets.md
@@ -10,7 +10,7 @@ The Pantavisor logging system uses two Unix sockets for inter-process log manage
 
 ## pv-ctrl-log
 
-This socket is used by applications and containers to send log messages directly to the Pantavisor Log Server. The wire format is auto-detected per message: the binary `logserver_msg` structure below, RFC 3164/RFC 5424 syslog text (also reachable via [`/dev/log`](#devlog)), or [JSON](#json-protocol).
+This socket is used by applications and containers to send log messages directly to the Pantavisor Log Server. The wire format is auto-detected per message: the binary `logserver_msg` structure below, RFC 3164/RFC 5424 syslog text (also reachable via [`/dev/log`](#devlog)), [JSON](#json-protocol), or [Key-Value](#key-value-protocol).
 
 Messages using the binary structure must follow the `logserver_msg` structure:
 
@@ -81,6 +81,50 @@ The supported log levels are:
 
 A message that fails to parse (invalid JSON, wrong `version`, unrecognized `level`, or missing `src`/`message`) is dropped; Pantavisor logs a `WARN` and continues.
 
+### Key-Value Protocol
+
+`pv-ctrl-log` also accepts log messages formatted as `key=value` pairs. Like JSON messages, key-value messages are sent as-is on the wire — they are not wrapped in the `logserver_msg` structure. A datagram is auto-detected as key-value formatted when it is made up entirely of `level=`, `src=`, and `message=` pairs and all three are present (see the [protocol detection table](#devlog) for how this fits together with the binary, syslog, and JSON formats).
+
+**Message format:**
+
+```
+level=INFO src=myapp message=hello
+```
+
+Values containing spaces must be quoted:
+
+```
+level="INFO" src="my-component" message="hello world"
+```
+
+* **level**: Log level name, case-insensitive. See the level table below.
+* **src**: The specific source of the log (e.g., a process name or module) — equivalent to `source` in the [Legacy Protocol](#legacy-protocol-code--0).
+* **message**: The actual log message content.
+
+All three keys are required and may appear in any order. Unlike the [JSON Protocol](#json-protocol), there is no `version` field.
+
+:::note
+Unquoted values end at the first whitespace character. `message=hello world` without quotes is parsed as `message=hello`, with `world` left dangling and the message rejected — quote any value that contains spaces, as shown above. Quoted values support escaped quotes (`\"`).
+:::
+
+:::note
+There is no `platform` field. The platform (the folder name under the log directory) is always derived automatically from the cgroup of the process that sent the message, the same way it is for the [Legacy](#legacy-protocol-code--0), [RFC 3164](#rfc-3164), [RFC 5424](#rfc-5424), and [JSON](#json-protocol) protocols.
+:::
+
+The supported log levels are:
+* `FATAL`
+* `ERROR`
+* `WARN`
+* `INFO`
+* `DEBUG`
+* `TRACE`
+
+:::note
+`ALL` is a valid threshold for [`PV_LOG_LEVEL`](pantavisor-configuration.md#summary), but it is not accepted as a per-message `level` here — a message with `level=ALL` is silently dropped, the same as for the [JSON Protocol](#json-protocol).
+:::
+
+A message that fails to parse (missing one of the three keys, or an unrecognized `level`) is dropped; Pantavisor logs a `WARN` and continues.
+
 ## pv-fd-log
 
 This socket allows containers to delegate the polling of their file descriptors (e.g., pipes, sockets, or open files) to Pantavisor.
@@ -141,6 +185,7 @@ The parser is selected at runtime based on the first bytes of each datagram:
 | `<NNN>1 …` (digit `1` immediately after the closing `>`) | RFC 5424 |
 | `<NNN>…` (any other character after the closing `>`) | RFC 3164 |
 | Valid JSON object (e.g. `{ "version": ...`) | [JSON](#json-protocol) |
+| `level=`/`src=`/`message=` pairs, all three present | [Key-Value](#key-value-protocol) |
 | Binary `struct logserver_msg` with `code` header | [Legacy binary](#pv-ctrl-log) |
 
 ### RFC 3164

--- a/logserver/logserver.c
+++ b/logserver/logserver.c
@@ -417,6 +417,7 @@ static int logserver_handle_msg(int fd)
 	case LOG_PROTOCOL_RFC5424:
 	case LOG_PROTOCOL_RFC3164:
 	case LOG_PROTOCOL_JSON:
+	case LOG_PROTOCOL_KEY_VAL:
 		ret = logserver_log_msg_data(&log, 0);
 		break;
 	case LOG_PROTOCOL_CMD:

--- a/logserver/proto/logserver_json.c
+++ b/logserver/proto/logserver_json.c
@@ -63,7 +63,7 @@ static int logserver_json_get_level(const char *buf, jsmntok_t *tokv, int tokc)
 		return -1;
 
 	for (size_t i = 0; i < strlen(name); i++)
-		name[i] = toupper(name[i]);
+		name[i] = toupper((unsigned char)name[i]);
 
 	int lvl = pv_log_level_value(name);
 	free(name);

--- a/logserver/proto/logserver_kv.c
+++ b/logserver/proto/logserver_kv.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Pantacor Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "logserver_kv.h"
+#include "logserver/logserver_timestamp.h"
+#include "log.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#define LOGSERVER_KV_KEY_LVL "level"
+#define LOGSERVER_KV_KEY_SRC "src"
+#define LOGSERVER_KV_KEY_MSG "message"
+
+#define LOGSERVER_KV_FLAG_LVL (1 << 0)
+#define LOGSERVER_KV_FLAG_SRC (1 << 1)
+#define LOGSERVER_KV_FLAG_MSG (1 << 2)
+#define LOGSERVER_KV_FLAG_ALL                                                  \
+	(LOGSERVER_KV_FLAG_LVL | LOGSERVER_KV_FLAG_SRC | LOGSERVER_KV_FLAG_MSG)
+
+static void logserver_kv_skip_space(char **ptr)
+{
+	char *p = *ptr;
+	while (*p && isspace((unsigned char)*p))
+		p++;
+	*ptr = p;
+}
+
+static bool logserver_kv_key_comp(const char *start, size_t len,
+				  const char *key)
+{
+	return len == strlen(key) && !strncmp(start, key, strlen(key));
+}
+
+static int logserver_kv_check_key(char **buf)
+{
+	char *ptr = *buf;
+
+	logserver_kv_skip_space(&ptr);
+	if (*ptr == '\0')
+		return 0;
+
+	const char *start = (const char *)ptr;
+	while (*ptr && *ptr != '=' && !isspace((unsigned char)*ptr))
+		ptr++;
+
+	if (*ptr == '\0')
+		return 0;
+
+	int len = ptr - start;
+	if (len == 0)
+		return 0;
+
+	*buf = ptr;
+
+	if (logserver_kv_key_comp(start, len, LOGSERVER_KV_KEY_LVL))
+		return LOGSERVER_KV_FLAG_LVL;
+	else if (logserver_kv_key_comp(start, len, LOGSERVER_KV_KEY_SRC))
+		return LOGSERVER_KV_FLAG_SRC;
+	else if (logserver_kv_key_comp(start, len, LOGSERVER_KV_KEY_MSG))
+		return LOGSERVER_KV_FLAG_MSG;
+
+	return 0;
+}
+
+bool debug = false;
+
+static bool logserver_kv_check_val(char **buf, char **val, int *vlen)
+{
+	char *ptr = *buf;
+
+	logserver_kv_skip_space(&ptr);
+	if (*ptr != '=')
+		return false;
+
+	ptr++;
+
+	logserver_kv_skip_space(&ptr);
+	if (*ptr == '\0')
+		return false;
+
+	if (*ptr != '"') {
+		const char *start = ptr;
+		while (*ptr && !isspace((unsigned char)*ptr))
+			++ptr;
+
+		if (val)
+			*val = (char *)start;
+		if (vlen)
+			*vlen = ptr - start;
+
+		*buf = ptr;
+
+		return ptr != start;
+	}
+
+	ptr++;
+
+	if (val)
+		*val = ptr;
+
+	bool closed = false;
+	while (*ptr) {
+		// scaped quote
+		if (*ptr == '\\' && *(ptr + 1) == '"') {
+			ptr += 2;
+			continue;
+		}
+
+		if (*ptr == '"') {
+			if (vlen)
+				*vlen = ptr - *val;
+			ptr++;
+			closed = true;
+			break;
+		}
+
+		ptr++;
+	}
+
+	*buf = ptr;
+
+	return closed;
+}
+
+static char *logserver_kv_check_kv(char *ptr, int *found)
+{
+	int f = logserver_kv_check_key(&ptr);
+	if (f == 0)
+		return NULL;
+
+	*found |= f;
+
+	if (f > 0)
+		debug = true;
+
+	bool x = logserver_kv_check_val(&ptr, NULL, NULL);
+
+	if (debug)
+		debug = false;
+
+	if (!x)
+		return NULL;
+
+	return ptr;
+}
+
+log_protocol_code_t logserver_kv_check_type(const char *buf)
+{
+	int found = 0;
+	char *ptr = (char *)buf;
+
+	while ((ptr = logserver_kv_check_kv(ptr, &found)))
+		;
+
+	if (found != LOGSERVER_KV_FLAG_ALL)
+		return LOG_PROTOCOL_UNKNOWN;
+
+	return LOG_PROTOCOL_KEY_VAL;
+}
+
+int logserver_kv_to_log(struct logserver_log_data *data,
+			struct logserver_log *log)
+{
+	char *ptr = data->buf;
+	char *val = NULL;
+	int vlen = 0;
+	int key = 0;
+
+	char *end = &data->buf[strlen(data->buf)];
+
+	while ((key = logserver_kv_check_key(&ptr)) > 0) {
+		if (!logserver_kv_check_val(&ptr, &val, &vlen))
+			return -1;
+
+		if (!val || vlen == 0)
+			return -1;
+
+		if (key & LOGSERVER_KV_FLAG_LVL) {
+			char *lvl = calloc(vlen + 1, sizeof(char));
+			if (!lvl)
+				return -1;
+			memcpy(lvl, val, vlen);
+
+			for (size_t i = 0; i < strlen(lvl); i++)
+				lvl[i] = toupper((unsigned char)lvl[i]);
+
+			log->lvl = pv_log_level_value(lvl);
+			free(lvl);
+			if (log->lvl == -1)
+				return -1;
+
+		} else if (key & LOGSERVER_KV_FLAG_MSG) {
+			log->data.len = vlen;
+			log->data.buf = val;
+			ptr = val + vlen;
+			if (*ptr && ptr < end) {
+				*ptr = '\0';
+				ptr++;
+			}
+		} else if (key & LOGSERVER_KV_FLAG_SRC) {
+			log->src = val;
+			ptr = val + vlen;
+			if (*ptr && ptr < end) {
+				*ptr = '\0';
+				ptr++;
+			}
+		}
+	}
+
+	if (logserver_proto_set_platform_name(data->cgroup, log->plat) != 0)
+		return -1;
+
+	log->code = LOG_PROTOCOL_KEY_VAL;
+	log->tnano = 0;
+	log->time = time(NULL);
+	log->tsec = logserver_timestamp_get_tsec(log->time);
+	log->running_rev = data->rev;
+	log->updated_rev = data->upd;
+
+	return 0;
+}

--- a/logserver/proto/logserver_kv.h
+++ b/logserver/proto/logserver_kv.h
@@ -20,31 +20,13 @@
  * SOFTWARE.
  */
 
-#ifndef LOGSERVER_PROTO_H
-#define LOGSERVER_PROTO_H
+#ifndef LOGSERVER_KV_H
+#define LOGSERVER_KV_H
 
-#include "logserver/logserver_out.h"
+#include "logserver_proto.h"
 
-typedef enum {
-	LOG_PROTOCOL_LEGACY = 0,
-	LOG_PROTOCOL_UNKNOWN,
-	LOG_PROTOCOL_RFC5424,
-	LOG_PROTOCOL_RFC3164,
-	LOG_PROTOCOL_JSON,
-	LOG_PROTOCOL_KEY_VAL,
-	LOG_PROTOCOL_CMD = 256
-} log_protocol_code_t;
-
-struct logserver_log_data {
-	char *rev;
-	char *upd;
-	char *cgroup;
-	char *buf;
-};
-
-log_protocol_code_t logserver_proto_get(const char *buf);
-int logserver_proto_to_log(struct logserver_log_data *data,
-			   struct logserver_log *log);
-int logserver_proto_set_platform_name(const char *cgroup, char *name);
+log_protocol_code_t logserver_kv_check_type(const char *buf);
+int logserver_kv_to_log(struct logserver_log_data *data,
+			  struct logserver_log *log);
 
 #endif

--- a/logserver/proto/logserver_proto.c
+++ b/logserver/proto/logserver_proto.c
@@ -24,6 +24,7 @@
 #include "logserver_rfc.h"
 #include "logserver_binary.h"
 #include "logserver_json.h"
+#include "logserver_kv.h"
 
 #include <stdbool.h>
 #include <string.h>
@@ -44,6 +45,7 @@ struct logserver_proto {
 static check_proto_fn proto_type[] = {
 	logserver_rfc_check_type,
 	logserver_json_check_type,
+	logserver_kv_check_type,
 	logserver_bin_check_type,
 };
 
@@ -53,6 +55,7 @@ static struct logserver_proto proto[] = {
 	{ LOG_PROTOCOL_RFC3164, logserver_rfc3164_to_log },
 	{ LOG_PROTOCOL_RFC5424, logserver_rfc5424_to_log },
 	{ LOG_PROTOCOL_JSON, logserver_json_to_log },
+	{ LOG_PROTOCOL_KEY_VAL, logserver_kv_to_log },
 	{ LOG_PROTOCOL_UNKNOWN, NULL }
 };
 
@@ -76,7 +79,7 @@ int logserver_proto_to_log(struct logserver_log_data *data,
 	log_protocol_code_t code = logserver_proto_get(data->buf);
 
 	if (code == LOG_PROTOCOL_UNKNOWN)
-		return 0;
+		return -1;
 
 	int ret = -1;
 


### PR DESCRIPTION
**IMPORTANT:** https://github.com/pantavisor/pantavisor/pull/784 is required to merge this one!

Now logserver support key-value formatted messages on its log socket. The message it's composed by 3 fields:
   
```python
level=DEBUG src=CUSTOM message=Heeello
```
To consider: 
1. The `level` field is case-insensitive.
2. 'src` field is used as file name in the platform folder at `/pv/logs/current/<platform>/`.
3. The platform is inferred from the cgroup of the process which originate the log
4. All values can be quoted to allow spaces like: `message="hello world"`

## Test
To test the protocol `netcat` (BSD-like) or `socat` can be used:
* netcat (from pantavisor):
```bash
echo 'level=DEBUG src=CUSTOM message="hello world"' | nc -U /pv/pv-ctrl-log
```
* socat (from a platform like pvr-sdk:
```bash
echo 'level=DEBUG src=CUSTOM message="hello world"' | socat - UNIX-CONNECT:/pantavisor/pv-ctrl-log
```