### PR TITLE
feat(power): drain queued revisions without sleeping in between

### DIFF
--- a/power/wakelock.c
+++ b/power/wakelock.c
@@ -677,6 +677,30 @@ static void _alarm_notify_cb(evutil_socket_t fd, short events, void *arg)
 	_poll_window_open();
 }
 
+// An update just finished. Poll once more before the device is allowed back to
+// sleep, so a queued revision applies in this wake rather than waiting a whole
+// wake interval. Must run while WL_UPDATE is still held: acquiring WL_POLL first
+// keeps the refcount off zero, which would otherwise let autosleep suspend us
+// between the two calls.
+void pv_wakelock_update_finished(void)
+{
+	if (!wl.init || wl.mode != PWR_MANAGED)
+		return;
+
+	// re-firing inside the open window keeps its max-awake cap, so the drain
+	// cannot extend this wake beyond the configured bound
+	if (wl.poll_active) {
+		wl.poll_round_ok = false;
+		pv_log(DEBUG,
+		       "wakelock: update finished; re-polling in window");
+		_poll_fire_requests();
+		return;
+	}
+
+	pv_log(DEBUG, "wakelock: update finished; opening drain window");
+	_poll_window_open();
+}
+
 // Called from the update-check response path. A round that round-tripped to Hub
 // completes the window (after the min-awake floor); a connection failure retries
 // within the max-awake budget instead of letting the device re-suspend.

--- a/power/wakelock.h
+++ b/power/wakelock.h
@@ -68,6 +68,10 @@ void pv_wakelock_devmeta_deauth(void);
 // staying awake, until one succeeds or max-awake elapses.
 void pv_wakelock_poll_round_done(bool reached_hub);
 
+// An update finished; poll again before sleeping so a queued revision applies
+// in this wake. Call while the update still holds WL_UPDATE.
+void pv_wakelock_update_finished(void);
+
 // Read-only state for the GET /wakelocks control endpoint. Caller frees.
 char *pv_wakelock_get_json(void);
 

--- a/update/update.c
+++ b/update/update.c
@@ -915,6 +915,9 @@ void pv_update_finish()
 	// release only if this update acquired it (finish also runs for
 	// done/failed/factory revisions that never acquired)
 	if (u->wakelock_held) {
+		// drain any queued revision in this wake; ordered before the
+		// release so the refcount never reaches zero in between
+		pv_wakelock_update_finished();
 		pv_wakelock_release(WL_UPDATE);
 		u->wakelock_held = false;
 	}


### PR DESCRIPTION
Follow-up to #768. In `managed` mode, a device with several revisions queued at Hub applies roughly one per wake instead of draining them.

## Why

`pv_update_finish()` releases `WL_UPDATE`. If the poll window has already closed (`round_ok` + `min_awake`, or the `max_awake` cap), that release drops the refcount to zero and autosleep suspends the device. `_poll_fire_requests()` runs once per window and only retries on *failure*, so nothing polls again for the next revision, and the updater's own timer is up to `updater.interval` away — the device is long gone by then.

The `GET /trails/.../steps` query already asks for every pending state, but the handler takes `pv_pantahub_msg_parse_next_step()` — one revision — and returns early while an update is in flight:

```c
if (pv_update_get_rev() && !pv_update_is_final()) {
	pv_log(..., "update is still not finished. defering to process new steps from hub ...");
	return;
}
```

So the queue is inherently drained one at a time; the only question is whether the device sleeps between them.

## What this does

Adds `pv_wakelock_update_finished()` and calls it from `pv_update_finish()`.

**Ordering is the load-bearing part.** The call sits *before* `pv_wakelock_release(WL_UPDATE)`, so `WL_POLL` is acquired while the refcount is still non-zero (1 → 2 → 1). Releasing first would leave a window where the count hits zero and autosleep takes the device — the same ~200µs re-suspend race the RTC wake path is built around.

**Bounded.** When a window is already open, it re-fires within it and keeps that window's existing `max_awake` cap, so draining cannot extend the wake past the configured bound. A fresh window is opened only when none is active — the post-reboot case, where a BSP revision completes in `TESTING` after the reboot. `_poll_window_open()` has no re-entry guard and would leak its libevent timers if called on an active window, which is why the two cases are split rather than unconditionally calling it.

Managed-only; a no-op in `locks` and `disabled`.

## Test plan

- [x] Reviewed against the wake-window state machine: `poll_active`, `poll_round_ok`, the `min`/`max`/`retry` timers and `run_window`
- [x] CI build
- [x] **On-device, non-reboot path** (i.MX8M Nano, `managed`, 300s wake interval). Two app-only revisions queued while the device slept, both applied in a single wake:

  ```
  16:43:01  wake window closed (round complete)
  16:43:03  finishing update
  16:43:03  wakelock: update finished; opening drain window
  16:43:03  wake window opened (min_awake=10s max_awake=60s)
  16:43:08  finishing update
  ```

  The window had already closed, so without this change the `WL_UPDATE` release would have dropped the refcount to zero and suspended the device; the second revision would have waited a further ~300s. No `PM: suspend entry` and no `Kernel command line:` anywhere between the two, and both ended `UPDATED` rather than `DONE` — confirming neither rebooted. Elapsed: first `UPDATED` 16:43:09, second `UPDATED` 16:44:11.

- [x] **Both branches exercised.** The run above took `_poll_window_open()` (no active window). An earlier run with reboot-triggering revisions took the `wl.poll_active` re-fire path (`wakelock: update finished; re-polling in window`).
- [x] **Device still suspends afterwards** — the drain window is not a trap:

  ```
  16:44:05  up=298  update finished; opening drain window
  16:44:05  up=298  wake window opened (min_awake=10s max_awake=60s)
  16:47:19  up=360  PM: suspend entry (deep)
  16:47:19  up=360  wake window closed (max-awake)
  16:47:20  up=363  managed wake
  ```

  Known cost, worth a follow-up: with nothing left to fetch, the drain window closed on `max-awake` (the full 60s cap) rather than `round complete` (~`min_awake`). So a drained batch pays up to `max_awake` of extra awake time at the tail. Bounded and safe, but avoidable — closing as soon as a drain poll comes back empty would reclaim it.

Note on picking a test target: containers with `restart_policy=system` (here `pvwificonnect`, `pvr-sdk`) or `group=root` force a reboot, so a revision touching them exercises the pre-existing chain-through-boot-window behaviour rather than this change. The non-reboot test needs a plain container.

Not covered here: batching more than one revision per poll. That is a Hub-protocol and update-FSM question, deliberately out of scope.


