### PR TITLE
ci(on-push): skip Yocto builds on docs-only changes

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -6,14 +6,14 @@ on:
       - master
     paths:
       - "**"
-      - ".github/configs/**"
+      - "!docs/**"
   pull_request:
     types: [opened, synchronize]
     branches:
       - "*"
     paths:
       - "**"
-      - ".github/configs/**"
+      - "!docs/**"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/on-push.yaml` from `paths: ["**", ".github/configs/**"]` to `paths-ignore: ["docs/**"]` for both the `push` and `pull_request` triggers.
- Doc-only changes under `docs/` no longer trigger the self-hosted Raspberry Pi / BananaPi / docker-x86_64 build matrix.
- All other paths (including `.github/configs/**`) still trigger builds as before.

## Test plan
- [x] Push/PR a docs-only change and confirm the `build` job is skipped
- [x] Push/PR a code change and confirm the `build` job still runs