### PR TITLE
fix(ctrl): reply to requests without a body

### DIFF
--- a/ctrl/ctrl_util.c
+++ b/ctrl/ctrl_util.c
@@ -337,6 +337,17 @@ void pv_ctrl_utils_drain_req(struct evhttp_request *req)
 	ctrl_utils_drain_buf(evhttp_request_get_input_buffer(req));
 }
 
+static bool ctrl_utils_expects_body(struct evhttp_request *req)
+{
+	const char *te = evhttp_find_header(
+		evhttp_request_get_input_headers(req), "transfer-encoding");
+
+	if (te && !evutil_ascii_strcasecmp(te, "chunked"))
+		return true;
+
+	return pv_ctrl_utils_get_content_length(req) > 0;
+}
+
 static void ctrl_utils_drain_ok_callback(struct evbuffer *buf,
 					 const struct evbuffer_cb_info *info,
 					 void *ctx)
@@ -380,6 +391,12 @@ static void ctrl_utils_drain_error_callback(struct evbuffer *buf,
 
 void pv_ctrl_utils_drain_on_arrive_with_ok(struct evhttp_request *req)
 {
+	if (!ctrl_utils_expects_body(req)) {
+		pv_ctrl_utils_drain_req(req);
+		pv_ctrl_utils_send_ok(req);
+		return;
+	}
+
 	evbuffer_add_cb(evhttp_request_get_input_buffer(req),
 			ctrl_utils_drain_ok_callback, req);
 }
@@ -387,6 +404,12 @@ void pv_ctrl_utils_drain_on_arrive_with_ok(struct evhttp_request *req)
 void pv_ctrl_utils_drain_on_arrive_with_err(struct evhttp_request *req,
 					    int code, const char *err_str)
 {
+	if (!ctrl_utils_expects_body(req)) {
+		pv_ctrl_utils_drain_req(req);
+		pv_ctrl_utils_send_error(req, code, err_str);
+		return;
+	}
+
 	struct ctrl_utils_drain_data *data =
 		calloc(1, sizeof(struct ctrl_utils_drain_data));
 	if (!data) {


### PR DESCRIPTION
## Problem

pv-ctrl never replies to a request that carries no body. libevent completes such
a request without ever filling the input buffer, so the drain callback that would
send the response never fires and the connection stays open until the client
times out.

`pvtx` re-sends the empty object `e3b0c44298fc...b855` on every update, so once it
is in storage the objects endpoint takes the "already exists and is valid" branch
and the update never commits. Any request rejected before its body arrives hangs
the same way, on every endpoint that defers its error through the drain helper
(steps, usrmeta, devmeta, daemons, containers).

## Fix

Reply inline when the request carries no body, using the same condition libevent
applies in `evhttp_get_body()`. Chunked and non-empty payloads keep the existing
callback path, so behaviour only changes for requests that could never have been
answered.

## Test

appengine x86_64, 11/11 pass: `local/control` (3), `local/runtime` (4),
`local/services` (4).

The regression test is `local/runtime/ctrl-empty-object-put` in the companion
meta-pantavisor PR. Without this change it reports `000` (client timeout) for the
second and third PUT; with it, all three return 200.
