### PR TITLE
fix(ctrl): require an exact cgroup name match for caller identity

### DIFF
--- a/ctrl/ctrl_caller.c
+++ b/ctrl/ctrl_caller.c
@@ -30,7 +30,6 @@
 #include <event2/http.h>
 #include <event2/bufferevent.h>
 
-#include <ctype.h>
 #include <string.h>
 
 #define MODULE_NAME "ctrl-caller"
@@ -48,7 +47,7 @@ int pv_ctrl_caller_init(struct pv_ctrl_caller *caller,
 {
 	pid_t pid = pv_socket_get_sender_pid(ctrl_caller_get_fd(req));
 	if (pid < 0) {
-		pv_log(WARN, "error requesting pid: %s (%d)", strerror(errno));
+		pv_log(WARN, "error requesting pid: %s", strerror(errno));
 		return -1;
 	}
 
@@ -63,32 +62,14 @@ int pv_ctrl_caller_init(struct pv_ctrl_caller *caller,
 
 	struct pantavisor *pv = pv_get_instance();
 	caller->plat = pv_state_fetch_platform(pv->state, name);
-	if (!caller->plat && pv_config_get_system_init_mode() == IM_APPENGINE) {
-		/* In appengine mode LXC may append -N to a container name when
-		 * the cgroup slot is already taken by a parallel test run.
-		 * Strip the suffix and retry so pvr-sdk-1 resolves to pvr-sdk. */
-		char *base = strdup(name);
-		if (base) {
-			char *dash = strrchr(base, '-');
-			if (dash) {
-				const char *p = dash + 1;
-				while (*p && isdigit((unsigned char)*p))
-					p++;
-				if (*p == '\0') {
-					*dash = '\0';
-					caller->plat = pv_state_fetch_platform(
-						pv->state, base);
-				}
-			}
-			free(base);
-		}
-	}
-	if (!caller->plat && strncmp(name, "_pv_", strlen(name))) {
+	bool is_pv = !strcmp(name, "_pv_");
+
+	if (!caller->plat && !is_pv) {
 		pv_log(WARN, "platform %s not found in current state", name);
 		goto out;
 	}
 
-	if (!strncmp(name, "_pv_", strlen(name)))
+	if (is_pv)
 		caller->is_privileged = true;
 	else
 		caller->is_privileged =


### PR DESCRIPTION
Caller identity in `pv_ctrl_caller_init()` is derived from the caller's cgroup name. Two paths accepted a non-exact match.

## 1. The `-N` suffix guess (appengine only)

```c
/* Strip the suffix and retry so pvr-sdk-1 resolves to pvr-sdk. */
```

A caller in cgroup `lxc/web-1` inherited platform `web`'s role — including its MGMT role — whenever `web-1` was not itself in the state.

It was added in f16fd493 for one reason: *"parallel test runs share the host cgroup namespace. When two containers both start an LXC container named `pvr-sdk`, LXC renames the second to `pvr-sdk-1`."* Each appengine worker now has its own cgroup namespace (pantavisor/meta-pantavisor#461), so those names no longer collide and the guess has nothing left to paper over.

A container legitimately named `web-1` still resolves — through the exact `pv_state_fetch_platform()` lookup, not by guessing.

## 2. The `_pv_` sentinel matched on any prefix (**all init modes**)

```c
strncmp(name, "_pv_", strlen(name))    /* length of name, not of "_pv_" */
```

`strlen(name)` means a caller whose name is a *prefix* of `_pv_` compares equal:

| cgroup name | today | correct |
|---|---|---|
| `_pv_` | privileged | privileged |
| `_pv` | **privileged** | not |
| `_p` | **privileged** | not |
| `_` | **privileged** | not |

So a container named `_`, `_p` or `_pv` is granted pantavisor's own authority on pv-ctrl. The same expression guards the "platform not found in current state" bail-out, so such a name skips that check too and needs no entry in the state at all.

Unlike the `-N` strip this is **not** mode-gated, so it applies to embedded devices as well as appengine. Fixed with `strcmp`.

## 3. Drive-by

`pv_log(WARN, "error requesting pid: %s (%d)", strerror(errno))` had a `%d` with no argument.

## Verification

`local` scope, 21 tests: **18 passed / 3 failed**, identical to master **reason-for-reason** — the 3 are a pre-existing `fallbear-cmd` cgroup-v1 issue on the test host, unrelated. `local/security/container-roles`, which exercises this role resolution directly, is unchanged.

Net `+5 / -24`.
