### PR TITLE
docs: close config/API gaps from 2026-08-27 code check

### DIFF
--- a/docs/overview/wakelocks.md
+++ b/docs/overview/wakelocks.md
@@ -78,6 +78,7 @@ the wakelock inline on the same thread closes that gap.
 | key | default | meaning |
 |-----|---------|---------|
 | `power.mode` | `locks` | `disabled` / `locks` / `managed` |
+| `power.devmeta.eager_push` | `false` | push a dirty `devmeta` change out-of-band right away rather than waiting up to a full devmeta interval, minimizing awake time |
 | `power.wake.interval` | `3600` | managed: seconds between timed wakes (device heartbeat) |
 | `power.wake.run_window` | `0` (off) | managed: after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
 | `power.autosleep.settle` | `90` | managed: delay after ready before autosleep is enabled |

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -93,6 +93,14 @@ To list all groups in the current revision:
 $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/groups"
 ```
 
+## /wakelocks
+
+Returns the current [power mode and wakelock state](../overview/wakelocks.md#inspecting-state): mode, refcount, whether autosleep/settle/poll are active, and which scopes are held. See [Wakelocks and power modes](../overview/wakelocks.md) for full semantics.
+
+```
+$ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/wakelocks"
+```
+
 ## /signal
 
 This type of command can be issued to alter the container [status](../overview/containers.md#status) in Pantavisor.
@@ -131,7 +139,7 @@ These are the different commands that are supported. You can test them by substi
 | ENABLE_SSH | N/A | [enable SSH server](../overview/pantavisor-configuration-levels.md#commands) ignoring config until reboot |
 | DISABLE_SSH | N/A | [disable SSH server](../overview/pantavisor-configuration-levels.md#commands) ignoring config until reboot |
 | GO_REMOTE | N/A | go remote when running on a [locals/ revision](pantavisor-commands.md#steps) if allowed by config |
-| DEFER_REBOOT | N/A | defer reboot when debug shell is active |
+| DEFER_REBOOT | new_timeout | defer reboot when debug shell is active, setting a new debug-shell-reboot timeout |
 | LOCAL_RUN_COMMIT | revision | transition to revision and commit it automatically |
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
@@ -264,6 +272,22 @@ With cURL, this would look like:
 
 ```
 curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/buildinfo"
+```
+
+## /config
+
+Returns the active [Pantavisor configuration](pantavisor-configuration.md) as a flat object with aliased dotted keys.
+
+```
+curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/config"
+```
+
+## /config2
+
+Returns the active [Pantavisor configuration](pantavisor-configuration.md) as an array of `{key, value, modified}` records, where `modified` shows where the value came from (`default`, a config file, etc.).
+
+```
+curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/config2"
 ```
 
 ## /drivers

--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -94,12 +94,22 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for single-file logs |
 | `PV_LOG_STDOUT_TIMESTAMP_FORMAT` | format string | empty | timestamp format for stdout logs |
 | `PV_LOG_TIMESTAMP` | `relative` or `absolute` | `relative` | clock behind the `tsec` field of every log line: seconds since boot, or Unix epoch |
+| `PV_LOOP_INDEX_BASE` | integer | `-1` | set base index of the [loop device range](../overview/init-mode.md) reserved for this instance; `-1` disables ranging |
 | `PV_LXC_LOG_LEVEL` | `0` to `5` | `2` | set LXC log level |
 | `PV_NET_BRADDRESS4` | IP address | `10.0.3.1` | set bridge IPv4 address |
 | `PV_NET_BRDEV` | interface name | `lxcbr0` | set bridge device name |
 | `PV_NET_BRMASK4` | IP mask | `255.255.255.0` | set bridge IPv4 mask |
 | `PV_OEM_NAME` | string | empty | set OEM name to load the in-revision [OEM configuration](../overview/pantavisor-configuration-levels.md#oem) file from `<PV_OEM_NAME>/<PV_POLICY>.config`; empty disables the OEM level |
 | `PV_POLICY` | string | empty | set policy name to select the [policy](../overview/pantavisor-configuration-levels.md#policies) config file and the name of the [OEM configuration](../overview/pantavisor-configuration-levels.md#oem) file (`default` if empty) |
+| `PV_POWER_AUTOSLEEP_SETTLE` | time (in seconds) | `90` | [managed power mode](../overview/wakelocks.md#configuration): delay after ready before autosleep is enabled |
+| `PV_POWER_DEVMETA_EAGER_PUSH` | `0` or `1` | `0` | push [device metadata](../overview/wakelocks.md#configuration) out-of-band right away instead of waiting up to a full devmeta interval, minimizing awake time |
+| `PV_POWER_DEVMETA_MAX_HELD` | time (in seconds) | `300` | max seconds the [`devmeta` wakelock](../overview/wakelocks.md#configuration) is held awaiting a Hub ack |
+| `PV_POWER_MODE` | `disabled`, `locks` or `managed` | `locks` | set [power mode](../overview/wakelocks.md#configuration) |
+| `PV_POWER_SYSFS_DIR` | path | `/sys/power` | base dir of the [wakelock sysfs nodes](../overview/wakelocks.md#configuration) |
+| `PV_POWER_WAKE_INTERVAL` | time (in seconds) | `3600` | [managed power mode](../overview/wakelocks.md#configuration): seconds between timed wakes (device heartbeat) |
+| `PV_POWER_WAKE_MAX_AWAKE` | time (in seconds) | `60` | [managed power mode](../overview/wakelocks.md#configuration): maximum awake seconds per wake window |
+| `PV_POWER_WAKE_MIN_AWAKE` | time (in seconds) | `10` | [managed power mode](../overview/wakelocks.md#configuration): minimum awake seconds per wake window |
+| `PV_POWER_WAKE_RUN_WINDOW` | time (in seconds) | `0` | [managed power mode](../overview/wakelocks.md#configuration): after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
 | `PV_REMOUNT_POLICY` | string | empty | set remount policy name for filesystem remounting |
 | `PV_REVISION_RETRIES` | integer | `10` | number of retries for revision transitions |
 | `PV_SECUREBOOT_CHECKSUM` | `0` or `1` | `1` | enable artifact [checksum validation](../overview/storage.md#artifact-checksum) |
@@ -123,6 +133,7 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_SYSCTL_KERNEL_CORE_PATTERN` | string | `\|/lib/pv/pvcrash --skip` | set kernel core dump pattern |
 | `PV_SYSTEM_APPARMOR_PROFILES` | string | empty | AppArmor profiles to load |
 | `PV_SYSTEM_CONFDIR` | path | `/configs` | set directory for system configurations |
+| `PV_SYSTEM_DISKSDIR` | path | `/run/pantavisor/disks` | set system disks directory |
 | `PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO` | `0` or `1` | `0` | enable early auto-loading of drivers |
 | `PV_SYSTEM_ETCDIR` | path | `/etc` | set system etc directory |
 | `PV_SYSTEM_ETCPANTAVISORDIR` | path | `/etc/pantavisor` | set Pantavisor etc directory |
@@ -208,12 +219,22 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_STDOUT_TIMESTAMP_FORMAT`     | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_TIMESTAMP`                   | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_LOOP_INDEX_BASE`                 | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_LXC_LOG_LEVEL`                   | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_NET_BRADDRESS4`                  | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_NET_BRDEV`                       | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_NET_BRMASK4`                     | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_OEM_NAME`                        | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_POLICY`                          | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| `PV_POWER_AUTOSLEEP_SETTLE`           | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_DEVMETA_EAGER_PUSH`         | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_DEVMETA_MAX_HELD`           | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_MODE`                       | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_SYSFS_DIR`                  | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_WAKE_INTERVAL`              | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_WAKE_MAX_AWAKE`             | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_WAKE_MIN_AWAKE`             | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_POWER_WAKE_RUN_WINDOW`            | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_REMOUNT_POLICY`                   | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
 | `PV_REVISION_RETRIES`                | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_SECUREBOOT_CHECKSUM`             | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
@@ -235,6 +256,7 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_SYSCTL_KERNEL_CORE_PATTERN`      | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_SYSTEM_APPARMOR_PROFILES`        | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_CONFDIR`                  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `PV_SYSTEM_DISKSDIR`                  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO`  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_ETCDIR`                   | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_INIT_MODE`                | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |

--- a/docs/tools/pantavisor-tools.md
+++ b/docs/tools/pantavisor-tools.md
@@ -16,6 +16,8 @@ Enter a running container's namespaces.
 pventer -c <container-name> [CMD ...]
 ```
 
+`-c`/`--container` is required; `--container` is the long-form alias of `-c`.
+
 Without a command, drops into the container's default shell. With a command, executes it inside the container's namespace. Uses `fallbear-cmd` under the hood via LXC paths.
 
 ```bash
@@ -155,7 +157,7 @@ pvtx queue process [base] [queue] [object]
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PVTXDIR` | `/var/pvr-sdk/pvtx` | Temp directory for transaction state |
+| `PVTXDIR` | `/var/cache/pvtx` (root), `~/.local/share/pvtx` (non-root) | Temp directory for transaction state |
 | `PVTX_OBJECT_BUF_SIZE` | — | Buffer size for saving objects (512B–10M) |
 | `PVTX_CTRL_BUF_SIZE` | — | Buffer size for pv-ctrl I/O (16K–10M) |
 


### PR DESCRIPTION
## Origin

docs-framework repo, `codechecks/pantavisor/2026-08-27-all-c228d1e-claude-sonnet-5.md` (repo: pantavisor, ref: master, commit `c228d1ea5d879f543639e9952635e9db3b84001c`, section: all, date: 2026-08-27, model: claude-sonnet-5). This repo does not carry that report file directly — it lives in the separate `docs-framework` evaluation repo.

## What the code says

- **Critical — `PV_POWER_DEVMETA_EAGER_PUSH` undocumented**: key exists in `config_index_t`/`entries[]` (`config.h:104`, `config.c:251-252`, default `false`), with zero mention in `docs/` despite its 8 sibling `PV_POWER_*` keys being documented in `wakelocks.md`.
- **Critical — `PV_SYSTEM_DISKSDIR` undocumented**: key exists in enum/`entries[]`/`aliases[]` (`config.h:140`, `config.c:306-307`, default `/run/pantavisor/disks`, alias `system.disksdir`), zero mention anywhere in `docs/`.
- **Minor — 8 `PV_POWER_*` keys unlinked**: fully documented with correct defaults in `wakelocks.md`'s Configuration table, but absent from `pantavisor-configuration.md`, the page that calls itself "the currently supported list of configuration keys."
- **Minor — `PV_LOOP_INDEX_BASE` unlinked**: named in prose in `init-mode.md:30`, but has no row in the canonical `pantavisor-configuration.md` reference table.
- **Minor — `GET /wakelocks` unlinked**: endpoint registered (`ctrl/ctrl_wakelock_ep.c:52-56`) and documented in `wakelocks.md`, but missing from `pantavisor-commands.md`, the page enumerating every pv-ctrl endpoint.
- **Minor — `GET /config`, `GET /config2` unlinked**: both registered (`ctrl/ctrl_config_ep.c:63-64`); `pvcontrol.md` promises every subcommand maps to an endpoint documented in `pantavisor-commands.md`, but neither endpoint has a section there.
- **Major — `DEFER_REBOOT` payload mismatched**: source requires a non-empty payload used as the new debug-shell-reboot timeout (`pantavisor.c:711-723`, `tools/pvcontrol:730`), but `pantavisor-commands.md`'s op table listed the payload column as `N/A`, disagreeing with both source and `pvcontrol.md`'s own `defer-reboot <new_timeout>` description.
- **Major — `PVTXDIR` default mismatched**: source default is `/var/cache/pvtx` (root) / `~/.local/share/pvtx` (non-root) (`pvtx/src/pvtx_txn.c:55-56`, confirmed by `pvtx`'s own `--help` text), but `pantavisor-tools.md` stated `/var/pvr-sdk/pvtx`, matching neither.
- **Trivial — `pventer --container` undocumented**: `tools/pventer:16-17` accepts `--container` as a long-form alias of `-c`, never mentioned in `pantavisor-tools.md`'s synopsis or examples.

## What changed and why

- `docs/reference/pantavisor-configuration.md`: added Summary + Levels rows for `PV_POWER_DEVMETA_EAGER_PUSH`, `PV_SYSTEM_DISKSDIR`, all 8 `PV_POWER_*` keys, and `PV_LOOP_INDEX_BASE`, matching the existing alphabetical ordering and column structure. Closes 4 findings (`PV_POWER_DEVMETA_EAGER_PUSH`, `PV_SYSTEM_DISKSDIR`, the 8 `PV_POWER_*` keys, `PV_LOOP_INDEX_BASE`).
- `docs/overview/wakelocks.md`: added a `power.devmeta.eager_push` row to the Configuration table alongside its siblings. Closes the `wakelocks.md` half of the `PV_POWER_DEVMETA_EAGER_PUSH` finding.
- `docs/reference/pantavisor-commands.md`: added `## /wakelocks`, `## /config`, and `## /config2` sections matching the existing per-endpoint pattern (short description + curl example), and changed the `DEFER_REBOOT` row's payload column from `N/A` to `new_timeout`. Closes 4 findings.
- `docs/tools/pantavisor-tools.md`: fixed the `PVTXDIR` row to state both real defaults, and added a note that `--container` is the long-form alias of `-c` in the pventer section. Closes 2 findings.

All 9 findings from the report were re-verified against the current checkout (commit `c228d1e`) and confirmed still applicable; none were already resolved.

## Status

This is a **draft** PR opened from an automated docs-eval code-check fix pass. It has not been verified against the rendered site (docs.pantavisor.io) and needs human review before merging.

