### PR TITLE
docs: name the watchdog config keys on the overview page

### DIFF
--- a/docs/overview/watchdog.md
+++ b/docs/overview/watchdog.md
@@ -7,7 +7,12 @@ Pantavisor also offers some [configurable](../reference/pantavisor-configuration
 
 ## Mode
 
-The watchdog mode will determine when the watchdog is pinged by Pantavisor.
+The watchdog mode will determine when the watchdog is pinged by Pantavisor. Set
+it with the [`PV_WDT_MODE`](../reference/pantavisor-configuration.md#summary)
+config key (`disabled`, `shutdown`, `startup`, or `always`; default
+`shutdown`); the ping interval is set separately with
+[`PV_WDT_TIMEOUT`](../reference/pantavisor-configuration.md#summary) (seconds,
+default `15`).
 
 ### Disabled
 


### PR DESCRIPTION
## Origin

[audits/pantavisor/2026-08-11-overview-development-claude-sonnet-5.md](https://github.com/pantavisor/docs-framework) (docs-framework repo, not pushed yet — local report), repo=pantavisor, section=overview, version=development, date=2026-08-11.

## What the rule requires

- **Rule**: `AGENTS.md`'s Actionability (`docs/`) rule — every feature description should give the reader a direct, concrete path to act on it (a command, config key, or path), not just prose.
- **Severity**: S3 — present but incomplete.
- **Evidence**: `overview/watchdog.md` describes the four watchdog modes (Disabled/Shutdown/Startup/Always) but never names the actual `PV_WDT_MODE`/`PV_WDT_TIMEOUT` config keys that control them — only a generic, unscoped link to the full configuration reference table.

## What changed and why

- `docs/overview/watchdog.md` — added a short paragraph under "## Mode" naming `PV_WDT_MODE` (values, default) and `PV_WDT_TIMEOUT` (units, default), each linked to their row in `docs/reference/pantavisor-configuration.md#summary`. Both keys were confirmed against that reference table before writing (`PV_WDT_MODE`: `disabled`/`shutdown`/`startup`/`always`, default `shutdown`; `PV_WDT_TIMEOUT`: seconds, default `15`).

## Status

Draft PR opened from an automated docs-eval fix pass (docs-framework's `FIXBOOK.md` workflow), not verified against the rendered site — please review before merging.