### PR TITLE
refactor(config): drop the dotted power.* aliases and document wakelocks with canonical keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Every feature described in `docs/` should give the reader a direct or inline pat
 
 ## Development Guidelines
 
+- **Configuration keys**: the `PV_*`/`PH_*` env-var name in `entries[]` (config.c) is the only identity of a key. The dotted `aliases[]` table is frozen legacy: never add an alias for a new entry, and write docs, commits, and examples in the env-var form only (see the note in [docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md)).
 - **Documentation**: Always check if [reference documentation](docs/reference/) should be updated after making changes to the code. Follow the link conventions in the Docs Pipeline section above.
 - **Commits**: Always use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (v1.0.0) for all commit messages.
 - **Formatting**: Run `clang-format -i` on modified `.c`/`.h` files before committing

--- a/config.c
+++ b/config.c
@@ -325,7 +325,7 @@ struct pv_config_alias {
 };
 
 static struct pv_config_alias aliases[] = {
-	// LEGACY CONFIG KEY
+	// frozen: keys that predate the env-var scheme only; never add new entries here
 	{ "creds.host", "PH_CREDS_HOST" },
 	{ "creds.id", "PH_CREDS_ID" },
 	{ "creds.port", "PH_CREDS_PORT" },
@@ -377,15 +377,6 @@ static struct pv_config_alias aliases[] = {
 	{ "net.brdev", "PV_NET_BRDEV" },
 	{ "net.brmask4", "PV_NET_BRMASK4" },
 	{ "policy", "PV_POLICY" },
-	{ "power.mode", "PV_POWER_MODE" },
-	{ "power.devmeta.eager_push", "PV_POWER_DEVMETA_EAGER_PUSH" },
-	{ "power.wake.interval", "PV_POWER_WAKE_INTERVAL" },
-	{ "power.wake.run_window", "PV_POWER_WAKE_RUN_WINDOW" },
-	{ "power.autosleep.settle", "PV_POWER_AUTOSLEEP_SETTLE" },
-	{ "power.wake.min_awake", "PV_POWER_WAKE_MIN_AWAKE" },
-	{ "power.wake.max_awake", "PV_POWER_WAKE_MAX_AWAKE" },
-	{ "power.devmeta.max_held", "PV_POWER_DEVMETA_MAX_HELD" },
-	{ "power.sysfs_dir", "PV_POWER_SYSFS_DIR" },
 	{ "revision.retries", "PV_REVISION_RETRIES" },
 	{ "secureboot.checksum", "PV_SECUREBOOT_CHECKSUM" },
 	{ "secureboot.handlers", "PV_SECUREBOOT_HANDLERS" },

--- a/docs/overview/pantavisor-configuration-levels.md
+++ b/docs/overview/pantavisor-configuration-levels.md
@@ -23,6 +23,10 @@ There are several ways to set Pantavisor configuration, depending on when it can
 
 Configuration file for [Pantavisor](pantavisor-architecture.md). It can only be changed at [build time](../../meta-pantavisor/overview/get-started.md).
 
+:::note
+Keys use the unified `PV_*`/`PH_*` env-var-style syntax; the older dotted syntax is legacy and frozen, so any key added since (e.g. `PV_POWER_*`) only exists in this form.
+:::
+
 ## pantahub.config
 
 [Build time](../../meta-pantavisor/overview/get-started.md) configuration file for Pantavisor built-in [Pantacor Hub client](remote-control.md#pantacor-hub).

--- a/docs/overview/wakelocks.md
+++ b/docs/overview/wakelocks.md
@@ -1,7 +1,7 @@
 # Wakelocks and power modes
 
 Pantavisor can block and schedule system suspend so a device sleeps between
-activity without missing updates. The behaviour is selected by `power.mode`:
+activity without missing updates. The behaviour is selected by `PV_POWER_MODE`:
 
 | mode | suspend | description |
 |------|---------|-------------|
@@ -37,7 +37,7 @@ scope owns a guard, so it contributes at most one to the count.
 
 `devmeta` is dirty-gated: held from a local `pv-ctrl` metadata change (only on an
 authenticated Hub device) until Hub acks the change, bounded by
-`power.devmeta.max_held`.
+`PV_POWER_DEVMETA_MAX_HELD`.
 
 ## Managed mode
 
@@ -51,10 +51,10 @@ platforms are up (first `RUN -> WAIT`), it enables kernel autosleep. From then:
    loop can re-suspend, then signals the event loop over an eventfd.
 3. The event loop opens a **wake window**: it re-arms the alarm for the next
    cycle and holds `poll` while it polls Hub. The window stays open at least
-   `power.wake.min_awake` (so the network can re-associate after deep
+   `PV_POWER_WAKE_MIN_AWAKE` (so the network can re-associate after deep
    suspend), until one poll round reaches Hub (or trivially, if unauthed/no
-   Hub configured) plus `power.wake.run_window` more as the containers'
-   guaranteed run time, bounded by `power.wake.max_awake`.
+   Hub configured) plus `PV_POWER_WAKE_RUN_WINDOW` more as the containers'
+   guaranteed run time, bounded by `PV_POWER_WAKE_MAX_AWAKE`.
 4. When the window closes, `poll` is released and the device suspends again.
 
 A found update holds `update` (independent of the poll window), so the device
@@ -62,7 +62,7 @@ stays awake through download, install and reboot regardless of the wake
 schedule.
 
 Every wake carries up to two payloads: the Hub roundtrip (if authed) and the
-container run window (`power.wake.run_window`, off by default). A wake is
+container run window (`PV_POWER_WAKE_RUN_WINDOW`, off by default). A wake is
 only re-armed if at least one payload applies — a device with neither Hub nor
 a declared run window has nothing to wake for and stays asleep until an
 external event.
@@ -77,17 +77,70 @@ the wakelock inline on the same thread closes that gap.
 
 | key | default | meaning |
 |-----|---------|---------|
-| `power.mode` | `locks` | `disabled` / `locks` / `managed` |
-| `power.devmeta.eager_push` | `false` | push a dirty `devmeta` change out-of-band right away rather than waiting up to a full devmeta interval, minimizing awake time |
-| `power.wake.interval` | `3600` | managed: seconds between timed wakes (device heartbeat) |
-| `power.wake.run_window` | `0` (off) | managed: after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
-| `power.autosleep.settle` | `90` | managed: delay after ready before autosleep is enabled |
-| `power.wake.min_awake` | `10` | managed: minimum awake seconds per wake window |
-| `power.wake.max_awake` | `60` | managed: maximum awake seconds per wake window |
-| `power.devmeta.max_held` | `300` | max seconds the `devmeta` lock is held awaiting a Hub ack |
-| `power.sysfs_dir` | `/sys/power` | base dir of the wakelock sysfs nodes |
+| `PV_POWER_MODE` | `locks` | `disabled` / `locks` / `managed` |
+| `PV_POWER_DEVMETA_EAGER_PUSH` | `false` | push a dirty `devmeta` change out-of-band right away rather than waiting up to a full devmeta interval, minimizing awake time |
+| `PV_POWER_WAKE_INTERVAL` | `3600` | managed: seconds between timed wakes (device heartbeat) |
+| `PV_POWER_WAKE_RUN_WINDOW` | `0` (off) | managed: after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
+| `PV_POWER_AUTOSLEEP_SETTLE` | `90` | managed: delay after ready before autosleep is enabled |
+| `PV_POWER_WAKE_MIN_AWAKE` | `10` | managed: minimum awake seconds per wake window |
+| `PV_POWER_WAKE_MAX_AWAKE` | `60` | managed: maximum awake seconds per wake window |
+| `PV_POWER_DEVMETA_MAX_HELD` | `300` | max seconds the `devmeta` lock is held awaiting a Hub ack |
+| `PV_POWER_SYSFS_DIR` | `/sys/power` | base dir of the wakelock sysfs nodes |
+
+All the DURATION keys above (every one but `PV_POWER_MODE` and
+`PV_POWER_SYSFS_DIR`) accept a bare number of seconds or a suffixed value —
+`30s`, `10min`, `1h`, `1d`.
+
+Set any of these like any other Pantavisor key — for example in
+`pantavisor.config` or as a boot environment variable, `PV_POWER_MODE=managed`
+— see [Configuration Levels](pantavisor-configuration-levels.md) for the full
+list of levels and precedence. Check the value actually in effect with
+`pvcontrol conf ls` (these keys have no legacy dotted alias, so they never show
+up in `pvcontrol config ls`).
 
 ## Inspecting state
 
-`GET /wakelocks` on the pv-ctrl socket returns the current mode, refcount,
-whether autosleep/settle/poll are active, and which scopes are held.
+`GET /wakelocks` on the pv-ctrl socket, or `pvcontrol wakelocks ls`, returns the
+current mode, refcount, whether autosleep/settle/poll are active, and which
+scopes are held:
+
+```
+$ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/wakelocks"
+{
+  "mode": "managed",
+  "count": 1,
+  "degraded": false,
+  "autosleep": true,
+  "settling": false,
+  "polling": true,
+  "run_window": true,
+  "held": {
+    "boot": false,
+    "update": false,
+    "update_check": false,
+    "devmeta": false,
+    "usrmeta": false,
+    "shutdown": false,
+    "debug_shell": false,
+    "poll": true
+  }
+}
+```
+
+| field | meaning |
+|-------|---------|
+| `mode` | the active power mode (`disabled` / `locks` / `managed`) |
+| `count` | current wakelock refcount; `0` means the device is free to suspend |
+| `degraded` | `true` when `locks` mode fell back to no-op wakelocks because the kernel lacks wakelock support (`managed` fails init instead) |
+| `autosleep` | `true` once managed mode has enabled kernel autosleep (after the settle delay) |
+| `settling` | `true` while managed mode is waiting out `PV_POWER_AUTOSLEEP_SETTLE` before enabling autosleep |
+| `polling` | `true` while a managed wake window is open (the device woke to poll Hub and/or run containers) |
+| `run_window` | `true` only while `polling` is true and the guaranteed container run window has not yet elapsed |
+| `held.boot` | the `boot` wakelock, held from start until the FSM first reaches steady state |
+| `held.update` | an update is downloading, installing, or in its post-boot test/commit |
+| `held.update_check` | a poll-for-updates roundtrip is in flight |
+| `held.devmeta` | a local device-metadata change is not yet synced to Hub |
+| `held.usrmeta` | a user-metadata GET is in flight |
+| `held.shutdown` | teardown (sync, unmount) is running during shutdown |
+| `held.debug_shell` | a debug/serial shell session is open |
+| `held.poll` | a managed-mode wake window is open (mirrors `polling`) |

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -95,10 +95,29 @@ $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/groups"
 
 ## /wakelocks
 
-Returns the current [power mode and wakelock state](../overview/wakelocks.md#inspecting-state): mode, refcount, whether autosleep/settle/poll are active, and which scopes are held. See [Wakelocks and power modes](../overview/wakelocks.md) for full semantics.
+Returns the current [power mode and wakelock state](../overview/wakelocks.md#inspecting-state): mode, refcount, whether autosleep/settle/poll are active, and which scopes are held. See [Wakelocks and power modes](../overview/wakelocks.md) for the field-by-field semantics.
 
 ```
 $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/wakelocks"
+{
+  "mode": "locks",
+  "count": 0,
+  "degraded": false,
+  "autosleep": false,
+  "settling": false,
+  "polling": false,
+  "run_window": false,
+  "held": {
+    "boot": false,
+    "update": false,
+    "update_check": false,
+    "devmeta": false,
+    "usrmeta": false,
+    "shutdown": false,
+    "debug_shell": false,
+    "poll": false
+  }
+}
 ```
 
 ## /signal

--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -11,6 +11,10 @@ This reference page presents the newly unified configuration key syntax. To get 
 :::
 
 :::note
+The legacy dotted key set is frozen: it only covers keys that predate the unified syntax. Keys added since (for example the `PV_POWER_*` power keys) have no dotted form and new keys are never given one. `GET /config` (`pvcontrol config ls`) therefore only shows the pre-existing legacy keys — use `/config2` (`pvcontrol conf ls`) for the full set.
+:::
+
+:::note
 This page lists all configuration keys, their values, and the levels each one supports. For an explanation of what each level means and how they take precedence over one another, see [Configuration Levels](../overview/pantavisor-configuration-levels.md).
 :::
 

--- a/docs/tools/pvcontrol.md
+++ b/docs/tools/pvcontrol.md
@@ -123,14 +123,17 @@ Plain-text build manifest. May be empty on some builds.
 ### Configuration
 
 ```bash
-pvcontrol config ls    # legacy /config — aliased key names
+pvcontrol config ls    # legacy /config — frozen, dotted-alias keys only
 pvcontrol conf ls      # full /config2 — complete configuration object
 ```
 
 Both return the active Pantavisor configuration. `conf ls` returns an array of
 `{key, value, modified}` records (the `modified` field shows where the value
-came from — `default`, a config file, etc.); `config ls` returns a flat object
-with aliased dotted keys:
+came from — `default`, a config file, etc.) covering every key; `config ls`
+returns a flat object with dotted keys, but only for the ones that predate the
+env-var scheme — that alias table is frozen, so a key added since (e.g. the
+`PV_POWER_*` power keys) has no dotted form and only ever shows up in
+`conf ls`:
 
 ```json
 // pvcontrol conf ls
@@ -152,6 +155,22 @@ pvcontrol graph ls
 
 Returns the current xconnect service-mesh graph (providers/consumers and the
 links between them). See [pantavisor-xconnect.md](../reference/pantavisor-xconnect.md).
+
+### Wakelocks
+
+```bash
+pvcontrol wakelocks ls
+```
+
+Returns the current power mode and wakelock state — mode, refcount, whether
+autosleep/settle/poll are active, and which scopes are held. Example output:
+
+```json
+{"mode":"locks","count":0,"degraded":false,"autosleep":false,"settling":false,"polling":false,"run_window":false,"held":{"boot":false,"update":false,"update_check":false,"devmeta":false,"usrmeta":false,"shutdown":false,"debug_shell":false,"poll":false}}
+```
+
+See [wakelocks.md](../overview/wakelocks.md#inspecting-state) for the
+field-by-field semantics and the `PV_POWER_*` configuration keys.
 
 ---
 
@@ -467,6 +486,7 @@ On a platform without managed drivers these are effectively no-ops returning
 | `daemons ls` | GET | `/daemons` |
 | `daemons start\|stop\|restart <name>` | PUT | `/daemons/{name}` |
 | `graph ls` | GET | `/xconnect-graph` |
+| `wakelocks ls` | GET | `/wakelocks` |
 | `signal ready\|alive` | POST | `/signal` |
 | `cmd <subcommand>` | POST | `/commands` |
 | `storage gc` | POST | `/storage/gc` |

--- a/pantavisor.c
+++ b/pantavisor.c
@@ -276,7 +276,7 @@ static pv_state_t _pv_run(struct pantavisor *pv)
 	// load configuration that lives in revision
 	pv_config_load_update(pv->state->rev, pv->state->bsp.config);
 
-	// power.mode may live in a config level loaded only now (e.g.
+	// PV_POWER_MODE may live in a config level loaded only now (e.g.
 	// pantahub.config on /storage); apply it so managed mode can start
 	pv_wakelock_apply_config();
 

--- a/power/wakelock.c
+++ b/power/wakelock.c
@@ -69,7 +69,7 @@
 
 static struct pv_wakelock {
 	bool init;
-	// power.mode=locks degrades (not fails) when the kernel lacks wakelock
+	// PV_POWER_MODE=locks degrades (not fails) when the kernel lacks wakelock
 	// support, since it never changes fundamental power behavior
 	bool degraded;
 	power_mode_t mode;
@@ -989,7 +989,7 @@ int pv_wakelock_init(void)
 
 		if (wl.mode == PWR_MANAGED) {
 			pv_log(ERROR,
-			       "wakelock: power.mode=%s requires kernel wakelock support: %s",
+			       "wakelock: PV_POWER_MODE=%s requires kernel wakelock support: %s",
 			       pv_config_get_power_mode_str(),
 			       strerror(open_errno));
 			wl.init = false;
@@ -998,7 +998,7 @@ int pv_wakelock_init(void)
 
 		wl.degraded = true;
 		pv_log(WARN,
-		       "wakelock: power.mode=locks unavailable: no kernel wakelock support (%s); continuing with wakelocks disabled",
+		       "wakelock: PV_POWER_MODE=locks unavailable: no kernel wakelock support (%s); continuing with wakelocks disabled",
 		       strerror(open_errno));
 		return 0;
 	}
@@ -1018,7 +1018,7 @@ int pv_wakelock_init(void)
 		int max_awake = pv_config_get_int(PV_POWER_WAKE_MAX_AWAKE);
 		if (min_awake + run_window > max_awake)
 			pv_log(WARN,
-			       "wakelock: power.wake.min_awake (%ds) + power.wake.run_window (%ds) exceeds power.wake.max_awake (%ds); the cap will swallow the run window",
+			       "wakelock: PV_POWER_WAKE_MIN_AWAKE (%ds) + PV_POWER_WAKE_RUN_WINDOW (%ds) exceeds PV_POWER_WAKE_MAX_AWAKE (%ds); the cap will swallow the run window",
 			       min_awake, run_window, max_awake);
 
 		_managed_arm_alarm();

--- a/power/wakelock.h
+++ b/power/wakelock.h
@@ -43,7 +43,7 @@ enum wl_scope {
 };
 
 int pv_wakelock_init(void);
-// Re-evaluate power.mode once config levels that load after pv_wakelock_init()
+// Re-evaluate PV_POWER_MODE once config levels that load after pv_wakelock_init()
 // (e.g. pantahub.config on /storage) are available.
 void pv_wakelock_apply_config(void);
 
@@ -57,7 +57,7 @@ void pv_wakelock_acquire(enum wl_scope scope);
 void pv_wakelock_release(enum wl_scope scope);
 
 // The devmeta scope is dirty-gated: held from a local pv-ctrl mutation until it
-// syncs to Hub or power.devmeta.max_held elapses. A generation counter keeps a
+// syncs to Hub or PV_POWER_DEVMETA_MAX_HELD elapses. A generation counter keeps a
 // change that lands mid-flight from releasing early.
 void pv_wakelock_devmeta_dirty(void);
 void pv_wakelock_devmeta_sent(void);

--- a/tools/pvcontrol
+++ b/tools/pvcontrol
@@ -46,7 +46,7 @@ OUTPUT=""
 MESSAGE=""
 
 usage() {
-	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons|storage> [arguments]"
+	echo "Usage: pvcontrol [options] <ls|containers|groups|signal|cmd|usrmeta|devmeta|buildinfo|objects|steps|conf|graph|daemons|storage|wakelocks> [arguments]"
 	echo "Control Pantavisor from your container"
 	echo "options:"
 	echo "       -h           show help"
@@ -169,6 +169,12 @@ usage_conf() {
 	echo "Usage: pvcontrol <configuration|conf> <ls>"
 	echo "Configuration related operations"
 	echo "       pvcontrol conf ls - lists current configuration"
+}
+
+usage_wakelocks() {
+	echo "Usage: pvcontrol wakelocks <ls>"
+	echo "Power mode and wakelock state operations"
+	echo "       pvcontrol wakelocks ls - show current power mode and wakelock state"
 }
 
 parse_ls_args() {
@@ -512,6 +518,20 @@ parse_conf_args() {
 	esac
 }
 
+parse_wakelocks_args() {
+	case "$1" in
+	ls|list)
+		cmd='listwakelocks'
+		;;
+	--help)
+		usage_wakelocks; exit 0
+		;;
+	*)
+		usage_wakelocks; exit 1
+		;;
+	esac
+}
+
 parse_args() {
 	# parse options
 	while [ $# -gt 0 ]; do
@@ -581,6 +601,9 @@ parse_args() {
 		;;
 	graph)
 		parse_graph_args "$2"
+		;;
+	wakelocks)
+		parse_wakelocks_args "$2"
 		;;
 	daemons)
 		parse_daemons_args "$2" "$3"
@@ -818,6 +841,9 @@ exec_cmd() {
 			;;
 		listconf)
 			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/config2"`
+			;;
+		listwakelocks)
+			response=`$CURL -X GET --unix-socket "$SOCKET" "http://localhost/wakelocks"`
 			;;
 		*)
 			echo "ERROR: unknown operation"; exit 1


### PR DESCRIPTION
## Summary

- **Drop the dotted `power.*` config aliases.** The wakelock/power subsystem landed after the unified `PV_*`/`PH_*` key scheme, so it should never have had a legacy dotted form. The nine `power.*` entries are removed from `aliases[]` in `config.c`.
- **Freeze the legacy key table, in the repo.** The alias table now says so in a one-line comment; the policy is written into `AGENTS.md` (Development Guidelines: "Configuration keys"), `docs/reference/pantavisor-configuration.md`, and `docs/overview/pantavisor-configuration-levels.md`: keys added since the unified syntax have no dotted form and new keys never get one; `GET /config` / `pvcontrol config ls` only shows the pre-existing legacy set, `/config2` / `pvcontrol conf ls` shows everything.
- **Wakelocks docs use only the canonical keys.** `docs/overview/wakelocks.md` is rewritten to `PV_POWER_*` throughout, documents the accepted DURATION forms (`30s`, `10min`, `1h`, `1d`, bare = seconds), and shows how to set and check a key. Comments/log strings in `power/wakelock.{c,h}` and `pantavisor.c` that still spelled the dotted names follow suit.
- **pv-ctrl documentation for wakelocks.** `GET /wakelocks` is now documented with a full example response and a field table (derived from `pv_wakelock_get_json()`) in `wakelocks.md` and `docs/reference/pantavisor-commands.md`. `pvcontrol` gains `wakelocks ls`, documented in `docs/tools/pvcontrol.md` and its command-to-endpoint table.

## Validation

- x86_64 appengine build (kas `docker-x86_64-scarthgap.yaml` + `with-workspace.yaml`), pantavisor sstate cleaned and rebuilt; the shipped binary carries no dotted power names and the shipped `pvcontrol` has the new subcommand.
- Local pvtest suite: 19/22 PASS. The 3 non-PASS (`security/container-roles`, `security/oem-secureboot`, `security/strict-secure-boot`) differ from their goldens only by the known `fallbear-cmd ... /sys/fs/cgroup/devices//cgroup.procs` host noise (unmounted cgroup-v1 `devices` hierarchy on the dev host). `core/legacy-config-overload`, `core/modern-config-overload` and all `control/*` tests pass.

## Out of scope / follow-ups

- Other post-scheme keys still carry dotted aliases (`system.drivers.load_early.auto`, `xconnect.dbus.systembus.enabled`, `metadata.devmeta.*`); candidates for the same treatment in a follow-up.
- `CHANGELOG/CHANGELOG-030.md` still mentions `power.wake.run_window` as a historical record.
- meta-pantavisor SRCREV bump via the automated job after merge.
