### PR TITLE
feat(pvtest): name the board re-type mechanism setbootconfig

### DIFF
--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -37,7 +37,7 @@ usage() {
 	echo "       PVTEST_CTRL               ctrl dir mounted from the host (req/resp/state)"
 	echo "       PVTEST_SLOTS              worker count (default: 1)"
 	echo "       PVTEST_MODEL              persistent (keep target across tests) | volatile (one per test)"
-	echo "       PVTEST_RETYPE             container (boot a generation) | hook (power-cycle a board) | none"
+	echo "       PVTEST_RETYPE             container (boot a generation) | setbootconfig (write the boot config, power-cycle a board) | none"
 	echo "       PVTEST_EXEC/PVTEST_HOST   as above, for a target that never re-types; a"
 	echo "                                 ready ctrl reply supersedes them for that slot"
 	echo ""
@@ -894,7 +894,7 @@ _install_initial_rev() {
 	local _st _res=0
 	_st=$(pvcontrol steps show-progress "$rev" 2>/dev/null | jq -r '.status' 2>/dev/null)
 	case "$PVTEST_RETYPE" in
-		container|hook)
+		container|setbootconfig|hook)
 			_reqcfg_gate "$required_env"; _res=$?
 			;;
 		*)


### PR DESCRIPTION
## Summary

`PVTEST_RETYPE=hook` said nothing about what the host does for a real board: it runs a board-specific script that writes a given set of pantavisor boot-config tokens to the device's boot-time config and power-cycles it. Name the mechanism `setbootconfig`, matching the manifest key on the meta-pantavisor side, where the script's input/output contract is now written down (pantavisor/meta-pantavisor#476).

`hook` is still accepted, so either repo can land first. Split out of #803 so it can go in before the native runner.

## Test plan

- [x] `pvtest-run` usage text and the `PVTEST_RETYPE` case updated; the appengine `container` path is untouched