### PR TITLE
docs: overview vs reference contract and fixup

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,43 @@
+name: "Docs"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "scripts/check-docs.sh"
+      - "config.c"
+      - "config.h"
+      - "ctrl/**"
+      - "metadata.h"
+      - "metadata.c"
+      - "logserver/**"
+      - "tools/pvcontrol"
+      - ".github/workflows/docs.yaml"
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - "*"
+    paths:
+      - "docs/**"
+      - "scripts/check-docs.sh"
+      - "config.c"
+      - "config.h"
+      - "ctrl/**"
+      - "metadata.h"
+      - "metadata.c"
+      - "logserver/**"
+      - "tools/pvcontrol"
+      - ".github/workflows/docs.yaml"
+
+jobs:
+  check:
+    name: "check docs against code"
+    runs-on: ["self-hosted"]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: check docs
+        run: ./scripts/check-docs.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,20 +15,49 @@ Pantavisor is a container-based runtime for embedded Linux systems. It handles c
 
 ## Documentation
 
+**Read [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) before writing or editing anything under `docs/`.** It is the
+single source of truth for placement, table conventions, frontmatter, and link conventions. The
+essentials:
+
+| Folder | Answers | Contains | Never contains |
+|--------|---------|----------|----------------|
+| `docs/overview/` | *How does this work, and why?* | Prose, rationale, diagrams, worked examples | Exhaustive key/field/endpoint tables — link to reference |
+| `docs/reference/` | *What exactly are the valid values?* | Complete tables: keys, values, defaults, fields, status codes | Multi-paragraph explanation — link to overview |
+| `docs/tools/` | *How do I invoke it?* | CLI synopsis, flags, exit codes, worked invocations | Subsystem theory |
+
+Reference is authoritative and complete; overview is readable top-to-bottom and never complete.
+If a value is enumerable from the code, it belongs in a reference table — never write `string`
+where the parser accepts a fixed set of tokens.
+
+### Every change gets a documentation pass
+
+After any change — a new feature, a change to an existing one, a fix that alters behaviour — stop
+and ask whether the **overview** and the **reference** still describe reality. Usually one of them
+needs an edit and often both do: the reference because a value, field or endpoint moved, and the
+overview because the explanation around it no longer matches.
+
+Answering "no change needed" is a fine outcome, but it should be an answer, not an omission.
+
+Run `scripts/check-docs.sh` before committing. It mechanically verifies configuration keys, control
+socket routes and device metadata keys against the code, and validates frontmatter, index membership
+and links — but it only catches what is enumerable. Whether the prose still makes sense is on you.
+
 ### Reference (`docs/reference/`)
 
 API and format specifications, versioned with each Pantavisor release. Always update when modifying the corresponding feature.
 
 | Document | Location | Description |
 |----------|----------|-------------|
+| **State Format** | [docs/reference/pantavisor-state-format-v2.md](docs/reference/pantavisor-state-format-v2.md) | state.json format (v2) |
+| **Configuration** | [docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md) | All configuration keys, values, defaults, and levels |
 | **Control Socket** | [docs/reference/pantavisor-commands.md](docs/reference/pantavisor-commands.md) | pv-ctrl HTTP endpoints (containers → PV) |
 | **xconnect** | [docs/reference/pantavisor-xconnect.md](docs/reference/pantavisor-xconnect.md) | Service mesh manifests and mediation patterns |
 | **xconnect Spec** | [xconnect/XCONNECT.md](xconnect/XCONNECT.md) | Technical specification and plugin architecture |
-| **Configuration** | [docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md) | All configuration keys, defaults, and levels |
-| **Log Sockets** | [docs/reference/logserver-sockets.md](docs/reference/logserver-sockets.md) | Logserver unix sockets reference |
 | **Metadata** | [docs/reference/pantavisor-metadata.md](docs/reference/pantavisor-metadata.md) | User and device metadata reference |
-| **State Format** | [docs/reference/pantavisor-state-format-v2.md](docs/reference/pantavisor-state-format-v2.md) | state.json format (v2) |
+| **Log Sockets** | [docs/reference/logserver-sockets.md](docs/reference/logserver-sockets.md) | Logserver sockets, protocols, outputs, timestamp formats |
 | **IPAM** | [docs/reference/pantavisor-ipam.md](docs/reference/pantavisor-ipam.md) | Address pool schema, per-container assignment, backend-plugin hook |
+| **Hooks** | [docs/reference/pantavisor-hooks.md](docs/reference/pantavisor-hooks.md) | Hook points, hook environment variables, failure semantics |
+| **Power** | [docs/reference/pantavisor-power.md](docs/reference/pantavisor-power.md) | Power modes, wakelock scopes, `PV_POWER_*` keys, `/wakelocks` |
 
 ### Tools (`docs/tools/`)
 
@@ -55,11 +84,12 @@ Feature overview intended to be read top-to-bottom as a book, versioned with eac
 | **Remote Control** | [docs/overview/remote-control.md](docs/overview/remote-control.md) | Pantacor Hub client and remote controllers |
 | **Local Control** | [docs/overview/local-control.md](docs/overview/local-control.md) | pv-ctrl socket, Pantabox, pvcontrol |
 | **IPAM** | [docs/overview/ipam.md](docs/overview/ipam.md) | Container IP address management: pools, allocation, network namespaces |
+| **Inter-Container Communication** | [docs/overview/xconnect.md](docs/overview/xconnect.md) | xconnect service mesh overview |
+| **Hooks** | [docs/overview/hooks.md](docs/overview/hooks.md) | System lifecycle hooks |
+| **Watchdog** | [docs/overview/watchdog.md](docs/overview/watchdog.md) | Watchdog configuration and modes |
+| **Power and Wakelocks** | [docs/overview/wakelocks.md](docs/overview/wakelocks.md) | Suspend, wakelocks, managed power mode |
 | **Configuration Levels** | [docs/overview/pantavisor-configuration-levels.md](docs/overview/pantavisor-configuration-levels.md) | Configuration levels and precedence |
 | **Init Mode** | [docs/overview/init-mode.md](docs/overview/init-mode.md) | Embedded, standalone, appengine modes |
-| **Watchdog** | [docs/overview/watchdog.md](docs/overview/watchdog.md) | Watchdog configuration and modes |
-| **Hooks** | [docs/overview/hooks.md](docs/overview/hooks.md) | System lifecycle hooks |
-| **Inter-Container Communication** | [docs/overview/xconnect.md](docs/overview/xconnect.md) | xconnect service mesh overview |
 
 ## Docs Pipeline
 
@@ -67,25 +97,8 @@ The `docs/` folder is published on [docs.pantavisor.io/reference](https://docs.p
 1. Each meta-pantavisor release publishes a docs tarball, tracked in [`releases.json`](https://pantavisor-ci.s3.amazonaws.com/meta-pantavisor/releases.json) on S3. The tarball bundles this repo's `docs/` as `pantavisor/` and meta-pantavisor's `docs/` as a sibling `meta-pantavisor/` directory.
 2. `scripts/sync-reference.mjs` + `migrate-docs.js` in docs.pantavisor download the tarball for each published version listed in `releases.json` and generate a versioned instance at `/reference/<version>/pantavisor/...`. This covers everything under `docs/` — `docs/reference/`, `docs/overview/`, and `docs/tools/` alike — snapshotted together per release.
 3. Hand-authored, versionless guides live in the site's `curated/` instance (served at the site root, e.g. `/build`, `/install`, `/operate`); they are never generated from this repo.
-
-### Actionability (docs/)
-
-Every feature described in `docs/` should give the reader a direct or inline path to *do* something with it, not just explain the concept. Concretely:
-
-- Alongside (or right after) the conceptual explanation of a feature, show the concrete command, config key, or endpoint that exercises it — e.g. a `pvcontrol` invocation ([docs/tools/pvcontrol.md](docs/tools/pvcontrol.md)), a raw `pv-ctrl` call ([docs/reference/pantavisor-commands.md](docs/reference/pantavisor-commands.md)), a configuration key ([docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md)), or an on-disk path to inspect ([docs/overview/storage.md](docs/overview/storage.md)).
-- Prefer a short fenced code block over prose describing what a command does — show the invocation and, where useful, its output.
-- If a feature genuinely has no user-facing action (e.g. it's fully automatic, internal bookkeeping), say so explicitly rather than leaving the reader to wonder — a one-line "this is managed automatically; no action needed" is enough.
-- Verify every command, config key, path, and filename you add against the actual source or an existing doc before writing it down — don't invent plausible-looking examples.
-- This applies both when writing new docs and when editing existing ones: if you touch a section that only explains a feature without showing how to use it, add the missing hands-on reference while you're there.
-
-### Link conventions (docs/)
-
-- **Within the same folder**: plain relative links, e.g. `containers.md#restart-policy`.
-- **Between `docs/overview/`, `docs/reference/`, and `docs/tools/`**: relative sibling links, e.g. `../reference/pantavisor-commands.md#steps`, `../overview/containers.md#status`, or `../tools/pvcontrol.md`. These resolve both on GitHub and on the published site.
-- **To meta-pantavisor docs**: `../../meta-pantavisor/<section>/<page>.md` — resolves only on the published site, where both repos' docs are siblings.
-- **To curated site pages**: full URLs, e.g. `https://docs.pantavisor.io/operate/device-access/serial-port`.
-- **Do not** use the retired MkDocs-era prefixes (`../../../reference/legacy/`, `../../../reference/027/`, `../../pantavisor-src/docs/...`) — they dangle on the Docusaurus site.
-- **Syntax**: the site renders MDX. Use Docusaurus admonitions (`:::note` … `:::`), not MkDocs `!!! Note`; avoid MkDocs Material icon codes like `:material-check:`.
+4. Pages marked `draft: true` — [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) and [docs/issues.md](docs/issues.md) — are excluded from the published build.
+5. `docs.pantahub.com`, the retired MkDocs site, still 301-redirects into some of those published URLs. A page's path under `docs/` is its URL, so renaming, moving, deleting or drafting one of the pages frozen in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#page-urls-are-permanent) turns a live redirect into a 404. `scripts/check-docs.sh` enforces the list.
 
 ## Architecture
 
@@ -99,7 +112,7 @@ Every feature described in `docs/` should give the reader a direct or inline pat
 ## Development Guidelines
 
 - **Configuration keys**: the `PV_*`/`PH_*` env-var name in `entries[]` (config.c) is the only identity of a key. The dotted `aliases[]` table is frozen legacy: never add an alias for a new entry, and write docs, commits, and examples in the env-var form only (see the note in [docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md)).
-- **Documentation**: Always check if [reference documentation](docs/reference/) should be updated after making changes to the code. Follow the link conventions in the Docs Pipeline section above.
+- **Documentation**: Every change gets a [documentation pass](#every-change-gets-a-documentation-pass) in the same commit — consider both the overview and the reference. See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for what belongs where, and run `scripts/check-docs.sh` before committing.
 - **Commits**: Always use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (v1.0.0) for all commit messages.
 - **Formatting**: Run `clang-format -i` on modified `.c`/`.h` files before committing
 - **API testing**: Use `pvcurl` (not `curl`) inside appengine containers

--- a/README.md
+++ b/README.md
@@ -40,42 +40,17 @@ After you've downloaded and flashed your device with Pantavisor, try out a tutor
 
 * For an overview of Pantavisor see:  [Working with Pantavisor](https://docs.pantahub.com/before-you-begin/)
 
-## Reference Documentation
+## Documentation
 
-| Document | Location | Description |
-|----------|----------|-------------|
-| **Control Socket** | [docs/reference/pantavisor-commands.md](docs/reference/pantavisor-commands.md) | Reference for pv-ctrl HTTP endpoints (containers -> PV) |
-| **xconnect** | [docs/reference/pantavisor-xconnect.md](docs/reference/pantavisor-xconnect.md) | Service mesh logic and manifests (container <-> container) |
-| **xconnect Spec** | [xconnect/XCONNECT.md](xconnect/XCONNECT.md) | Technical specification and plugin architecture |
-| **Configuration** | [docs/reference/pantavisor-configuration.md](docs/reference/pantavisor-configuration.md) | Pantavisor configuration reference |
-| **Log Sockets** | [docs/reference/logserver-sockets.md](docs/reference/logserver-sockets.md) | Logserver unix sockets reference |
-| **Metadata** | [docs/reference/pantavisor-metadata.md](docs/reference/pantavisor-metadata.md) | User and device metadata reference |
-| **State Format** | [docs/reference/pantavisor-state-format-v2.md](docs/reference/pantavisor-state-format-v2.md) | Pantavisor state.json format (v2) |
-| **Config (Legacy)**| [docs/reference/pantavisor-configuration-legacy.md](docs/reference/pantavisor-configuration-legacy.md) | Legacy configuration reference |
+The full runtime documentation lives in [`docs/`](docs/index.md) and is published on
+[docs.pantavisor.io/reference](https://docs.pantavisor.io/reference):
 
-## Tools
+- [Technical Overview](docs/overview/index.md) — how Pantavisor works, meant to be read top-to-bottom
+- [Reference](docs/reference/index.md) — state format, configuration keys, control socket, metadata, log sockets, hooks, power, IPAM, xconnect
+- [Tools](docs/tools/index.md) — `pventer`, `pvcurl`, `pvcontrol`, `pvtx`
 
-| Document | Location | Description |
-|----------|----------|-------------|
-| **Tools** | [docs/tools/pantavisor-tools.md](docs/tools/pantavisor-tools.md) | pventer, pvcurl, pvcontrol, pvtx — on-device CLI tools |
-| **pvcontrol** | [docs/tools/pvcontrol.md](docs/tools/pvcontrol.md) | Full `pvcontrol` CLI reference with worked examples |
-
-## Technical Overview
-
-| Document | Location | Description |
-|----------|----------|-------------|
-| **Architecture** | [docs/overview/pantavisor-architecture.md](docs/overview/pantavisor-architecture.md) | High-level architecture and state machine |
-| **Revisions** | [docs/overview/revisions.md](docs/overview/revisions.md) | Revision concept and state JSON structure |
-| **BSP** | [docs/overview/bsp.md](docs/overview/bsp.md) | Kernel, modules, firmware, bootloader |
-| **Containers** | [docs/overview/containers.md](docs/overview/containers.md) | Container runtime, groups, roles, status |
-| **Updates** | [docs/overview/updates.md](docs/overview/updates.md) | Update flow, states, transitions |
-| **Storage** | [docs/overview/storage.md](docs/overview/storage.md) | On-disk layout, logs, metadata, integrity |
-| **Remote Control** | [docs/overview/remote-control.md](docs/overview/remote-control.md) | Pantacor Hub client and remote controllers |
-| **Local Control** | [docs/overview/local-control.md](docs/overview/local-control.md) | pv-ctrl socket, Pantabox, pvcontrol |
-| **Configuration Levels** | [docs/overview/pantavisor-configuration-levels.md](docs/overview/pantavisor-configuration-levels.md) | Configuration levels and precedence |
-| **Init Mode** | [docs/overview/init-mode.md](docs/overview/init-mode.md) | Embedded, standalone, appengine modes |
-| **Watchdog** | [docs/overview/watchdog.md](docs/overview/watchdog.md) | Watchdog configuration and modes |
-| **Inter-Container Communication** | [docs/overview/xconnect.md](docs/overview/xconnect.md) | xconnect service mesh overview |
+Contributing documentation? See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for what belongs in
+overview vs. reference vs. tools.
 
 ## Getting help and support
 We're a friendly and helpful community and welcome questions, and any feedback you may have. 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+---
+title: "Documentation Contract"
+draft: true
+---
+
+# Documentation Contract
+
+How to decide where a documentation change goes. This page is the single source of truth for the
+rules; [AGENTS.md](../AGENTS.md) points here rather than restating them.
+
+It is `draft: true`, so it never publishes to docs.pantavisor.io — it is for people and agents
+working in this repository.
+
+## The three folders
+
+| Folder | Answers | Contains | Never contains |
+|--------|---------|----------|----------------|
+| [`docs/overview/`](overview/index.md) | *How does this work, and why is it built this way?* | Prose, rationale, diagrams, worked examples, algorithm walk-throughs | Exhaustive key / field / endpoint tables — link to reference instead |
+| [`docs/reference/`](reference/index.md) | *What exactly are the valid values?* | Tables: every key, every accepted value, every default, every field, every status code | Multi-paragraph explanation — link to overview instead |
+| [`docs/tools/`](tools/index.md) | *How do I invoke it?* | CLI synopsis, flags, exit codes, worked invocations | Subsystem theory |
+
+Reference is **authoritative and complete**. Overview is **readable top-to-bottom and never
+complete** — it is allowed to skip cases, and it must say where the complete list lives.
+
+## Deciding where a change goes
+
+Ask, in order:
+
+1. **Is it enumerable from the code?** A config key, an accepted value, an endpoint, a JSON field,
+   an environment variable, a status code, an exit code. → **reference**. If the set is finite,
+   list every member; never write `string` where the parser accepts seven specific tokens.
+2. **Does it explain a mechanism, a trade-off, or a "why"?** → **overview**.
+3. **Is it how to run a command-line tool?** → **tools**.
+4. **Both?** Write both, and link them to each other. The overview names the feature and explains
+   it; the reference table is the complete list. Neither duplicates the other's job.
+
+A new subsystem needs all three of: an overview page, an entry in
+[`overview/index.md`](overview/index.md), and a reference page for its tables. A feature that is
+purely a set of config keys may skip the overview page, but its keys still go in the
+[configuration reference](reference/pantavisor-configuration.md).
+
+## Every change gets a documentation pass
+
+After any change (a new feature, a change to an existing one, a fix that alters behaviour) stop
+and ask whether the **overview** and the **reference** still describe reality. Usually one of them
+needs an edit and often both do: the reference because a value, field or endpoint moved, and the
+overview because the explanation around it no longer matches. Answering "no change needed" is a
+fine outcome, but it should be an answer, not an omission.
+
+The map below is a lookup aid for the reference half — where each subsystem's tables live. It is
+not a list of the only changes that need documenting.
+
+| Subsystem | Reference page |
+|-----------|----------------|
+| Configuration keys (`config.c` `entries[]`, `config.h` `config_index_t`) | [`reference/pantavisor-configuration.md`](reference/pantavisor-configuration.md) — **both** the Summary and the Levels table |
+| Control socket routes and status codes (`ctrl/*_ep.c`) | [`reference/pantavisor-commands.md`](reference/pantavisor-commands.md) |
+| Commands (`ctrl/ctrl_cmd.h`) | [`reference/pantavisor-commands.md`](reference/pantavisor-commands.md) `/commands` section |
+| Device metadata (`metadata.h` `DEVMETA_KEY_*`) | [`reference/pantavisor-metadata.md`](reference/pantavisor-metadata.md) |
+| Log server and its protocols (`logserver/`) | [`reference/logserver-sockets.md`](reference/logserver-sockets.md) |
+| Manifest parsing for `run.json`, `device.json`, `groups.json`, `disks.json` | [`reference/pantavisor-state-format-v2.md`](reference/pantavisor-state-format-v2.md) |
+| Hooks (`hooks.c`) | [`reference/pantavisor-hooks.md`](reference/pantavisor-hooks.md) |
+| Power and wakelocks (`power/`) | [`reference/pantavisor-power.md`](reference/pantavisor-power.md) |
+| IPAM (`ipam/`) | [`reference/pantavisor-ipam.md`](reference/pantavisor-ipam.md) |
+| xconnect manifests (`xconnect/`) | [`reference/pantavisor-xconnect.md`](reference/pantavisor-xconnect.md) |
+| `tools/pvcontrol` | [`tools/pvcontrol.md`](tools/pvcontrol.md) |
+| `tools/pventer`, `tools/pvcurl` | [`tools/pantavisor-tools.md`](tools/pantavisor-tools.md) |
+
+`scripts/check-docs.sh` mechanically verifies the first four rows against the code. Everything else,
+including whether the overview still reads true, is on you.
+
+## Table conventions
+
+- **Enumerate.** If the parser accepts a fixed set of strings, the Value column lists all of them.
+  `string` is only correct for genuinely free-form values.
+- **Default means the built-in default** — the value in `config.c`'s `entries[]` table, *not* what
+  `embedded/pantavisor.config.in` or `appengine/pantavisor.config.in` ships.
+- **One row, one line.** No paragraphs inside a cell. If a value needs explanation, put a sentence
+  under the table or link to the overview page.
+- **Sorted.** Key tables are alphabetical.
+- **Verified.** Every command, key, path and filename is checked against the source before it is
+  written down. Do not invent plausible-looking examples.
+
+## Actionability
+
+Every feature described in `docs/` gives the reader a direct path to *do* something with it:
+
+- Alongside the concept, show the concrete command, config key, or endpoint that exercises it — a
+  [`pvcontrol`](tools/pvcontrol.md) invocation, a raw [`pv-ctrl`](reference/pantavisor-commands.md)
+  call, a [configuration key](reference/pantavisor-configuration.md), or an on-disk path to inspect.
+- Prefer a short fenced code block over prose describing what a command does.
+- If a feature genuinely has no user-facing action, say so — a one-line "this is managed
+  automatically; no action needed" is enough.
+
+## Frontmatter
+
+Every page under `docs/` carries:
+
+```yaml
+---
+title: "Short Page Name"
+sidebar_position: <n>
+description: "One sentence, used as the search and card summary."
+---
+```
+
+`sidebar_position` is unique within its folder and follows the order of that folder's `index.md`.
+Meta pages that must not publish (this page, [`issues.md`](issues.md)) use `draft: true` instead of
+`sidebar_position`.
+
+## Link conventions
+
+- **Within the same folder**: plain relative links, e.g. `containers.md#restart-policy`.
+- **Between `overview/`, `reference/` and `tools/`**: relative sibling links, e.g.
+  `../reference/pantavisor-commands.md#steps`, `../overview/containers.md#status`. These resolve
+  both on GitHub and on the published site.
+- **To meta-pantavisor docs**: `../../meta-pantavisor/<section>/<page>.md` — resolves only on the
+  published site, where both repos' docs are siblings.
+- **To curated site pages**: full URLs, e.g.
+  `https://docs.pantavisor.io/operate/device-access/serial-port`.
+- **Do not** use the retired MkDocs-era prefixes (`../../../reference/legacy/`,
+  `../../../reference/027/`, `../../pantavisor-src/docs/...`) — they dangle on the site.
+- **Syntax**: the site renders MDX. Use Docusaurus admonitions (`:::note` … `:::`), not MkDocs
+  `!!! Note`; avoid MkDocs Material icon codes like `:material-check:`.
+
+## Cross-linking
+
+Navigation must work in both directions:
+
+- Every overview page ends with a **Reference** line pointing at the reference pages that carry its
+  tables.
+- Every reference page opens with an **Overview** line pointing at the page that explains it.
+
+## Page URLs are permanent
+
+A page's path under `docs/` *is* its published URL: `docs/overview/bsp.md` is served as
+`https://docs.pantavisor.io/pantavisor/overview/bsp/`. The retired MkDocs site,
+`docs.pantahub.com`, still 301-redirects into those URLs, so renaming, moving or deleting one of
+the pages below does not just move a page — it turns a live redirect into a 404.
+
+| Page | Redirected from |
+|------|-----------------|
+| [`overview/bsp.md`](overview/bsp.md) | `docs.pantahub.com/bsp/` |
+| [`overview/containers.md`](overview/containers.md) | `docs.pantahub.com/containers/` |
+| [`overview/init-mode.md`](overview/init-mode.md) | `docs.pantahub.com/init-mode/` |
+| [`overview/local-control.md`](overview/local-control.md) | `docs.pantahub.com/local-control/` |
+| [`overview/pantavisor-architecture.md`](overview/pantavisor-architecture.md) | `docs.pantahub.com/pantavisor-architecture/` |
+| [`overview/pantavisor-configuration-levels.md`](overview/pantavisor-configuration-levels.md) | `docs.pantahub.com/pantavisor-configuration-levels/` |
+| [`overview/remote-control.md`](overview/remote-control.md) | `docs.pantahub.com/remote-control/` |
+| [`overview/revisions.md`](overview/revisions.md) | `docs.pantahub.com/revisions/` |
+| [`overview/storage.md`](overview/storage.md) | `docs.pantahub.com/storage/` |
+| [`overview/updates.md`](overview/updates.md) | `docs.pantahub.com/updates/` |
+| [`overview/watchdog.md`](overview/watchdog.md) | `docs.pantahub.com/watchdog/` |
+| [`reference/logserver-sockets.md`](reference/logserver-sockets.md) | `docs.pantahub.com/logserver-sockets/` |
+| [`reference/pantavisor-commands.md`](reference/pantavisor-commands.md) | `docs.pantahub.com/pantavisor-commands/` |
+| [`reference/pantavisor-configuration.md`](reference/pantavisor-configuration.md) | `docs.pantahub.com/pantavisor-configuration/` |
+| [`reference/pantavisor-metadata.md`](reference/pantavisor-metadata.md) | `docs.pantahub.com/pantavisor-metadata/` |
+| [`reference/pantavisor-state-format-v2.md`](reference/pantavisor-state-format-v2.md) | `docs.pantahub.com/pantavisor-state-format-v2/` |
+
+Rules for those pages:
+
+- **Do not rename, move or delete them**, and do not mark them `draft: true` — that unpublishes the
+  page and breaks the redirect just as effectively. `scripts/check-docs.sh` reads the table above
+  and fails if a listed page is gone or drafted.
+- **Split, do not move.** When a page grows too big, leave it in place and move the *content* into
+  a new page it links to.
+- If a rename is genuinely unavoidable, it is a two-repo change: the replacement redirect goes into
+  [`docs.pantavisor`](https://github.com/pantavisor/docs.pantavisor)
+  (`docusaurus.config.ts`, `plugin-client-redirects`) **before** this side merges, and the row above
+  is updated in the same PR.
+
+Everything else in `docs/` is free to move; only the redirect targets are frozen. Adding pages is
+always safe.
+
+## Before you commit
+
+```bash
+scripts/check-docs.sh
+```
+
+It is also run in CI by `.github/workflows/docs.yaml` on any PR touching `docs/` or the sources
+listed in the table above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,13 @@
 ---
 title: "Pantavisor Documentation"
-sidebar_position: 1
+sidebar_position: 0
 description: "Entry point for Pantavisor runtime documentation."
 ---
 
 # Pantavisor Documentation
 
-- [Technical Overview](overview/index.md) — Concept-level explanations of how Pantavisor works, ordered from architecture down to individual subsystems
-- [Reference](reference/index.md) — Exact specifications for state formats, configuration keys, control socket commands, and schemas
-- [Tools](tools/index.md) — On-device CLI tools: `pventer`, `pvcurl`, `pvcontrol`, and `pvtx`
+- [Technical Overview](overview/index.md) — how Pantavisor works and why, ordered to be read top-to-bottom
+- [Reference](reference/index.md) — complete specifications: state format, configuration keys, control socket, metadata, log sockets, hooks, power, IPAM, xconnect
+- [Tools](tools/index.md) — on-device CLI tools: `pventer`, `pvcurl`, `pvcontrol` and `pvtx`
+
+Writing documentation? [CONTRIBUTING.md](CONTRIBUTING.md) says what belongs in each of the three.

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -29,3 +29,12 @@ that resolve both in this repository and in the Docusaurus reference instance on
 docs.pantavisor.io. Links to MkDocs-era how-to pages (`inspect-device.md`,
 `claim-device.md`, `make-a-new-revision.md`, …) now point to the equivalent
 curated pages on https://docs.pantavisor.io.
+
+### Issue 6 — Overview and reference had drifted into each other (resolved 2026-09)
+
+Reference tables (log sinks, timestamp formats, hook points, hook environment, wakelock scopes,
+`PV_POWER_*` keys, disk field requirements, container status values) had accumulated in
+`docs/overview/`, while narrative had accumulated in `docs/reference/`. Content was moved to the
+side that owns it, two reference pages were added (`pantavisor-hooks.md`, `pantavisor-power.md`),
+every page was cross-linked in both directions, and the rules were written down in
+[CONTRIBUTING.md](CONTRIBUTING.md) and enforced by `scripts/check-docs.sh` in CI.

--- a/docs/overview/bsp.md
+++ b/docs/overview/bsp.md
@@ -1,5 +1,7 @@
 ---
+title: "BSP"
 sidebar_position: 3
+description: "Board Support Package: kernel, modules, firmware, and the supported bootloaders."
 ---
 # BSP
 
@@ -86,3 +88,9 @@ This mode sets Pantavisor up to work with [tryboot_a-b for Raspberry Pi](https:/
 ### grub
 
 In this mode, both Pantavisor and GRUB will write and read to and from a file in [storage](storage.md) that contains the revision information that GRUB needs to boot up at any moment. With that information, Kernel and initrd will be loaded from that same [storage](storage.md) by GRUB.
+
+## Reference
+
+- [State Format → BSP](../reference/pantavisor-state-format-v2.md#2-bsp-bsprunjson) — every `bsp/run.json` field
+- [State Format → Drivers](../reference/pantavisor-state-format-v2.md#3-drivers-bspdriversjson) — the `bsp/drivers.json` alias map
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_BOOTLOADER_*` and `PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO`

--- a/docs/overview/containers.md
+++ b/docs/overview/containers.md
@@ -1,5 +1,7 @@
 ---
+title: "Containers"
 sidebar_position: 4
+description: "Container runtime: storage, networking, groups, roles, status, auto-recovery, lifecycle control."
 ---
 # Containers
 
@@ -116,7 +118,7 @@ If the restart policy is not [explicitly configured](../reference/pantavisor-sta
 
 After a new [revision](revisions.md) is [updated](updates.md), or after the board is booted up, the containers will try to start if they were not previously started (this could happen in case of a [non-reboot update](updates.md#non-reboot-transition)).
 
-These are the different status containers can be at:
+These are the different [status](../reference/pantavisor-commands.md#status-values) containers can be at:
 
 * INSTALLED: the container is installed and ready to go.
 * MOUNTED: the container volumes are mounted, but not yet started.
@@ -160,12 +162,12 @@ Containers can be configured to automatically restart after a crash using the `a
 
 ### Recovery Policies
 
-| Policy | Behavior |
-| ------ | -------- |
-| `no` | Never restart (default). |
-| `on-failure` | Restart on exit. (Note: the current implementation does not distinguish exit codes — it behaves the same as `always`. A future revision will leave the container stopped if it exits with status 0.) |
-| `always` | Restart on any exit. |
-| `unless-stopped` | Restart on any exit unless the container was explicitly stopped via API. |
+The recovery policy controls what happens if a container unexpectedly stops. A container either
+never restarts (`no`, the default), restarts on any exit (`always`), restarts unless it was
+explicitly stopped through [ctrl](local-control.md) (`unless-stopped`), or restarts on failure
+(`on-failure`). See the
+[auto-recovery object](../reference/pantavisor-state-format-v2.md#auto-recovery-object) for the
+full field list.
 
 ### Exponential Backoff
 
@@ -177,15 +179,13 @@ The `stable_timeout` field defines how many seconds a container must survive aft
 
 ### Backoff Policy
 
-The `backoff_policy` field controls what happens after `max_retries` is exhausted:
+The `backoff_policy` field controls what happens after all restart retries is exhausted: reboot
+the system (`reboot`, the default), leave the container stopped (`never`), or wait a
+[duration](../reference/pantavisor-state-format-v2.md#auto-recovery-object) such as `10min` before
+resetting the retry counter and restarting the whole recovery cycle.
 
-| Value | Behavior |
-| ----- | -------- |
-| `reboot` | Reboot the system (default). |
-| `never` | Leave the container stopped; system continues running. |
-| Duration (e.g., `10min`) | Wait the specified duration, reset the retry counter, and restart the full recovery cycle. Supported units: `s` (seconds), `min` (minutes), `h` (hours). |
-
-During [TESTING](updates.md#testing), `max_retries` exhaustion always triggers a [rollback](updates.md#error) regardless of the backoff policy.
+During [TESTING](updates.md#testing), a restart retry exhaustion always triggers a
+[rollback](updates.md#error) regardless of the backoff policy.
 
 ### Group-Level Defaults
 
@@ -231,3 +231,9 @@ This list can be expanded to other files using the [state JSON](../reference/pan
 ## Service Mesh
 
 Containers can expose services to each other and consume services from other containers through [xconnect](xconnect.md), Pantavisor's built-in service mesh. Providers declare services in a `services.json` manifest; consumers declare requirements in their `run.json`. The `pv-xconnect` daemon handles mediation and resource injection at runtime, supporting Unix sockets, REST, D-Bus, DRM, and Wayland.
+
+## Reference
+
+- [State Format → Container](../reference/pantavisor-state-format-v2.md#7-container-containerrunjson) — every `run.json` field, plus the auto-recovery, storage and service-requirement objects
+- [Control Socket → /containers](../reference/pantavisor-commands.md#containers) — listing, lifecycle actions, and the status values
+- [xconnect](../reference/pantavisor-xconnect.md) — the service manifests behind the service mesh

--- a/docs/overview/disks.md
+++ b/docs/overview/disks.md
@@ -1,5 +1,7 @@
 ---
+title: "Disks"
 sidebar_position: 7
+description: "Disk types, single and dual-mode partitioning, dm-crypt encryption, and boot sequence."
 ---
 # Disks
 
@@ -26,14 +28,10 @@ not prevent parsing the others.
 
 Swap space from a block device, file, or zram.
 
-- `path`: block device or file path (ignored when `provision` is `"zram"`)
-- `provision`: required by the dispatcher — `"file"` for file-backed
-  swap, `"zram"` for compressed RAM (see Zram section). For block
-  device swap, set to any non-zram value (e.g. `"block"`).
-- `provision_ops`: for file-backed swap, must contain `size=<value>`
-  (e.g. `"size=64M"`)
-- `format_ops`: optional — passed to `mkswap`
-- `mount_ops`: optional — passed to `swapon`
+The `provision` field selects the backend: `"file"` for file-backed swap, `"zram"` for compressed
+RAM, or any other value for a plain block device. See
+[required fields per disk type](../reference/pantavisor-state-format-v2.md#required-fields-per-disk-type)
+for what each backend needs.
 
 Swap disks are mounted first during boot, before all other disk types.
 
@@ -53,7 +51,7 @@ Swap disks are mounted first during boot, before all other disk types.
     "name": "my-swap",
     "type": "swap-disk",
     "provision": "file",
-    "provision_ops": "size=64M",
+    "provision_options": "size=64M",
     "path": "/storage/swapfile",
     "format": "swap"
 }
@@ -65,7 +63,7 @@ Swap disks are mounted first during boot, before all other disk types.
     "name": "my-zram-swap",
     "type": "swap-disk",
     "provision": "zram",
-    "provision_ops": "disksize=128M comp_algorithm=lz4",
+    "provision_options": "disksize=128M comp_algorithm=lz4",
     "format": "swap"
 }
 ```
@@ -88,9 +86,6 @@ The bind mount target uses the `dmcrypt` namespace because `volumes.c`
 resolves disk-backed volume paths under that namespace regardless of the
 actual disk type.
 
-- `provision`: absent
-- `path`, `format`, `mount_target`: not required
-
 This is the recommended mode for appengine and CI test environments where
 dm-crypt hardware (CAAM, DCP) is unavailable.
 
@@ -112,16 +107,10 @@ dm-crypt hardware (CAAM, DCP) is unavailable.
 
 Plain (unencrypted) ext4/ext3 volume mounted at a specified target.
 
-- `format`: required — `"ext4"` or `"ext3"`
-- `mount_target`: required — where to mount the filesystem
-- `path`: required — block device path (ignored when `provision` is `"zram"`)
-- `provision`: set to `"zram"` for compressed RAM backend (see Zram section);
-  any other non-empty value selects block device mode.
-- `format_ops`: optional — passed to `mkfs.<format>`
-- `mount_ops`: optional — comma-separated mount flags:
-  `MS_NOATIME`, `MS_NODEV`, `MS_NOEXEC`, `MS_NOSUID`, `MS_RDONLY`,
-  `MS_RELATIME`, `MS_SYNCHRONOUS`, `MS_DIRSYNC`, `MS_LAZYTIME`,
-  `MS_MANDLOCK`, `MS_NODIRATIME`, `MS_REC`, `MS_SILENT`, `MS_STRICTATIME`
+Setting `provision` to `"zram"` selects a compressed RAM backend; any other non-empty value selects
+block device mode. See
+[required fields per disk type](../reference/pantavisor-state-format-v2.md#required-fields-per-disk-type)
+for the mandatory fields and the accepted `mount_options` flags.
 
 **Block device backed:**
 ```json
@@ -142,7 +131,7 @@ Plain (unencrypted) ext4/ext3 volume mounted at a specified target.
     "name": "my-tmpdata",
     "type": "volume-disk",
     "provision": "zram",
-    "provision_ops": "disksize=64M",
+    "provision_options": "disksize=64M",
     "format": "ext4",
     "mount_target": "/tmp/data"
 }
@@ -154,9 +143,8 @@ When `provision` is `"zram"`, a compressed RAM-backed block device is
 created dynamically instead of using a physical device. Works for both
 swap and volume disk types.
 
-- `provision_ops`: space-separated `key=value` pairs written to
-  `/sys/block/zramX/*` — e.g. `"disksize=128M comp_algorithm=lz4"`
-- `path`: ignored (overwritten with `/dev/zramX`)
+`provision_options` carries the zram tunables and `path` is overwritten with the allocated device.
+See [required fields per disk type](../reference/pantavisor-state-format-v2.md#required-fields-per-disk-type).
 
 The zram device is reset on umount.
 
@@ -165,7 +153,7 @@ The zram device is reset on umount.
     "name": "my-zram-swap",
     "type": "swap-disk",
     "provision": "zram",
-    "provision_ops": "disksize=128M comp_algorithm=lz4"
+    "provision_options": "disksize=128M comp_algorithm=lz4"
 }
 ```
 
@@ -292,13 +280,8 @@ are internal (see Internal Disks section below).
 
 #### init_order Actions
 
-| Action | Description |
-|--------|-------------|
-| `primary` | Try mounting existing primary disk (`--no-create`). Fails if not initialized. |
-| `secondary` | Try mounting existing secondary disk (`--no-create`). Fails if not initialized. |
-| `create-primary` | Create, format, and mount primary disk. |
-| `create-secondary` | Create, format, and mount secondary disk. |
-| `copy-once-to-primary` | Mount secondary read-only, create primary, copy all data with file-level verification. Skipped if already done (tracked by dual `init_done` marker). |
+Pantavisor tries each action in turn until one succeeds. See
+[`init_order` actions](../reference/pantavisor-state-format-v2.md#init_order-actions).
 
 #### Common Policies
 
@@ -483,3 +466,9 @@ Crypt disks: `<mediadir>/pv/dmcrypt/<disk-name>`
 Volume disks: configured via `mount_target` field.
 
 Swap disks: no mount point (activated via `swapon`).
+
+## Reference
+
+- [State Format → Disks](../reference/pantavisor-state-format-v2.md#6-storage-disksjson) — every `device.json` disk field, and the required fields per type
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_DISK_*`, `PV_SYSTEM_DISKSDIR`, `PV_VOLMOUNT_DM_EXTRA_ARGS`
+- [Storage](storage.md) — how disks relate to the rest of the on-disk layout

--- a/docs/overview/hooks.md
+++ b/docs/overview/hooks.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 14
+title: "Hooks"
+sidebar_position: 12
+description: "System lifecycle hooks: what they gate, when they run, and how to write one."
 ---
 # Hooks
-
-## Overview
 
 Hooks are executable scripts that Pantavisor runs at well-defined lifecycle points. They allow operators to execute custom logic — such as notifying an external service, validating system state, or triggering a reboot — at specific moments during startup, update installation, and platform status goal complete.
 
@@ -29,40 +29,31 @@ All hooks are placed under:
 /usr/lib/pantavisor/pv/hooks/system.d/
 ```
 
-The base path (`/usr/lib/pantavisor/pv`) is set at build time via `CMAKE_INSTALL_FULL_LIBDIR` and may differ depending on the target configuration.
-
-Pantavisor discovers scripts in this directory on every hook invocation. Execution follows these rules:
-
-- Scripts run in **alphabetical order** by filename.
-- Only **regular files** with the **executable bit** (`S_IXUSR`) set are run; directories, symlinks, and non-executable files are silently skipped.
-- Naming convention: use a numeric prefix (e.g. `10-my-hook`, `50-notify`) to control execution order.
+Pantavisor re-scans this directory on every hook invocation and runs the executable regular files it
+finds, in alphabetical order, so a numeric prefix (`10-my-hook`, `50-notify`) controls the order.
+Anything non-executable is skipped, and a missing directory simply means no hooks. See
+[hook directory rules](../reference/pantavisor-hooks.md#hook-directory) for the exact conditions.
 
 ## Hook Points
 
-Each hook point corresponds to a specific moment in [Pantavisor's lifecycle](pantavisor-architecture.md#state-machine). The active hook point is communicated to hook scripts via the [`PV_OP`](#environment-variables) environment variable.
+Each hook point corresponds to a specific moment in
+[Pantavisor's lifecycle](pantavisor-architecture.md#state-machine), and is communicated to the
+script through the `PV_OP` environment variable:
 
-| `PV_OP` value | When it fires |
-|---|---|
-| `system-start` | Early during Pantavisor initialization, before containers are started. |
-| [`system-before-install-update`](updates.md) | Before Pantavisor writes the incoming revision into the [bootloader](bsp.md#bootloader) environment (so the bootloader loads the right kernel on next boot). Fired only on backends with a dedicated install step: [`uboot-ab`](bsp.md#uboot-ab) and [`rpiab`](bsp.md#rpiab). |
-| [`system-after-install-update`](updates.md) | After Pantavisor has written the incoming revision into the [bootloader](bsp.md#bootloader) environment. Same backends as `system-before-install-update`: [`uboot-ab`](bsp.md#uboot-ab) and [`rpiab`](bsp.md#rpiab). |
-| [`system-install-update`](updates.md) | Combines before and after into a single hook point. Fired on backends without a dedicated install step: [`uboot`](bsp.md#uboot) and [`grub`](bsp.md#grub). |
-| `system-boot-done` | After the new revision has been committed following a successful try-boot. `PV_TRYBOOT` is always `"true"` at this point. See [environment variables](#environment-variables) |
-| `system-done` | When the platform reaches fully-running state (all containers have met their [status goal](containers.md#status-goal)). |
+- `system-start` fires early in initialization, before containers start.
+- `system-before-install-update` fires before writing the incoming revision into the 
+  [bootloader](bsp.md#bootloader) environment during an [update](updates.md).
+- `system-after-install-update` fires after writing the already installed revision into
+  the [bootloader](bsp.md#bootloader) environment during an [update](updates.md).
+- `system-install-update` combines the previous two.
+- `system-boot-done` fires after a new revision has been committed following a successful try-boot.
+- `system-done` fires when all containers have reached their [status goal](containers.md#status-goal).
 
-## Environment Variables
-
-Pantavisor sets the following environment variables before executing every hook:
-
-| Variable | Description |
-|---|---|
-| `PV_OP` | Name of the [hook point](#hook-points) currently running (see table above). |
-| `PV_REV` | ID of the currently running [revision](revisions.md). |
-| `PV_TRY` | ID of the revision being attempted for the next boot. Empty string if not in a try-boot or once the try-boot has been committed. For update hooks (`system-*-install-update`), this is the incoming revision being installed. |
-| `PV_TRYBOOT` | `"true"` if the device booted into a trial revision that has not yet been committed, `"false"` otherwise. |
-| `PV_OBJ_STORAGE` | Absolute path to the object [storage](storage.md) directory. |
-| `PV_TRAILS_STORAGE` | Absolute path to the [trails](storage.md#trails-and-objects) directory for the current revision. |
-| `PV_STATUS` | Current revision [status](updates.md) string from the progress JSON (e.g. `DONE`, `TESTING`). Empty if no progress file is available. |
+Alongside `PV_OP`, Pantavisor passes the current and incoming revision IDs, the try-boot flag, the
+object and trails storage paths, and the revision status to the script as variables. See the
+[hook points](../reference/pantavisor-hooks.md#hook-points) and
+[hook environment variables](../reference/pantavisor-hooks.md#hook-environment-variables) tables for
+the complete lists.
 
 ## Writing a Hook
 
@@ -103,8 +94,22 @@ For a Yocto recipe, use `do_install` to copy the file and `chmod +x` it, or plac
 
 ## Failure Behaviour
 
-- A hook that exits with a **non-zero status** causes Pantavisor to abort any remaining hooks in the directory and fail the triggering operation.
-- For `system-start`, failure is **fatal**: Pantavisor exits, the device reboots, and the bootloader's tryboot counter decrements. Once the counter reaches zero, the bootloader selects the last-good revision and the device rolls back. Treat `system-start` as a hard gate on the revision.
-- For update hooks (`system-before-install-update`, `system-after-install-update`, `system-install-update`, `system-boot-done`), failure aborts the update process.
-- For `system-done`, failure is **logged only** and does not prevent the platform from transitioning to its running state. This asymmetry with `system-start` is intentional: `system-done` fires after all containers have reached their status goal and the revision is already running; at that point there is no safe rollback path, so the hook result is informational.
-- Hook output (stdout and stderr) is captured by the [logserver](storage.md#logs) and available in the device logs.
+A hook that exits non-zero aborts the remaining hooks in the directory and fails the triggering
+operation, with one deliberate exception.
+
+For `system-start`, failure is **fatal**: Pantavisor exits, the device reboots, and the bootloader's
+tryboot counter decrements. Once the counter reaches zero the bootloader selects the last-good
+revision and the device rolls back. Treat `system-start` as a hard gate on the revision. Update
+hooks behave the same way, aborting the update.
+
+For `system-done`, failure is **logged only** and does not prevent the platform from transitioning
+to its running state. The asymmetry is intentional: `system-done` fires after all containers have
+reached their status goal and the revision is already running, so there is no safe rollback path
+left and the hook result is informational.
+
+Hook output (stdout and stderr) is captured by the [logserver](storage.md#logs) and available in the
+device logs.
+
+## Reference
+
+- [Hooks](../reference/pantavisor-hooks.md) — hook points, environment variables, directory rules, failure semantics

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,23 +1,42 @@
 ---
 title: "Technical Overview"
-sidebar_position: 1
+sidebar_position: 0
 description: "Concept-level explanations of how Pantavisor works, meant to be read top-to-bottom."
 ---
 
 # Technical Overview
 
-1. [Architecture](pantavisor-architecture.md) — High-level system design: container orchestration, cloud and local communication, service mesh, and the state machine
-2. [Revisions](revisions.md) — The core state model: what a revision is, how state JSON represents it, and how the trail of revisions enables rollback
-3. [BSP](bsp.md) — Board Support Package: kernel, modules, firmware, and how they are versioned alongside application containers
-4. [Containers](containers.md) — Container runtime, groups, roles, lifecycle, and restart policy
-5. [Updates](updates.md) — Atomic update flow, state transitions, success and failure paths
-6. [Storage](storage.md) — On-disk layout, object store, logs, and metadata persistence
-7. [Disks](disks.md) — Disk types, single and dual-mode partitioning, dm-crypt encryption, and boot sequence
-8. [Remote Control](remote-control.md) — Pantacor Hub client, cloud-initiated updates, and remote command handling
-9. [Local Control](local-control.md) — pv-ctrl Unix socket, Pantabox, and the pvcontrol CLI
-10. [IPAM](ipam.md) — Container IP address management: address allocation and network namespace configuration
-11. [Inter-Container Communication](xconnect.md) — xconnect service mesh: service discovery, Unix sockets, D-Bus, DRM, and Wayland mediation between containers
-12. [Configuration Levels](pantavisor-configuration-levels.md) — The precedence hierarchy for pantavisor.json configuration across factory, device, and container scopes. See the [Pantavisor Configuration reference](../reference/pantavisor-configuration.md) for the full list of keys, defaults, and levels
-13. [Init Mode](init-mode.md) — Embedded, standalone, and appengine operational modes and when to use each
-14. [Hooks](hooks.md) — System lifecycle hooks: boot, update, platform-ready, and custom extension points
-15. [Watchdog](watchdog.md) — Hardware and software watchdog integration, kick intervals, and failure handling
+How Pantavisor works and why it is built this way, ordered to be read as a book. For the exact
+keys, fields and endpoints behind any of it, follow the **Reference** links at the foot of each
+page, or start from the [Reference index](../reference/index.md).
+
+## Foundations
+
+1. [Architecture](pantavisor-architecture.md) — the two jobs Pantavisor does, and the state machine it does them in
+2. [Revisions](revisions.md) — the unit of state: what a revision is and how state JSON makes it reproducible
+3. [BSP](bsp.md) — kernel, modules, firmware and bootloader, versioned alongside application containers
+4. [Containers](containers.md) — runtime, groups, roles, status, auto-recovery and lifecycle control
+
+## State and storage
+
+5. [Updates](updates.md) — the atomic update flow, its progress states, and the failure paths
+6. [Storage](storage.md) — on-disk layout, object store, logs, metadata and integrity
+7. [Disks](disks.md) — disk types, single and dual-mode partitioning, dm-crypt, boot sequence
+
+## Control
+
+8. [Remote Control](remote-control.md) — the Pantacor Hub client and other remote controllers
+9. [Local Control](local-control.md) — the pv-ctrl socket, Pantabox and pvcontrol
+
+## Runtime services
+
+10. [IPAM](ipam.md) — container IP address management: pools, allocation, network namespaces
+11. [Inter-Container Communication](xconnect.md) — the xconnect service mesh
+12. [Hooks](hooks.md) — lifecycle hooks, and how `system-start` gates a revision
+13. [Watchdog](watchdog.md) — kernel watchdog integration and the four ping modes
+14. [Power and Wakelocks](wakelocks.md) — blocking and scheduling suspend without missing updates
+
+## Configuration and modes
+
+15. [Configuration Levels](pantavisor-configuration-levels.md) — the precedence hierarchy across factory, device and container scopes
+16. [Init Mode](init-mode.md) — embedded, standalone and appengine, and when to use each

--- a/docs/overview/init-mode.md
+++ b/docs/overview/init-mode.md
@@ -1,5 +1,7 @@
 ---
-sidebar_position: 13
+title: "Init Mode"
+sidebar_position: 16
+description: "Embedded, standalone, and appengine operational modes, and when to use each."
 ---
 # Init Mode
 
@@ -30,3 +32,8 @@ Some container-specific behaviours worth knowing:
 - **Loop devices:** There is no udev, so `/dev/loop0..1023` are pre-created. Loop devices are host-global, so concurrent appengines each need their own `PV_LOOP_INDEX_BASE` 64 device range reserved. To avoid conflicts with leftover loop devices, the entrypoint reaps stale devices in its own 64-device band, detaching only those whose backing file reads `(deleted)`.
 - **Log location:** Logs live under the storage mount at `<storage>/logs/0/`, not `/run/pantavisor/pv/logs/0/` as on a device so they can be inspected from host. `PV_LOG_SERVER_OUTPUTS=filetree,stdout_direct` additionally streams the internal log to stdout, unbuffered, as each event happens. See [logserver-sockets.md](../reference/logserver-sockets.md).
 - **Named initial revisions:** Pantavisor only auto-commits the revision it boots into when that revision is named `0`. When `PV_APPENGINE_INITIAL_REV` names a different revision, `pv-appengine` writes the `.pv/done` and `.pv/progress` markers the factory path would have written. This is what lets a caller boot straight into a prepared revision with no install and no commit reboot.
+
+## Reference
+
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_SYSTEM_INIT_MODE`, `PV_LOOP_INDEX_BASE` and the appengine-specific keys
+- [Log Sockets](../reference/logserver-sockets.md#log-server-outputs) — the sinks appengine uses to stream to stdout

--- a/docs/overview/ipam.md
+++ b/docs/overview/ipam.md
@@ -1,5 +1,7 @@
 ---
+title: "IPAM"
 sidebar_position: 10
+description: "Container IP address management: pools, allocation, and network namespace configuration."
 ---
 # IPAM — Container IP Address Management
 
@@ -52,7 +54,7 @@ A pool is a named L3 segment with a bridge and optional NAT:
 }
 ```
 
-The `nat` flag is independent per pool — you can have one pool that reaches the external network through a MASQUERADE rule, and another that is only routable on its own bridge.
+The `nat` flag is independent per pool — you can have one pool that reaches the external network through a MASQUERADE rule, and another that is only routable on its own bridge. Pantavisor installs that rule with nftables when `nft` is present and falls back to `iptables` otherwise: nftables-first because every kernel from 3.13 onward has it natively, and recent distros ship `iptables` as a compat shim over nftables anyway. See [NAT backend](../reference/pantavisor-ipam.md#nat-backend).
 
 Today only `type: "bridge"` is wired up end-to-end. A `macvlan` type is sketched in the schema for future work.
 
@@ -80,7 +82,7 @@ A pool's subnet may overlap with a bridge that is also used by containers with b
 
 Pantavisor handles this automatically. At startup, right after `pv_ipam_setup_bridges()` runs, a **reservation walk** visits every container and asks the backend plugin to enumerate its hard-coded IPv4 addresses. Each enumerated address that falls inside a pool's subnet is added to that pool's lease list as a tagged reservation (`pv:static:<container>`), so `pv_ipam_allocate()`'s `is_ip_available()` check already skips it without any change to the allocator. Addresses outside any pool's subnet are logged at DEBUG and ignored — those containers are managing their own networking on a bridge pantavisor doesn't know about, and that's fine.
 
-The plugin hook is optional — backends that don't provide it simply contribute nothing to the reservation set, and the pool allocates from the full subnet minus the gateway and any existing leases.
+The plugin hook is optional — backends that don't provide it simply contribute nothing to the reservation set, and the pool allocates from the full subnet minus the gateway and any existing leases. Addresses that clash with a pool's gateway are warned about rather than reserved, since the container will likely fail to bring that interface up anyway. See [backend plugin hooks](../reference/pantavisor-ipam.md#backend-plugin-hooks) for the hook signatures and the full disposition table.
 
 ## Pre-start validation
 
@@ -99,6 +101,22 @@ Short version: **if a container declares a pool, don't hand-roll `lxc.net.*` in 
 - **Platform teardown** (state transition / reboot / rollback): releases the lease. The new revision's allocation starts clean.
 - **Unknown pool reference**: the container is refused at start time; the revision is torn down and rolled back in TESTING.
 
+## Devices that do not use IPAM
+
+If a device's `device.json` has no `network.pools` block and no container declares a `network` block,
+IPAM is inert. `pv_ipam_init()` and `pv_ipam_setup_bridges()` still run, but over an empty registry —
+no bridges, no netfilter rules, no routes. Every per-container IPAM path in `platforms.c`, `state.c`
+and the LXC plugin is guarded on the container actually being in pool mode and is skipped, as is the
+plugin's config-validation hook. The only observable effect is two INFO lines at boot.
+
+Both blocks are optional in the schema. See [`device.json` pools](../reference/pantavisor-ipam.md#devicejson--pools)
+and [`run.json` per-container network](../reference/pantavisor-ipam.md#runjson--per-container-network).
+
 ## Isolation (follow-up)
 
 Today the kernel's default `FORWARD` policy is `ACCEPT`, so containers in different pools can reach each other at L3. That is a gap, tracked as a separate effort that defaults all pools to isolated and expects cross-pool service access to go through the [xconnect service mesh](xconnect.md) rather than flat routing.
+
+## Reference
+
+- [IPAM](../reference/pantavisor-ipam.md) — pool and per-container schemas, lease lifecycle, plugin hooks, NAT backend, error handling
+- [State Format](../reference/pantavisor-state-format-v2.md) — where `network` sits in `device.json` and `run.json`

--- a/docs/overview/local-control.md
+++ b/docs/overview/local-control.md
@@ -1,5 +1,7 @@
 ---
+title: "Local Control"
 sidebar_position: 9
+description: "The pv-ctrl socket, Pantabox, pvcontrol, and writing your own local controller."
 ---
 # Local Control
 
@@ -46,3 +48,9 @@ pvcontrol
 In the end, [Pantabox](#pantabox) and [pvcontrol](#pvcontrol) are just HTTP clients that are making use of [Pantavisor control socket](../reference/pantavisor-commands.md).
 
 If you want to take advantage of the local control in your own container, first make sure [mgmt role](containers.md#roles) is selected in your container. Then, consider importing Pantabox and/or pvcontrol into your container. Besides this option, you can always directly use [cURL](https://curl.se/) or any other HTTP client to attack the [control socket endpoints](../reference/pantavisor-commands.md).
+
+## Reference
+
+- [Control Socket](../reference/pantavisor-commands.md) — every endpoint, payload and status code
+- [pvcontrol](../tools/pvcontrol.md) — the CLI reference, with a worked example per command
+- [Tools](../tools/pantavisor-tools.md) — `pventer`, `pvcurl`, `pvcontrol` and `pvtx`

--- a/docs/overview/pantavisor-architecture.md
+++ b/docs/overview/pantavisor-architecture.md
@@ -1,5 +1,7 @@
 ---
+title: "Architecture"
 sidebar_position: 1
+description: "High-level system design: container orchestration, cloud and local communication, service mesh, and the state machine."
 ---
 # Pantavisor Architecture
 
@@ -55,3 +57,9 @@ Each state can be summarized as:
     - Process [control socket](local-control.md) requests
     - Manage [metadata](storage.md#metadata)
     - Check and run [garbage collector](storage.md#garbage-collector)
+
+## Reference
+
+- [Reference index](../reference/index.md) — every specification, grouped by kind
+- [Configuration](../reference/pantavisor-configuration.md) — every key that shapes the behaviour described here
+- [Control Socket](../reference/pantavisor-commands.md) — the API the WAIT state serves

--- a/docs/overview/pantavisor-configuration-levels.md
+++ b/docs/overview/pantavisor-configuration-levels.md
@@ -1,6 +1,7 @@
 ---
 title: "Configuration Levels"
-sidebar_position: 12
+sidebar_position: 15
+description: "The precedence hierarchy for configuration across factory, device, and container scopes."
 ---
 # Configuration Levels
 
@@ -135,3 +136,8 @@ It is important to notice that these changes will not persist after a device reb
 :::
 
 The [Pantavisor control socket](local-control.md), or consequently the [PVControl tool](local-control.md#pvcontrol), offers another way to change a very limited subset of configuration values. Specifically, using the [command](../reference/pantavisor-commands.md#commands) endpoint.
+
+## Reference
+
+- [Configuration](../reference/pantavisor-configuration.md) — every key, its accepted values, its default, and the levels it may be set at
+- [State Format](../reference/pantavisor-state-format-v2.md#1-root-level-statejson) — where the OEM config file sits in a revision

--- a/docs/overview/remote-control.md
+++ b/docs/overview/remote-control.md
@@ -1,5 +1,7 @@
 ---
+title: "Remote Control"
 sidebar_position: 8
+description: "Pantacor Hub client, cloud-initiated updates, and other remote controllers."
 ---
 # Remote Control
 
@@ -55,3 +57,9 @@ for an illustrative example (not a measured benchmark).
 It is also possible to control Pantavisor using any other server. For that, it is necessary to implement a container that performs the communication between the server itself and [Pantavisor](local-control.md).
 
 One example of this kind of setup is our [Azure IoT Hub client](https://github.com/Azure/iot-hub-device-update/tree/contributor/pantacor%2FPVContainer-ci).
+
+## Reference
+
+- [Configuration](../reference/pantavisor-configuration.md#summary) — every `PH_*` key, plus `PV_CONTROL_REMOTE` and `PV_CONTROL_REMOTE_ALWAYS`
+- [Metadata](../reference/pantavisor-metadata.md) — what the device reports up and what it reads back down
+- [State Format](../reference/pantavisor-state-format-v2.md) — the revision format the trail is made of

--- a/docs/overview/revisions.md
+++ b/docs/overview/revisions.md
@@ -1,103 +1,41 @@
 ---
+title: "Revisions"
 sidebar_position: 2
+description: "The revision as Pantavisor's unit of state, and the state JSON that makes it reproducible."
 ---
 # Revisions
 
-A revision is composed by a [BSP](bsp.md) (Pantavisor binary, Linux kernel, modules and firmware) plus a number of [containers](containers.md).
+A revision is composed by a [BSP](bsp.md) (Pantavisor binary, Linux kernel, modules and firmware)
+plus a number of [containers](containers.md).
 
-In order to make revisions reproducible, they can be defined in a state JSON. This JSON is a flat representation of a set of either binary objects or other inline JSON documents. Here you can take a look at a simple example revision formed by just a BSP and a container named _awconnect_:
+In order to make revisions reproducible, they are defined in a state JSON. This JSON is a flat
+representation of a set of either binary objects or other inline JSON documents: every key is a
+path, and every value is either the SHA256 of a binary artifact or an inline JSON manifest.
 
-```
+```json
 {
   "#spec": "pantavisor-service-system@1",
-  "_hostconfig/pvr/docker.json": {
-    "platforms": [
-      "linux/arm64",
-      "linux/arm"
-    ]
-  },
-  "awconnect/lxc.container.conf": "153d58588b0327f73c8424c214c039fcdd975814bc075bc5c72f82fd3cdfd7b6",
-  "awconnect/root.squashfs": "e1ddabe573021b48dd5d66d59593d94fbc57b7a2f85dac59628959ae6955d2e2",
-  "awconnect/root.squashfs.docker-digest": "828054813b64d71d26756903010a52828941f6bb0859e878cb70f6f1e0ec7d2d",
-  "awconnect/run.json": {
-    "#spec": "service-manifest-run@1",
-    "config": "lxc.container.conf",
-    "name": "awconnect",
-    "root-volume": "root.squashfs",
-    "storage": {
-      "docker--etc-NetworkManager-system-connections": {
-        "persistence": "permanent"
-      },
-      "lxc-overlay": {
-        "persistence": "boot"
-      }
-    },
-    "type": "lxc",
-    "volumes": []
-  },
-  "awconnect/src.json": {
-    "#spec": "service-manifest-src@1",
-    "docker_config": {
-      "AttachStderr": false,
-      "AttachStdin": false,
-      "AttachStdout": false,
-      "Cmd": [
-        "/lib/systemd/systemd"
-      ],
-      "Domainname": "",
-      "Env": [
-        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-      ],
-      "Hostname": "",
-      "Image": "sha256:a8c4da0f0bde245a971a4a63a205cf56e071611f78b3d650715f309b7cefc57b",
-      "OpenStdin": false,
-      "StdinOnce": false,
-      "Tty": false,
-      "User": "",
-      "Volumes": {
-        "/etc/NetworkManager/system-connections/": {}
-      },
-      "WorkingDir": "/opt/wifi-connect/"
-    },
-    "docker_digest": "registry.gitlab.com/pantacor/pv-platforms/wifi-connect@sha256:b2ad073c0a41d186b6338fb8b81714eb1b8da9421383bbf8914fb86a01bbcafb",
-    "docker_name": "registry.gitlab.com/pantacor/pv-platforms/wifi-connect",
-    "docker_source": "remote,local",
-    "docker_tag": "arm32v5",
-    "persistence": {},
-    "template": "builtin-lxc-docker"
-  },
-  "bsp/addon-plymouth.cpio.xz4": "beae6a7bb235916cac52bcfece64c30615cded8c4c640e6941e7ecabe53b4920",
-  "bsp/build.json": {
-    "altrepogroups": "",
-    "branch": "master",
-    "commit": "e2a4911eb35de2032e85f74c8f239de81c6f622b",
-    "gitdescribe": "014-rc14-18-ge2a4911",
-    "pipeline": "436189414",
-    "platform": "rpi64",
-    "project": "pantacor/pv-manifest",
-    "pvrversion": "pvr version 026-52-gbf3bd5d6",
-    "target": "arm-rpi64",
-    "time": "2021-12-24 01:25:27 +0000"
-  },
-  "bsp/firmware.squashfs": "f37e9699ea8add7042e2843d095e68a316e6344d832b74d41244cb0bca29464e",
+  "bsp/run.json": { "linux": "kernel.img", "initrd": "pantavisor", "modules": "modules.squashfs" },
   "bsp/kernel.img": "990f8b0fcab8b99f631497753cc55b70f6f522a1d91cd4ae0777a7747b98509e",
-  "bsp/modules.squashfs": "0e202a7ee3a575bc502ec3869251a3587a3110079f221fc15c63da1e8d8a08ae",
-  "bsp/pantavisor": "1e6561f75cba98500f023e09aae430557fe0d1b02aeb1fa9adb3c2d3b6d250c6",
-  "bsp/run.json": {
-    "addons": [
-      "addon-plymouth.cpio.xz4"
-    ],
-    "firmware": "firmware.squashfs",
-    "initrd": "pantavisor",
-    "initrd_config": "",
-    "linux": "kernel.img",
-    "modules": "modules.squashfs"
-  },
-  "bsp/src.json": {
-    "#spec": "bsp-manifest-src@1",
-    "pvr": "https://pvr.pantahub.com/pantahub-ci/arm_rpi64_bsp_latest#bsp"
-  }
+  "awconnect/run.json": { "#spec": "service-manifest-run@1", "name": "awconnect", "type": "lxc" },
+  "awconnect/root.squashfs": "e1ddabe573021b48dd5d66d59593d94fbc57b7a2f85dac59628959ae6955d2e2"
 }
 ```
 
-To know more about this, you can take a look at our [state JSON reference](../reference/pantavisor-state-format-v2.md).
+The binary artifacts referenced by hash are the [objects](storage.md#trails-and-objects); because
+they are content-addressed they can be shared between revisions, so an [update](updates.md) only
+downloads what actually changed.
+
+Installed revisions form a trail, which is what makes [rollback](updates.md#error) possible: the
+previous revision's state JSON and objects are still on disk, so returning to it is a bootloader
+decision rather than a download.
+
+```bash
+pvcontrol steps ls                 # every revision installed on the device
+pvcontrol steps get current        # the running revision's state.json
+```
+
+## Reference
+
+- [State Format](../reference/pantavisor-state-format-v2.md) — every root key and manifest, with a [complete example](../reference/pantavisor-state-format-v2.md#10-complete-example)
+- [Control Socket → /steps](../reference/pantavisor-commands.md#steps) — installing and querying revisions

--- a/docs/overview/storage.md
+++ b/docs/overview/storage.md
@@ -1,5 +1,7 @@
 ---
+title: "Storage"
 sidebar_position: 6
+description: "On-disk layout: boot, cache, metadata, config, logs, trails and objects, integrity, garbage collection."
 ---
 # Storage
 
@@ -175,17 +177,10 @@ There are a number of parameters that can be tweaked from the [configuration](..
 PV_LOG_SERVER_OUTPUTS=filetree,stdout
 ```
 
-Multiple outputs are comma-separated and combined, choosing from:
-
-* [filetree](#file-tree)
-* [singlefile](#single-file)
-* [stdout](#standard-output)
-* [stdout.pantavisor](#standard-output-pantavisor)
-* [stdout.containers](#standard-output-containers)
-* [stdout_direct](#standard-output-direct)
-* [nullsink](#null-sink)
-
-These options are not mutually exclusive and can be combined in any fashion.
+Multiple outputs are comma-separated and combined, not mutually exclusive. The complete list of
+accepted values is in the
+[log server outputs reference](../reference/logserver-sockets.md#log-server-outputs); the sections
+below explain what each one is useful for.
 
 #### File tree
 
@@ -251,17 +246,10 @@ Send logs to /dev/null.
 
 ### Timestamp format
 
-All the log outputs, except for the NULL Sink, will print the timestamp along the log lines. It is possible to configure the format of the timestamp with the [configuration](../reference/pantavisor-configuration.md#summary) key `log.<output>.timestamp.format`, which can be set with the following values:
-
-| value | example |
-|-------|---------|
-golang:Layout | "01/02 03:04:05PM '06 -0700" |
-golang:RubyDate | "Mon Jan 02 15:04:05 -0700 2006" |
-golang:ANSIC | "Mon Jan \_2 15:04:05 2006" |
-golang:RFC822Z | "02 Jan 06 15:04 -0700" |
-golang:RFC1123Z | "Mon, 02 Jan 2006 15:04:05 -0700"|
-
-Those formats are based in the [Golang time constants](https://pkg.go.dev/time#pkg-constants). For other formats, the strftime formatters can be used setting the `strftime:` prefix. For example: `strftime:%d, %T %Y`. Please check the [strftime manual](https://man7.org/linux/man-pages/man3/strftime.3.html) for more information about formatters.
+Every output except the NULL Sink prefixes each line with a timestamp. The format is configurable
+per sink, either as one of the Go time layout constants or as an arbitrary `strftime` format
+string. See [timestamp formats](../reference/logserver-sockets.md#timestamp-formats) for the
+accepted values and the keys that set them.
 
 ### Log Directory Size Management
 
@@ -281,13 +269,9 @@ Partition size is read from `/sys/class/block/<dev>/size` (kernel sectors × 512
 
 #### Manual sizing
 
-Set `PV_LOG_DIR_MAXSIZE` to an explicit value using one of these formats:
-
-| Format | Example | Meaning |
-|--------|---------|---------|
-| Plain integer (bytes) | `16777216` | 16 MiB |
-| With unit suffix | `256MB`, `1GB`, `512K` | Absolute size |
-| Percentage | `20%` | 20% of the underlying partition |
+Set [`PV_LOG_DIR_MAXSIZE`](../reference/pantavisor-configuration.md#summary) to an explicit value:
+a plain byte count, a size with a unit suffix (`256MB`, `1GB`, `512K`), or a percentage of the
+underlying partition (`20%`).
 
 Values exceeding the available partition capacity are rejected and fall back to the auto-calculated default.
 
@@ -318,13 +302,9 @@ low_watermark  = 512 MB - 128 MB = 384 MB  → cleanup stops here
 rotation_size  = 128 MB / 5 ≈ 25 MB       → per-file size before rotation
 ```
 
-#### Configuration reference
-
-| Key | Default | Purpose |
-|-----|---------|---------|
-| [`PV_LOG_DIR_MAXSIZE`](../reference/pantavisor-configuration.md#summary) | `0` (auto) | Total log directory budget |
-| [`PV_LOG_HYSTERESIS_FACTOR`](../reference/pantavisor-configuration.md#summary) | `4` | Controls the gap between high and low watermarks |
-| [`PV_LOG_ROTATE_FACTOR`](../reference/pantavisor-configuration.md#summary) | `5` | Per-file rotation size divisor |
+The three keys behind this (`PV_LOG_DIR_MAXSIZE`, `PV_LOG_HYSTERESIS_FACTOR` and
+`PV_LOG_ROTATE_FACTOR`) are documented with their defaults and levels in the
+[configuration reference](../reference/pantavisor-configuration.md#summary).
 
 
 ## Trails and objects
@@ -455,3 +435,10 @@ pvcontrol storage gc     # run GC synchronously, reports bytes reclaimed
 ```
 
 See [pvcontrol Storage](../tools/pvcontrol.md#storage) for the difference between the two.
+
+## Reference
+
+- [Log Sockets](../reference/logserver-sockets.md) — log socket protocols, output sinks, timestamp formats
+- [Configuration](../reference/pantavisor-configuration.md#summary) — every `PV_LOG_*`, `PV_STORAGE_*` and `PV_CACHE_*` key
+- [Metadata](../reference/pantavisor-metadata.md) — every device and user metadata key
+- [State Format](../reference/pantavisor-state-format-v2.md) — the `state.json` stored in each trail

--- a/docs/overview/updates.md
+++ b/docs/overview/updates.md
@@ -1,5 +1,7 @@
 ---
+title: "Updates"
 sidebar_position: 5
+description: "Atomic update flow: progress states, reboot and non-reboot transitions, success and failure paths."
 ---
 # Updates
 
@@ -169,3 +171,10 @@ Unexpected rollback | Crash or power cycle before having the chance to report an
 ### CANCELLED
 
 Only applicable on [remote](remote-control.md#pantacor-hub) updates. The revision has been marked as cancelled by the cloud side.
+
+## Reference
+
+- [Control Socket → /steps](../reference/pantavisor-commands.md#steps) — installing revisions and reading update progress
+- [Control Socket → /commands](../reference/pantavisor-commands.md#commands) — `LOCAL_RUN`, `TRY_ONCE`, `LOCAL_RUN_COMMIT` and friends
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_UPDATER_*`, `PH_UPDATER_*` and `PV_REVISION_RETRIES`
+- [Hooks](../reference/pantavisor-hooks.md#hook-points) — the update hook points fired along the way

--- a/docs/overview/wakelocks.md
+++ b/docs/overview/wakelocks.md
@@ -1,146 +1,76 @@
-# Wakelocks and power modes
+---
+title: "Power and Wakelocks"
+sidebar_position: 14
+description: "How Pantavisor blocks and schedules system suspend so a device sleeps without missing updates."
+---
 
-Pantavisor can block and schedule system suspend so a device sleeps between
-activity without missing updates. The behaviour is selected by `PV_POWER_MODE`:
+# Power and Wakelocks
 
-| mode | suspend | description |
-|------|---------|-------------|
-| `disabled` | never | no power management; wakelock calls are no-ops |
-| `locks` (default) | opportunistic | kernel autosleep is on; Pantavisor holds a wakelock whenever it is busy, so the device suspends only when idle and comes back on an external wake source |
-| `managed` | opportunistic + timed wake | as `locks`, plus Pantavisor wakes itself on a timer to poll Hub, so it works with no external wake source |
+Pantavisor can block and schedule system suspend so a device sleeps between activity without missing
+updates. Which of the three [power modes](../reference/pantavisor-power.md#power-modes) is in effect
+is selected by [`PV_POWER_MODE`](../reference/pantavisor-configuration.md#summary): `disabled` does
+nothing, `locks` (the default) suspends whenever Pantavisor is idle and relies on an external wake
+source, and `managed` additionally wakes the device on a timer so it works with no external source
+at all.
 
-`locks` and `managed` both need kernel wakelock support (`CONFIG_PM_WAKELOCKS`,
-a writable `/sys/power/wake_lock`). If it is missing: `managed` fails init and
-Pantavisor does not start (a tryboot to such a revision never confirms and
-rolls back), since silently never suspending would defeat the point of the
-mode; `locks` degrades instead — one WARN, wakelocks become no-ops, boot
-proceeds (reported via `degraded` in `GET /wakelocks`). Only `disabled`
-tolerates its absence outright.
+`locks` and `managed` both need kernel wakelock support. If it is missing, `managed` fails init and
+Pantavisor does not start — a try-boot into such a revision never confirms and rolls back — because
+silently never suspending would defeat the point of the mode. `locks` degrades instead: one warning,
+wakelocks become no-ops, boot proceeds. Only `disabled` tolerates its absence outright. See
+[kernel requirement](../reference/pantavisor-power.md#kernel-requirement).
 
 ## Wakelocks
 
-All suspend blocking goes through one kernel wakelock named `pantavisor`,
-reference-counted in userspace: the first acquire writes the name to
-`/sys/power/wake_lock`, the last release writes `/sys/power/wake_unlock`. Each
-scope owns a guard, so it contributes at most one to the count.
+All suspend blocking goes through one kernel wakelock named `pantavisor`, reference-counted in
+userspace: the first acquire writes the name to `<PV_POWER_SYSFS_DIR>/wake_lock`, the last release
+writes `wake_unlock`. Each [scope](../reference/pantavisor-power.md#wakelock-scopes) owns a guard,
+so it contributes at most one to the count — boot, an in-flight update, a metadata sync, an open
+debug shell, and so on.
 
-| scope | held while |
-|-------|-----------|
-| `boot` | from start until the FSM first reaches steady state (`RUN -> WAIT`) |
-| `update` | an update downloads, installs and passes the post-boot test/commit |
-| `update_check` | a poll-for-updates roundtrip is in flight |
-| `devmeta` | a local device-metadata change is not yet synced to Hub |
-| `usrmeta` | a user-metadata GET is in flight |
-| `shutdown` | teardown (sync, unmount) during shutdown |
-| `debug_shell` | a debug/serial shell session is open |
-| `poll` | a managed-mode wake window is open |
-
-`devmeta` is dirty-gated: held from a local `pv-ctrl` metadata change (only on an
+`devmeta` is dirty-gated: it is held from a local `pv-ctrl` metadata change (only on an
 authenticated Hub device) until Hub acks the change, bounded by
-`PV_POWER_DEVMETA_MAX_HELD`.
+[`PV_POWER_DEVMETA_MAX_HELD`](../reference/pantavisor-configuration.md#summary).
 
 ## Managed mode
 
-At init, managed mode arms an RTC wake alarm. Once the boot lock is released and
-platforms are up (first `RUN -> WAIT`), it enables kernel autosleep. From then:
+At init, managed mode arms an RTC wake alarm. Once the boot lock is released and platforms are up
+(first `RUN` → `WAIT`), it enables kernel autosleep. From then:
 
 1. The device suspends whenever the wakelock refcount reaches zero.
-2. A worker thread is parked in a blocking `read()` on `/dev/rtc0`. When the RTC
-   alarm fires it wakes the device; the thread grabs the `pantavisor` wakelock
-   inline — same thread, right after the read returns — before the autosleep
-   loop can re-suspend, then signals the event loop over an eventfd.
-3. The event loop opens a **wake window**: it re-arms the alarm for the next
-   cycle and holds `poll` while it polls Hub. The window stays open at least
-   `PV_POWER_WAKE_MIN_AWAKE` (so the network can re-associate after deep
-   suspend), until one poll round reaches Hub (or trivially, if unauthed/no
-   Hub configured) plus `PV_POWER_WAKE_RUN_WINDOW` more as the containers'
-   guaranteed run time, bounded by `PV_POWER_WAKE_MAX_AWAKE`.
+2. A worker thread is parked in a blocking `read()` on `/dev/rtc0`. When the RTC alarm fires it
+   wakes the device; the thread grabs the `pantavisor` wakelock inline — same thread, right after
+   the read returns — before the autosleep loop can re-suspend, then signals the event loop over an
+   eventfd.
+3. The event loop opens a **wake window**: it re-arms the alarm for the next cycle and holds `poll`
+   while it polls Hub. The window stays open at least `PV_POWER_WAKE_MIN_AWAKE` (so the network can
+   re-associate after deep suspend), until one poll round reaches Hub (or trivially, if unauthed or
+   no Hub is configured), plus `PV_POWER_WAKE_RUN_WINDOW` more as the containers' guaranteed run
+   time — all bounded by `PV_POWER_WAKE_MAX_AWAKE`.
 4. When the window closes, `poll` is released and the device suspends again.
 
-A found update holds `update` (independent of the poll window), so the device
-stays awake through download, install and reboot regardless of the wake
-schedule.
+A found update holds `update` independently of the poll window, so the device stays awake through
+download, install and reboot regardless of the wake schedule.
 
-Every wake carries up to two payloads: the Hub roundtrip (if authed) and the
-container run window (`PV_POWER_WAKE_RUN_WINDOW`, off by default). A wake is
-only re-armed if at least one payload applies — a device with neither Hub nor
-a declared run window has nothing to wake for and stays asleep until an
-external event.
+Every wake carries up to two payloads: the Hub roundtrip (if authed) and the container run window
+(off by default). A wake is only re-armed if at least one payload applies — a device with neither
+Hub nor a declared run window has nothing to wake for and stays asleep until an external event.
 
-Waking through the RTC char device with a blocking read is deliberate. A
-`CLOCK_BOOTTIME_ALARM` timerfd serviced from the event loop loses the race:
-autosleep re-suspends before the callback can grab a wakelock. A blocking
-`read()` returns in-kernel while the RTC wakeup event is still held, so grabbing
-the wakelock inline on the same thread closes that gap.
-
-## Configuration
-
-| key | default | meaning |
-|-----|---------|---------|
-| `PV_POWER_MODE` | `locks` | `disabled` / `locks` / `managed` |
-| `PV_POWER_DEVMETA_EAGER_PUSH` | `false` | push a dirty `devmeta` change out-of-band right away rather than waiting up to a full devmeta interval, minimizing awake time |
-| `PV_POWER_WAKE_INTERVAL` | `3600` | managed: seconds between timed wakes (device heartbeat) |
-| `PV_POWER_WAKE_RUN_WINDOW` | `0` (off) | managed: after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
-| `PV_POWER_AUTOSLEEP_SETTLE` | `90` | managed: delay after ready before autosleep is enabled |
-| `PV_POWER_WAKE_MIN_AWAKE` | `10` | managed: minimum awake seconds per wake window |
-| `PV_POWER_WAKE_MAX_AWAKE` | `60` | managed: maximum awake seconds per wake window |
-| `PV_POWER_DEVMETA_MAX_HELD` | `300` | max seconds the `devmeta` lock is held awaiting a Hub ack |
-| `PV_POWER_SYSFS_DIR` | `/sys/power` | base dir of the wakelock sysfs nodes |
-
-All the DURATION keys above (every one but `PV_POWER_MODE` and
-`PV_POWER_SYSFS_DIR`) accept a bare number of seconds or a suffixed value —
-`30s`, `10min`, `1h`, `1d`.
-
-Set any of these like any other Pantavisor key — for example in
-`pantavisor.config` or as a boot environment variable, `PV_POWER_MODE=managed`
-— see [Configuration Levels](pantavisor-configuration-levels.md) for the full
-list of levels and precedence. Check the value actually in effect with
-`pvcontrol conf ls` (these keys have no legacy dotted alias, so they never show
-up in `pvcontrol config ls`).
+Waking through the RTC char device with a blocking read is deliberate. A `CLOCK_BOOTTIME_ALARM`
+timerfd serviced from the event loop loses the race: autosleep re-suspends before the callback can
+grab a wakelock. A blocking `read()` returns in-kernel while the RTC wakeup event is still held, so
+grabbing the wakelock inline on the same thread closes that gap.
 
 ## Inspecting state
 
-`GET /wakelocks` on the pv-ctrl socket, or `pvcontrol wakelocks ls`, returns the
-current mode, refcount, whether autosleep/settle/poll are active, and which
-scopes are held:
-
-```
-$ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/wakelocks"
-{
-  "mode": "managed",
-  "count": 1,
-  "degraded": false,
-  "autosleep": true,
-  "settling": false,
-  "polling": true,
-  "run_window": true,
-  "held": {
-    "boot": false,
-    "update": false,
-    "update_check": false,
-    "devmeta": false,
-    "usrmeta": false,
-    "shutdown": false,
-    "debug_shell": false,
-    "poll": true
-  }
-}
+```bash
+pvcurl /wakelocks
 ```
 
-| field | meaning |
-|-------|---------|
-| `mode` | the active power mode (`disabled` / `locks` / `managed`) |
-| `count` | current wakelock refcount; `0` means the device is free to suspend |
-| `degraded` | `true` when `locks` mode fell back to no-op wakelocks because the kernel lacks wakelock support (`managed` fails init instead) |
-| `autosleep` | `true` once managed mode has enabled kernel autosleep (after the settle delay) |
-| `settling` | `true` while managed mode is waiting out `PV_POWER_AUTOSLEEP_SETTLE` before enabling autosleep |
-| `polling` | `true` while a managed wake window is open (the device woke to poll Hub and/or run containers) |
-| `run_window` | `true` only while `polling` is true and the guaranteed container run window has not yet elapsed |
-| `held.boot` | the `boot` wakelock, held from start until the FSM first reaches steady state |
-| `held.update` | an update is downloading, installing, or in its post-boot test/commit |
-| `held.update_check` | a poll-for-updates roundtrip is in flight |
-| `held.devmeta` | a local device-metadata change is not yet synced to Hub |
-| `held.usrmeta` | a user-metadata GET is in flight |
-| `held.shutdown` | teardown (sync, unmount) is running during shutdown |
-| `held.debug_shell` | a debug/serial shell session is open |
-| `held.poll` | a managed-mode wake window is open (mirrors `polling`) |
+Reports the active mode, the refcount, whether autosleep/settle/poll are active, and which scopes
+are held. See [`GET /wakelocks`](../reference/pantavisor-power.md#get-wakelocks) for the response
+fields.
+
+## Reference
+
+- [Power](../reference/pantavisor-power.md) — modes, scopes, `PV_POWER_*` keys, `/wakelocks` response
+- [Configuration](../reference/pantavisor-configuration.md#summary) — the `PV_POWER_*` rows with their levels

--- a/docs/overview/watchdog.md
+++ b/docs/overview/watchdog.md
@@ -1,5 +1,7 @@
 ---
-sidebar_position: 15
+title: "Watchdog"
+sidebar_position: 13
+description: "Linux kernel watchdog integration and the four ping modes."
 ---
 # Watchdog
 
@@ -29,3 +31,8 @@ This mode combines Pantavisor pinging the watchdog during initialization and shu
 ### Always
 
 In this mode, Pantavisor will ping the watchdog during all the device operation.
+
+## Reference
+
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_WDT_MODE` and `PV_WDT_TIMEOUT`, with their levels
+- [Power](../reference/pantavisor-power.md) — the separate suspend/wakelock machinery

--- a/docs/overview/xconnect.md
+++ b/docs/overview/xconnect.md
@@ -1,5 +1,7 @@
 ---
+title: "Inter-Container Communication"
 sidebar_position: 11
+description: "The xconnect service mesh: service discovery and resource mediation between containers."
 ---
 # Inter-Container Communication
 
@@ -21,6 +23,12 @@ The service mesh operates through a graph of connections maintained by `pv-xconn
 
 This is entirely declarative: no code changes are needed in containers to expose or consume services.
 
+`pv-xconnect` runs as a managed daemon spawned by Pantavisor init, in every init mode. Its three
+jobs are **discovery and reconciliation** — periodically consuming the `xconnect-graph` from the
+`pv-ctrl` socket and maintaining the state of active connects; **plumbing** — namespace-aware
+helpers that inject virtual resources inside the consumer's namespace; and **security** — being the
+single point of truth for role-based access control.
+
 ## Supported Service Types
 
 | Type | Description |
@@ -39,4 +47,9 @@ Pantavisor acts as the security broker. Containers use logical service names rat
 
 The xconnect service mesh can be inspected at runtime through the [/xconnect-graph](../reference/pantavisor-commands.md#xconnect-graph) endpoint of the [Pantavisor control socket](local-control.md). The `pv-xconnect` daemon can be started and stopped via the [/daemons](../reference/pantavisor-commands.md#daemons) endpoint.
 
-For a full reference of service manifest formats and mediation patterns, see the [xconnect reference](../reference/pantavisor-xconnect.md).
+## Reference
+
+- [xconnect](../reference/pantavisor-xconnect.md) — `services.json` and `run.json` manifest formats, mediation patterns, the hosted D-Bus system bus
+- [xconnect Spec](https://github.com/pantavisor/pantavisor/blob/master/xconnect/XCONNECT.md) — full technical design and plugin architecture
+- [Control Socket → /xconnect-graph](../reference/pantavisor-commands.md#xconnect-graph) — inspecting the graph at runtime
+- [Configuration](../reference/pantavisor-configuration.md#summary) — `PV_XCONNECT_DBUS_SYSTEMBUS_ENABLED`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,15 +1,31 @@
 ---
 title: "Reference"
-sidebar_position: 2
+sidebar_position: 0
 description: "Exact specifications for state formats, configuration, commands, and schemas."
 ---
 
 # Reference
 
-- [State Format](pantavisor-state-format-v2.md) — `state.json` schema (v2): root keys, BSP manifest, container manifest, device and groups manifests, signature manifest, and all field definitions
-- [Pantavisor Configuration](pantavisor-configuration.md) — All `pantavisor.json` keys, default values, value types, and the configuration level at which each key is effective
-- [Control Socket](pantavisor-commands.md) — pv-ctrl HTTP-over-Unix-socket endpoints: containers, groups, signals, daemons, and xconnect graph
-- [xconnect](pantavisor-xconnect.md) — Service mesh manifest format: `services.json` export declarations and `run.json` requirement declarations for Unix sockets, D-Bus, DRM, and Wayland
-- [Metadata](pantavisor-metadata.md) — User-defined and system-managed device metadata: key namespaces, update API, and persistence
-- [Log Sockets](logserver-sockets.md) — Logserver Unix socket paths, message format, and how containers attach to the log stream
-- [IPAM](pantavisor-ipam.md) — IP address management configuration: address pools, container address assignment, and namespace configuration
+Complete, enumerable specifications. Every accepted value, default and field is listed here; the
+[Technical Overview](../overview/index.md) explains what they mean.
+
+## Formats
+
+- [State Format](pantavisor-state-format-v2.md) — `state.json` schema (v2): root keys, BSP, drivers, infrastructure, groups, disks, container, service-mesh and signature manifests, with a complete example
+
+## Runtime interfaces
+
+- [Control Socket](pantavisor-commands.md) — pv-ctrl HTTP-over-Unix-socket endpoints: containers, groups, wakelocks, signals, commands, storage, objects, steps, metadata, xconnect graph, config and drivers
+- [Log Sockets](logserver-sockets.md) — `pv-ctrl-log` and `pv-fd-log`, the `/dev/log` syslog protocols, output sinks and timestamp formats
+- [Metadata](pantavisor-metadata.md) — device and user metadata keys, formats, refresh behaviour and change thresholds
+
+## Configuration
+
+- [Pantavisor Configuration](pantavisor-configuration.md) — every configuration key, its accepted values, built-in default, and the levels it may be set at
+
+## Subsystems
+
+- [Hooks](pantavisor-hooks.md) — hook directory rules, hook points, hook environment variables and failure semantics
+- [Power](pantavisor-power.md) — power modes, wakelock scopes, `PV_POWER_*` keys and the `/wakelocks` response
+- [IPAM](pantavisor-ipam.md) — pool and per-container network schemas, lease lifecycle, backend plugin hooks, NAT backend and error handling
+- [xconnect](pantavisor-xconnect.md) — `services.json` and `run.json` service manifests, mediation patterns and the hosted D-Bus system bus

--- a/docs/reference/logserver-sockets.md
+++ b/docs/reference/logserver-sockets.md
@@ -6,6 +6,9 @@ description: "Logserver Unix socket paths and message formats."
 
 # Pantavisor Log Sockets
 
+**Overview:** [Storage → Logs](../overview/storage.md#logs) explains how the log server fits together and
+what each sink is for.
+
 The Pantavisor logging system uses two Unix sockets for inter-process log management: `pv-ctrl-log` for receiving direct log messages and `pv-fd-log` for subscribing file descriptors to be polled by Pantavisor.
 
 ## pv-ctrl-log
@@ -16,11 +19,14 @@ Messages using the binary structure must follow the `logserver_msg` structure:
 
 ```C
 struct logserver_msg {
-    int code; // Protocol code: 0 for LEGACY, 256 for CMD
+    int code; // Protocol code: 0 for LEGACY, 256 for CMD (internal)
     int len;  // Length of the following buffer
     char buf[0]; // Log data buffer
 };
 ```
+
+Code `256` (CMD) is reserved for Pantavisor's own internal use. The log server rejects any CMD
+message whose sender PID is not Pantavisor's, so containers cannot use it.
 
 ### Legacy Protocol (code = 0)
 
@@ -211,13 +217,15 @@ Annotated example:
 
 | RFC 3164 field | Pantavisor attribute | Notes |
 |----------------|----------------------|-------|
-| `HOSTNAME` | `platform` | Container name or source identifier |
-| `APP` | `src` (source) | Process name; `[PID]` suffix is stripped |
+| `HOSTNAME` | — | Parsed to advance the cursor, then discarded |
+| `APP` | `src` (source) | Process name; `[PID]` suffix is stripped. Falls back to `unknown-app` |
 | `PRI` severity bits | `lvl` (level) | See [priority table](#priority-and-facility) |
 | Timestamp | `time` | Parsed with `strptime("%b %d %H:%M:%S")` |
 | Message text | log data | Everything after `APP[PID]: ` |
+| — | `plat` (platform) | Not taken from the message: resolved from the sender's cgroup, falling back to `unknown-platform` |
 
-Missing or unparseable fields fall back to `"unknown-host"` and `"unknown-app"`.
+The `HOSTNAME` a client sends is never trusted or stored. Like every other protocol on this socket,
+the platform is resolved by Pantavisor from the sending process' cgroup.
 
 ### RFC 5424
 
@@ -245,8 +253,8 @@ Nil fields are represented by a single `-` character. Pantavisor accepts `PROCID
 
 | RFC 5424 field | Pantavisor attribute | Notes |
 |----------------|----------------------|-------|
-| `HOSTNAME` | `platform` | Container name or source identifier |
-| `APP` | `src` (source) | Application name |
+| `HOSTNAME` | — | Ignored entirely; `plat` is resolved from the sender's cgroup |
+| `APP` | `src` (source) | Application name. Falls back to `unknown-app` |
 | `PRI` severity bits | `lvl` (level) | See [priority table](#priority-and-facility) |
 | `TIMESTAMP` | `time` | Parsed with `strptime("%Y-%m-%dT%H:%M:%S")`; nil (`-`) → current time |
 | `MSG` | log data | Everything after the structured-data field |
@@ -338,3 +346,47 @@ func main() {
     w.Info("Container started")
 }
 ```
+
+## Log server outputs
+
+Where the log server writes what it receives is set with
+[`PV_LOG_SERVER_OUTPUTS`](pantavisor-configuration.md#summary), a comma-separated list. The sinks
+are not mutually exclusive and can be combined in any fashion; unknown tokens are dropped with a
+warning.
+
+| Value | Destination |
+|-------|-------------|
+| `filetree` | One file per container under `<PV_LOG_DIR>/<revision>/<container>/`. Default |
+| `singlefile` | All logs as JSON lines in a single `<PV_LOG_DIR>/<revision>/pv.log` |
+| `stdout` | Standard output, processed by the log server |
+| `stdout.pantavisor` | Standard output, Pantavisor's own messages only |
+| `stdout.containers` | Standard output, container messages only |
+| `stdout_direct` | Standard output, bypassing the log server. Also auto-enabled before the server starts and after it stops, and always passes FATAL through |
+| `nullsink` | `/dev/null` |
+
+See [Output types](../overview/storage.md#output-types) for what each sink is useful for.
+
+## Timestamp formats
+
+Every sink except `nullsink` prefixes each line with a timestamp. The format is set per sink with
+[`PV_LOG_FILETREE_TIMESTAMP_FORMAT`](pantavisor-configuration.md#summary),
+`PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` and `PV_LOG_STDOUT_TIMESTAMP_FORMAT`.
+
+Two prefixes are accepted:
+
+| Prefix | Meaning |
+|--------|---------|
+| `golang:<constant>` | One of the [Go time layout constants](https://pkg.go.dev/time#pkg-constants) below |
+| `strftime:<format>` | Any [strftime(3)](https://man7.org/linux/man-pages/man3/strftime.3.html) format string, e.g. `strftime:%d, %T %Y` |
+
+| `golang:` constant | Example |
+|--------------------|---------|
+| `golang:Layout` | `01/02 03:04:05PM '06 -0700` |
+| `golang:RubyDate` | `Mon Jan 02 15:04:05 -0700 2006` |
+| `golang:ANSIC` | `Mon Jan _2 15:04:05 2006` |
+| `golang:RFC822Z` | `02 Jan 06 15:04 -0700` |
+| `golang:RFC1123Z` | `Mon, 02 Jan 2006 15:04:05 -0700` |
+
+Separately, [`PV_LOG_TIMESTAMP`](pantavisor-configuration.md#summary) selects the clock behind the
+`tsec` field of every log line: `relative` (seconds since boot, the default) or `absolute`
+(Unix epoch).

--- a/docs/reference/pantavisor-commands.md
+++ b/docs/reference/pantavisor-commands.md
@@ -6,6 +6,9 @@ description: "pv-ctrl HTTP-over-Unix-socket endpoints."
 
 # Pantavisor Control Socket
 
+**Overview:** [Local Control](../overview/local-control.md) explains what the control socket is for and
+who may use it.
+
 The pv-ctrl socket enables communication between the containers and Pantavisor during runtime.
 
 The following subsections describe the behaviour of the HTTP API for the different endpoints, which you can test either using any HTTP client or our [pvcontrol tool](https://gitlab.com/pantacor/pv-platforms/pvr-sdk/-/blob/master/files/usr/bin/pvcontrol) from the default [pvr-sdk container](https://gitlab.com/pantacor/pv-platforms/pvr-sdk).
@@ -25,6 +28,27 @@ Returns all containers with their [status](../overview/containers.md#status), [r
 ```
 $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/containers"
 ```
+
+#### Status values
+
+The same values are reported per group by [`/groups`](#groups) and per revision in
+[device metadata](pantavisor-metadata.md#device-metadata).
+
+| Status | Meaning |
+|--------|---------|
+| `NONE` | No status yet assigned |
+| `INSTALLED` | Installed and ready to go |
+| `MOUNTED` | Volumes mounted, not started |
+| `BLOCKED` | A container in an earlier [group](../overview/containers.md#groups) has not met its status goal |
+| `STARTING` | Starting |
+| `STARTED` | The container PID is running |
+| `READY` | A readiness [signal](#signal) has been received from the container |
+| `RECOVERING` | Crashed, and [auto-recovery](../overview/containers.md#auto-recovery) is waiting to restart it |
+| `STOPPING` | Stopping because of an [update transition](../overview/updates.md) |
+| `STOPPED` | Stopped |
+
+`MOUNTED`, `STARTED` and `READY` are also the three values accepted as a container's or group's
+[`status_goal`](pantavisor-state-format-v2.md#7-container-containerrunjson).
 
 ### Lifecycle control
 
@@ -95,7 +119,7 @@ $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/groups"
 
 ## /wakelocks
 
-Returns the current [power mode and wakelock state](../overview/wakelocks.md#inspecting-state): mode, refcount, whether autosleep/settle/poll are active, and which scopes are held. See [Wakelocks and power modes](../overview/wakelocks.md) for the field-by-field semantics.
+Returns the current power mode and wakelock state: mode, refcount, whether autosleep/settle/poll are active, and which scopes are held. See [`GET /wakelocks`](pantavisor-power.md#get-wakelocks) for the field-by-field semantics, and [Power and Wakelocks](../overview/wakelocks.md) for what the modes mean.
 
 ```
 $ curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/wakelocks"
@@ -148,7 +172,7 @@ These are the different commands that are supported. You can test them by substi
 
 | op | payload | Description |
 | -- | ------- | ----------- |
-| UPDATE_METADATA | {key, value} | upload the json as a new pair of device metadata to Pantacor Hub |
+| UPDATE_METADATA | `{key, value}` | upload the json as a new pair of device metadata to Pantacor Hub |
 | REBOOT_DEVICE | message | reboot device with optional message |
 | POWEROFF_DEVICE | message | poweroff device with optional message |
 | TRY_ONCE | revision | try a revision once (will rollback on failure or next reboot) |
@@ -163,6 +187,20 @@ These are the different commands that are supported. You can test them by substi
 | LOCAL_APPLY | revision | apply revision changes without a full reboot |
 | XCONNECT_GRAPH | N/A | trigger an immediate xconnect graph reconciliation |
 | UNCLAIM | N/A | remove Pantacor Hub credentials so the device registers and becomes claimable again, without a reboot |
+
+### Rejections
+
+A command is not always accepted. These are the non-`200` responses and what causes them:
+
+| Status | Header | Commands | Condition |
+|--------|--------|----------|-----------|
+| `204` | — | `GO_REMOTE` | device is already in remote mode |
+| `204` | — | `UNCLAIM` | device is already unclaimed |
+| `409` | — | `UPDATE_METADATA` | device is not in remote mode |
+| `409` | — | `GO_REMOTE` | remote control is disabled by [`PV_CONTROL_REMOTE`](pantavisor-configuration.md#summary) |
+| `409` | — | `DEFER_REBOOT` | the [debug shell](pantavisor-configuration.md#summary) is not active |
+| `503` | `Retry-After: 600` | `REBOOT_DEVICE`, `POWEROFF_DEVICE`, `LOCAL_RUN`, `LOCAL_RUN_COMMIT`, `MAKE_FACTORY`, `UNCLAIM` | an [update](../overview/updates.md) is ongoing |
+| `503` | `Retry-After: 120` | any | another command is still pending |
 
 ## /storage
 
@@ -213,7 +251,7 @@ To get an existing step json:
 curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/steps/033e779113f2499a2bfb55c0c374803fba9c820361d71bbda616643007cacd5a"
 ```
 
-To send a new json, the format of the new revision in the URI has to contain the "locals/" prefix. The name after the prefix must be under 64 characters and must not contain any other "/" character. These revisions that are installed using the socket ([locals](../overview/local-control.md)) are treated in a different way than the ones installed from Pantacor Hub ([remotes](../overview/remote-control.md)), as you will have to manually request the transition to locals using the [run command](#commands). Most importantly, locals will not attempt any communication with Pantacor Hub during runtime unless a [go remote command](#commands) is issued.
+To send a new json, the format of the new revision in the URI has to contain the "locals/" prefix. The name after the prefix must not contain any other "/" character. These revisions that are installed using the socket ([locals](../overview/local-control.md)) are treated in a different way than the ones installed from Pantacor Hub ([remotes](../overview/remote-control.md)), as you will have to manually request the transition to locals using the [run command](#commands). Most importantly, locals will not attempt any communication with Pantacor Hub during runtime unless a [go remote command](#commands) is issued.
 
 ```
 curl -X PUT --upload-file json --unix-socket /pantavisor/pv-ctrl "http://localhost/steps/locals/example"
@@ -224,6 +262,15 @@ To get the update progress (DONE, TESTING, INPROGRESS...) and some related infor
 ```
 curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/steps/033e779113f2499a2bfb55c0c374803fba9c820361d71bbda616643007cacd5a/progress"
 ```
+
+Every `/steps/{sha}` route has a `locals/{name}` counterpart for revisions installed through this
+socket:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/steps/locals/{name}` | read back a local revision's state json |
+| `GET` | `/steps/locals/{name}/progress` | update progress of a local revision |
+| `PUT` | `/steps/locals/{name}/commitmsg` | set the commit message of a local revision |
 
 Finally, you can set a commit message that will be stored along a revision and showed when listing revisions so the user can idendifcate each one of them:
 
@@ -282,6 +329,9 @@ This endpoint returns the current xconnect service mesh graph in JSON format. Fo
 ```
 curl -X GET --unix-socket /pantavisor/pv-ctrl "http://localhost/xconnect-graph"
 ```
+
+On a build without the `PANTAVISOR_XCONNECT` feature, this endpoint returns `404` with
+`{"Error":"xconnect not enabled at build time"}`.
 
 ## /buildinfo
 

--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -6,6 +6,9 @@ description: "All pantavisor.json configuration keys, defaults, and allowed leve
 
 # Pantavisor Configuration
 
+**Overview:** [Configuration Levels](../overview/pantavisor-configuration-levels.md) explains what the levels
+mean and how they take precedence.
+
 :::note
 This reference page presents the newly unified configuration key syntax. To get to the deprecated but still supported previous format, you will have to go [here](https://github.com/pantavisor/docs.pantavisor/blob/master/archive/legacy/pantavisor-configuration-legacy.md).
 :::
@@ -32,6 +35,18 @@ All keys are case insensitive.
 Syntax and behavior of keys tagged with (experimental) might change and break backwards compatibility.
 :::
 
+:::note
+**Default** is the built-in default compiled into Pantavisor. A device may well be running a
+different value: to see what it actually resolved, and which level set it, use
+[`pvcontrol conf ls`](../tools/pvcontrol.md#configuration).
+:::
+
+:::note
+Keys whose value is `0` or `1` also accept the symbolic forms `true`/`false`, `yes`/`no` and
+`on`/`off`, case-insensitively. The one exception is `PH_CREDS_PROXY_NOPROXYCONNECT`, which is
+integer-typed and accepts only numeric `0` or `1`.
+:::
+
 This table contains the currently supported list of configuration keys, sorted alphabetically.
 
 | Key | Value | Default | Description |
@@ -39,16 +54,16 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PH_CREDS_HOST` | IP or hostname | `api.pantahub.com` | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) address |
 | `PH_CREDS_ID` | string | empty | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) device ID |
 | `PH_CREDS_PORT` | port | `443` | set port for communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
+| `PH_CREDS_PRN` | string | empty | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) device PRN |
 | `PH_CREDS_PROXY_HOST` | IP or hostname | empty | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) proxy address |
 | `PH_CREDS_PROXY_NOPROXYCONNECT` | `0` or `1` | `0` | disable proxy communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PH_CREDS_PROXY_PORT` | port | `3218` | set port for proxy communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
-| `PH_CREDS_PRN` | string | empty | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) device PRN |
 | `PH_CREDS_SECRET` | string | empty | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) credentials secret |
-| `PH_CREDS_TYPE` | `builtin` | `builtin` | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) credentials type |
+| `PH_CREDS_TYPE` | `builtin` or `ext-<handler>` | `builtin` | set [Pantacor Hub](../overview/remote-control.md#pantacor-hub) credentials type; `ext-<handler>` delegates login to an external handler binary instead of the built-in PRN/secret flow |
 | `PH_FACTORY_AUTOTOK` | token | empty | set [factory auto token](https://docs.pantahub.com/pantahub-base/devices/#auto-assign-devices-to-owners) for communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PH_LIBEVENT_HTTP_RETRIES` | number of retries | `1` | set HTTP request number of retries for communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PH_LIBEVENT_HTTP_TIMEOUT` | time (in seconds) | `60` | set HTTP request timeout for communication with [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
-| `PH_METADATA_DEVMETA_HEARTBEAT` | time (in seconds) | `60` | upper bound between [device metadata](../overview/storage.md#device-metadata) pushes; a push happens even when nothing changed, so [Pantacor Hub](../overview/remote-control.md#pantacor-hub) keeps seeing the device as alive |
+| `PH_METADATA_DEVMETA_HEARTBEAT` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `60` | upper bound between [device metadata](../overview/storage.md#device-metadata) pushes; a push happens even when nothing changed, so [Pantacor Hub](../overview/remote-control.md#pantacor-hub) keeps seeing the device as alive |
 | `PH_METADATA_DEVMETA_INTERVAL` | time (in seconds) | `10` | set push interval for [device metadata](../overview/storage.md#device-metadata) to [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PH_METADATA_DEVMETA_THRESHOLD` | percent | `1` | relative change a numeric [device metadata](pantavisor-metadata.md#change-thresholds) field needs before it triggers a push of its own |
 | `PH_METADATA_USRMETA_INTERVAL` | time (in seconds) | `5` | set refresh interval for [user metadata](../overview/storage.md#user-metadata) from [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
@@ -81,56 +96,56 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_DROPBEAR_CACHE_DIR` | path | `/storage/cache/dropbear` | set [debug ssh server](../../meta-pantavisor/getting-started/operate/device-access/local-network.md) cache directory |
 | `PV_LIBEVENT_DEBUG_MODE` | `0` or `1` | `0` | enable event loop debug logs |
 | `PV_LIBTHTTP_CERTSDIR` | path | `/certs` | set certificates directory for libthttp |
-| `PV_LIBTHTTP_LOG_LEVEL` | `0` to `5` | `3` | set libthttp log verbosity level |
+| `PV_LIBTHTTP_LOG_LEVEL` | `0` FATAL, `1` ERROR, `2` WARN, `3` INFO, `4` DEBUG, `5` TRACE | `3` | set libthttp log verbosity level |
+| `PV_LOG_AUTO_DEVLOG` | `0` or `1` | `1` | globally enable or disable the [/dev/log](logserver-sockets.md#devlog) bind-mount into containers; can be overridden per-container with `dev-log` in `run.json` |
 | `PV_LOG_BUF_NITEMS` | integer | `128` | set in-memory [logs](../overview/storage.md#logs) buffer size |
 | `PV_LOG_CAPTURE` | `0` or `1` | `1` | capture logs from containers |
 | `PV_LOG_CAPTURE_DMESG` | `0` or `1` | `1` | capture dmesg logs |
 | `PV_LOG_DIR` | path | `/storage/logs/` | set [logs](../overview/storage.md#logs) directory |
-| `PV_LOG_DIR_MAXSIZE` | integer with optional suffix `B`(default),`K`,`KB`,`M`,`MB`,`G`,`GB`,`T`,`TB`,`%`; `0` for auto 10% (100% if tmpfs) | `16777216` | max size of log directory |
-| `PV_LOG_FILETREE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for filetree logs |
+| `PV_LOG_DIR_MAXSIZE` | integer with optional suffix `B`(default),`K`,`KB`,`M`,`MB`,`G`,`GB`,`T`,`TB`,`%`; `0` for auto | `0` | max size of the [log directory](../overview/storage.md#log-directory-size-management); `0` auto-sizes to 10% of the backing partition, or 100% if it is tmpfs |
+| `PV_LOG_FILETREE_TIMESTAMP_FORMAT` | `golang:<constant>` or `strftime:<format>` | empty | [timestamp format](logserver-sockets.md#timestamp-formats) for filetree logs |
 | `PV_LOG_HYSTERESIS_FACTOR` | positive integer | `4` | controls the gap between high and low watermarks for [log directory cleanup](../overview/storage.md#log-directory-size-management) |
-| `PV_LOG_LEVEL` | `0` to `5` | `0` | set Pantavisor log level (0: FATAL to 5: TRACE) |
+| `PV_LOG_LEVEL` | `0` FATAL, `1` ERROR, `2` WARN, `3` INFO, `4` DEBUG, `5` TRACE | `0` | set Pantavisor [log](../overview/storage.md#logs) verbosity level |
 | `PV_LOG_LOGGERS` | `0` or `1` | `1` | enable loggers for containers |
 | `PV_LOG_PUSH` | `0` or `1` | `1` | push logs to [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PV_LOG_ROTATE_FACTOR` | integer | `5` | determines per-file rotation threshold for [log directory cleanup](../overview/storage.md#log-directory-size-management) |
-| `PV_LOG_SERVER_OUTPUTS` | string | `filetree` | set log server outputs (comma separated) |
-| `PV_LOG_AUTO_DEVLOG` | `0` or `1` | `1` | globally enable or disable the [/dev/log](logserver-sockets.md#devlog) bind-mount into containers; can be overridden per-container with `dev-log` in `run.json` |
-| `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for single-file logs |
-| `PV_LOG_STDOUT_TIMESTAMP_FORMAT` | format string | empty | timestamp format for stdout logs |
+| `PV_LOG_SERVER_OUTPUTS` | comma-separated list of `filetree`, `singlefile`, `stdout`, `stdout.pantavisor`, `stdout.containers`, `stdout_direct`, `nullsink` | `filetree` | set [log server outputs](logserver-sockets.md#log-server-outputs); unknown tokens are dropped with a warning |
+| `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | `golang:<constant>` or `strftime:<format>` | empty | [timestamp format](logserver-sockets.md#timestamp-formats) for single-file logs |
+| `PV_LOG_STDOUT_TIMESTAMP_FORMAT` | `golang:<constant>` or `strftime:<format>` | empty | [timestamp format](logserver-sockets.md#timestamp-formats) for stdout logs |
 | `PV_LOG_TIMESTAMP` | `relative` or `absolute` | `relative` | clock behind the `tsec` field of every log line: seconds since boot, or Unix epoch |
 | `PV_LOOP_INDEX_BASE` | integer | `-1` | set base index of the [loop device range](../overview/init-mode.md) reserved for this instance; `-1` disables ranging |
-| `PV_LXC_LOG_LEVEL` | `0` to `5` | `2` | set LXC log level |
+| `PV_LXC_LOG_LEVEL` | `0` FATAL, `1` ERROR, `2` WARN, `3` INFO, `4` DEBUG, `5` TRACE | `2` | log verbosity forwarded to the LXC platform plugin |
 | `PV_NET_BRADDRESS4` | IP address | `10.0.3.1` | set bridge IPv4 address |
 | `PV_NET_BRDEV` | interface name | `lxcbr0` | set bridge device name |
 | `PV_NET_BRMASK4` | IP mask | `255.255.255.0` | set bridge IPv4 mask |
 | `PV_OEM_NAME` | string | empty | set OEM name to load the in-revision [OEM configuration](../overview/pantavisor-configuration-levels.md#oem) file from `<PV_OEM_NAME>/<PV_POLICY>.config`; empty disables the OEM level |
 | `PV_POLICY` | string | empty | set policy name to select the [policy](../overview/pantavisor-configuration-levels.md#policies) config file and the name of the [OEM configuration](../overview/pantavisor-configuration-levels.md#oem) file (`default` if empty) |
-| `PV_POWER_AUTOSLEEP_SETTLE` | time (in seconds) | `90` | [managed power mode](../overview/wakelocks.md#configuration): delay after ready before autosleep is enabled |
-| `PV_POWER_DEVMETA_EAGER_PUSH` | `0` or `1` | `0` | push [device metadata](../overview/wakelocks.md#configuration) out-of-band right away instead of waiting up to a full devmeta interval, minimizing awake time |
-| `PV_POWER_DEVMETA_MAX_HELD` | time (in seconds) | `300` | max seconds the [`devmeta` wakelock](../overview/wakelocks.md#configuration) is held awaiting a Hub ack |
-| `PV_POWER_MODE` | `disabled`, `locks` or `managed` | `locks` | set [power mode](../overview/wakelocks.md#configuration) |
-| `PV_POWER_SYSFS_DIR` | path | `/sys/power` | base dir of the [wakelock sysfs nodes](../overview/wakelocks.md#configuration) |
-| `PV_POWER_WAKE_INTERVAL` | time (in seconds) | `3600` | [managed power mode](../overview/wakelocks.md#configuration): seconds between timed wakes (device heartbeat) |
-| `PV_POWER_WAKE_MAX_AWAKE` | time (in seconds) | `60` | [managed power mode](../overview/wakelocks.md#configuration): maximum awake seconds per wake window |
-| `PV_POWER_WAKE_MIN_AWAKE` | time (in seconds) | `10` | [managed power mode](../overview/wakelocks.md#configuration): minimum awake seconds per wake window |
-| `PV_POWER_WAKE_RUN_WINDOW` | time (in seconds) | `0` | [managed power mode](../overview/wakelocks.md#configuration): after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
+| `PV_POWER_AUTOSLEEP_SETTLE` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `90` | [managed power mode](pantavisor-power.md#configuration-keys): delay after ready before autosleep is enabled |
+| `PV_POWER_DEVMETA_EAGER_PUSH` | `0` or `1` | `0` | push [device metadata](pantavisor-power.md#configuration-keys) out-of-band right away instead of waiting up to a full devmeta interval, minimizing awake time |
+| `PV_POWER_DEVMETA_MAX_HELD` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `300` | max seconds the [`devmeta` wakelock](pantavisor-power.md#wakelock-scopes) is held awaiting a Hub ack |
+| `PV_POWER_MODE` | `disabled`, `locks` or `managed` | `locks` | set [power mode](pantavisor-power.md#power-modes) |
+| `PV_POWER_SYSFS_DIR` | path | `/sys/power` | base dir of the [wakelock sysfs nodes](pantavisor-power.md#kernel-requirement) |
+| `PV_POWER_WAKE_INTERVAL` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `3600` | [managed power mode](pantavisor-power.md#configuration-keys): seconds between timed wakes (device heartbeat) |
+| `PV_POWER_WAKE_MAX_AWAKE` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `60` | [managed power mode](pantavisor-power.md#configuration-keys): maximum awake seconds per wake window |
+| `PV_POWER_WAKE_MIN_AWAKE` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `10` | [managed power mode](pantavisor-power.md#configuration-keys): minimum awake seconds per wake window |
+| `PV_POWER_WAKE_RUN_WINDOW` | duration: seconds, or `30s`, `10min`, `1h`, `1d` | `0` | [managed power mode](pantavisor-power.md#configuration-keys): after the wake's payload(s) complete, stay awake this many further seconds as the containers' guaranteed run window |
 | `PV_REMOUNT_POLICY` | string | empty | set remount policy name for filesystem remounting |
 | `PV_REVISION_RETRIES` | integer | `10` | number of retries for revision transitions |
 | `PV_SECUREBOOT_CHECKSUM` | `0` or `1` | `1` | enable artifact [checksum validation](../overview/storage.md#artifact-checksum) |
 | `PV_SECUREBOOT_HANDLERS` | `0` or `1` | `1` | enable handlers verification |
 | `PV_SECUREBOOT_MODE` | `disabled`, `audit`, `lenient` or `strict` | `lenient` | set secureboot mode |
-| `PV_SECUREBOOT_OEM_TRUSTSTORE` | path | `/etc/pantavisor/certs/oem` | set path to OEM truststore |
-| `PV_SECUREBOOT_TRUSTSTORE` | path | `/etc/pantavisor/certs` | set path to Pantavisor truststore |
+| `PV_SECUREBOOT_OEM_TRUSTSTORE` | truststore name | `ca-oem-certificates` | name of the OEM truststore, resolved to `<PV_SYSTEM_ETCDIR>/pantavisor/pvs/trust/<name>.crt` |
+| `PV_SECUREBOOT_TRUSTSTORE` | truststore name | `ca-certificates` | name of the Pantavisor truststore, resolved to `<PV_SYSTEM_ETCDIR>/pantavisor/pvs/trust/<name>.crt` |
 | `PV_STORAGE_DEVICE` | string | empty | set storage device name |
-| `PV_STORAGE_FSTYPE` | string | empty | set storage filesystem type |
+| `PV_STORAGE_FIRMWARE_VOL` | `0` or `1` | `0` | use bsp volume `pv--firmware` as alternate kernel firmware load path (written to `/sys/module/firmware_class/parameters/path`); requires the volume to be declared in `device.json` |
+| `PV_STORAGE_FSTYPE` | filesystem name | empty | set storage filesystem type; passed to `mount(2)`. `ext4`, `ubifs` and `jffs2` additionally select special handling |
 | `PV_STORAGE_GC_KEEP_FACTORY` | `0` or `1` | `0` | keep factory revision during GC |
 | `PV_STORAGE_GC_RESERVED` | percentage | `5` | reserved storage percentage for GC |
 | `PV_STORAGE_GC_THRESHOLD` | percentage | `0` | storage GC threshold percentage |
 | `PV_STORAGE_GC_THRESHOLD_DEFERTIME` | time (in seconds) | `600` | defer time for GC threshold |
 | `PV_STORAGE_LOGTEMPSIZE` | size string | empty | set size for temporary log storage |
 | `PV_STORAGE_MNTPOINT` | path | empty | set storage mount point |
-| `PV_STORAGE_MNTTYPE` | string | empty | set storage mount type |
-| `PV_STORAGE_FIRMWARE_VOL` | `0` or `1` | `0` | use bsp volume `pv--firmware` as alternate kernel firmware load path (written to `/sys/module/firmware_class/parameters/path`); requires the volume to be declared in `device.json` |
+| `PV_STORAGE_MNTTYPE` | filesystem name | empty | set storage mount type; passed to `mount(2)`. `ext4`, `ubifs` and `jffs2` additionally select special handling |
 | `PV_STORAGE_PHCONFIG_VOL` | `0` or `1` | `0` | use volume for Pantahub configuration |
 | `PV_STORAGE_WAIT` | time (in seconds) | `5` | time to wait for storage device |
 | `PV_SYSCTL_*` | string | — | set any kernel sysctl at runtime; key maps to `/proc/sys/` (e.g. `PV_SYSCTL_KERNEL_CORE_PATTERN` → `/proc/sys/kernel/core_pattern`) |
@@ -145,7 +160,7 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_SYSTEM_LIBDIR` | path | `/lib` | set system library directory |
 | `PV_SYSTEM_MEDIADIR` | path | `/media` | set system media directory |
 | `PV_SYSTEM_MOUNT_SECURITYFS` | `0` or `1` | `0` | mount securityfs |
-| `PV_SYSTEM_RUNDIR` | path | `/run/pantavisor/pv` | set system run directory |
+| `PV_SYSTEM_RUNDIR` | path | `/pv` | set system run directory |
 | `PV_SYSTEM_USRDIR` | path | `/usr` | set system usr directory |
 | `PV_UPDATER_COMMIT_DELAY` | time (in seconds) | `25` | delay before committing an update |
 | `PV_UPDATER_GOALS_TIMEOUT` | time (in seconds) | `120` | timeout for reaching update goals |
@@ -159,20 +174,27 @@ This table contains the currently supported list of configuration keys, sorted a
 
 This table shows the [configuration levels](../overview/pantavisor-configuration-levels.md) that are allowed for each [configuration key](#summary).
 
+:::note
+The **Command** column is currently unreachable. The only command that mutates configuration
+(`ENABLE_SSH` / `DISABLE_SSH`) applies its override at the user-metadata level, so
+[`pvcontrol conf ls`](../tools/pvcontrol.md#configuration) reports those keys as modified by
+`metadata`, never by `command`.
+:::
+
 | Key | [pv.conf](../overview/pantavisor-configuration-levels.md#pantavisorconfig) | [ph.conf](../overview/pantavisor-configuration-levels.md#pantahubconfig) | [env,bootargs](../overview/pantavisor-configuration-levels.md#environment-variables) | [Policy](../overview/pantavisor-configuration-levels.md#policies) | [OEM](../overview/pantavisor-configuration-levels.md#oem) | [User meta](../overview/pantavisor-configuration-levels.md#user-metadata) | [Command](../overview/pantavisor-configuration-levels.md#commands) |
 |-----|------------------------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------------|-------------------------------------------------------|-----------------------------------------------|---------------------------------------------------------------|--------------------------------------------------------|
 | `PH_CREDS_HOST`                      | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_ID`                        | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_PORT`                      | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PH_CREDS_PRN`                       | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_PROXY_HOST`                | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_PROXY_NOPROXYCONNECT`      | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_PROXY_PORT`                | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
-| `PH_CREDS_PRN`                       | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_SECRET`                    | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_CREDS_TYPE`                      | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PH_FACTORY_AUTOTOK`                 | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ |
-| `PH_LIBEVENT_HTTP_TIMEOUT`           | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PH_LIBEVENT_HTTP_RETRIES`           | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PH_LIBEVENT_HTTP_TIMEOUT`           | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PH_METADATA_DEVMETA_HEARTBEAT`      | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PH_METADATA_DEVMETA_INTERVAL`       | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PH_METADATA_DEVMETA_THRESHOLD`      | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
@@ -187,8 +209,8 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_BOOTLOADER_TYPE`                 | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_BOOTLOADER_UBOOTAB_A_NAME`       | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_BOOTLOADER_UBOOTAB_B_NAME`       | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
-| `PV_BOOTLOADER_UBOOTAB_ENV_NAME`     | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_BOOTLOADER_UBOOTAB_ENV_BAK_NAME` | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `PV_BOOTLOADER_UBOOTAB_ENV_NAME`     | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_BOOTLOADER_UBOOTAB_ENV_OFFSET`   | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_BOOTLOADER_UBOOTAB_ENV_SIZE`     | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_CACHE_DEVMETADIR`                | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
@@ -207,6 +229,7 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_LIBEVENT_DEBUG_MODE`             | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LIBTHTTP_CERTSDIR`               | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_LIBTHTTP_LOG_LEVEL`              | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_LOG_AUTO_DEVLOG`                 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_LOG_BUF_NITEMS`                  | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_LOG_CAPTURE`                     | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_LOG_CAPTURE_DMESG`               | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
@@ -219,7 +242,6 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_LOG_PUSH`                        | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_ROTATE_FACTOR`               | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_SERVER_OUTPUTS`              | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
-| `PV_LOG_AUTO_DEVLOG`                 | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_STDOUT_TIMESTAMP_FORMAT`     | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_LOG_TIMESTAMP`                   | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
@@ -247,14 +269,16 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_SECUREBOOT_OEM_TRUSTSTORE`       | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SECUREBOOT_TRUSTSTORE`           | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_DEVICE`                  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `PV_STORAGE_FIRMWARE_VOL`            | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_FSTYPE`                  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_GC_KEEP_FACTORY`         | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_STORAGE_GC_RESERVED`             | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
-| `PV_STORAGE_GC_THRESHOLD_DEFERTIME`  | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_STORAGE_GC_THRESHOLD`            | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `PV_STORAGE_GC_THRESHOLD_DEFERTIME`  | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ |
 | `PV_STORAGE_LOGTEMPSIZE`             | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_MNTPOINT`                | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_MNTTYPE`                 | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `PV_STORAGE_PHCONFIG_VOL`            | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_STORAGE_WAIT`                    | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSCTL_*`                        | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
 | `PV_SYSCTL_KERNEL_CORE_PATTERN`      | ✓ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
@@ -263,6 +287,7 @@ This table shows the [configuration levels](../overview/pantavisor-configuration
 | `PV_SYSTEM_DISKSDIR`                  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_DRIVERS_LOAD_EARLY_AUTO`  | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_ETCDIR`                   | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `PV_SYSTEM_ETCPANTAVISORDIR`         | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_INIT_MODE`                | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_LIBDIR`                   | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `PV_SYSTEM_MEDIADIR`                 | ✓ | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |

--- a/docs/reference/pantavisor-hooks.md
+++ b/docs/reference/pantavisor-hooks.md
@@ -1,0 +1,69 @@
+---
+title: "Hooks"
+sidebar_position: 8
+description: "Hook points, hook environment variables, and failure semantics."
+---
+
+# Pantavisor Hooks
+
+**Overview:** [Hooks](../overview/hooks.md) explains what hooks are for, why they are part of the
+revision, and how to write one.
+
+## Hook directory
+
+```
+/usr/lib/pantavisor/pv/hooks/system.d/
+```
+
+The base path (`/usr/lib/pantavisor/pv`) is set at build time via `CMAKE_INSTALL_FULL_LIBDIR` and
+may differ per target.
+
+| Rule | Behaviour |
+|------|-----------|
+| Discovery | The directory is re-scanned on every hook invocation |
+| Order | Alphabetical by filename. Use a numeric prefix (`10-my-hook`, `50-notify`) to control it |
+| Eligibility | Regular files with the owner-execute bit (`S_IXUSR`) set |
+| Skipped | Directories, symlinks and non-executable files, silently |
+| Missing directory | Not an error — no hooks run |
+| Output | stdout and stderr are captured by the [log server](logserver-sockets.md) under the hook's filename |
+
+## Hook points
+
+The active hook point is passed to the script as [`PV_OP`](#hook-environment-variables).
+
+| `PV_OP` value | When it fires | Bootloader backends |
+|---------------|---------------|---------------------|
+| `system-start` | Early in Pantavisor initialization, before containers are started | all |
+| `system-before-install-update` | Before the incoming revision is written into the [bootloader](../overview/bsp.md#bootloader) environment | [`uboot-ab`](../overview/bsp.md#uboot-ab), [`rpiab`](../overview/bsp.md#rpiab) |
+| `system-after-install-update` | After the incoming revision has been written into the bootloader environment | [`uboot-ab`](../overview/bsp.md#uboot-ab), [`rpiab`](../overview/bsp.md#rpiab) |
+| `system-install-update` | Both of the above combined, for backends with no dedicated install step | [`uboot`](../overview/bsp.md#uboot), [`grub`](../overview/bsp.md#grub) |
+| `system-boot-done` | After a new revision has been committed following a successful try-boot | all |
+| `system-done` | When all containers have reached their [status goal](../overview/containers.md#status-goal) | all |
+
+## Hook environment variables
+
+Set before executing every hook, unset afterwards.
+
+| Variable | Value |
+|----------|-------|
+| `PV_OP` | The [hook point](#hook-points) currently running |
+| `PV_REV` | ID of the currently running [revision](../overview/revisions.md) |
+| `PV_TRY` | ID of the revision being attempted for the next boot; the incoming revision for update hooks. Empty outside a try-boot, or once committed |
+| `PV_TRYBOOT` | `"true"` if booted into an uncommitted trial revision, `"false"` otherwise. Always `"true"` during `system-boot-done` |
+| `PV_OBJ_STORAGE` | Absolute path to the object [storage](../overview/storage.md) directory |
+| `PV_TRAILS_STORAGE` | Absolute path to the [trails](../overview/storage.md#trails-and-objects) directory for the current revision |
+| `PV_STATUS` | Current revision [status](../overview/updates.md) from the progress JSON (e.g. `DONE`, `TESTING`). Empty if no progress file exists |
+
+## Failure semantics
+
+A non-zero exit aborts the remaining hooks in the directory. What happens next depends on the hook
+point:
+
+| `PV_OP` | Effect of a non-zero exit |
+|---------|---------------------------|
+| `system-start` | Fatal. Pantavisor exits, the device reboots, and the bootloader's tryboot counter decrements toward [rollback](../overview/updates.md#error) |
+| `system-before-install-update` | The update install is aborted |
+| `system-after-install-update` | The update install is aborted |
+| `system-install-update` | The update install is aborted |
+| `system-boot-done` | The commit fails |
+| `system-done` | Logged only. The platform still transitions to its running state |

--- a/docs/reference/pantavisor-ipam.md
+++ b/docs/reference/pantavisor-ipam.md
@@ -6,6 +6,9 @@ description: "IP address management configuration: pools, leases, and per-contai
 
 # Pantavisor IPAM
 
+**Overview:** [IPAM](../overview/ipam.md) explains why pools exist, how allocation works, and how IPAM
+coexists with backend-native static IPs.
+
 Reference for the IP Address Management (IPAM) subsystem: `device.json` pool schema, per-container `run.json` / `args.json` schema, lifecycle behaviors, and backend-plugin hook.
 
 For the narrative overview, see [Technical Overview — IPAM](../overview/ipam.md).
@@ -107,34 +110,36 @@ Leases are keyed by `(pool_name, container_name)` and held in each pool's in-mem
 | Platform teardown (state transition, reboot, rollback) | Lease released in `pv_platform_free`. |
 | IPAM alloc failure mid-start (e.g. static IP collision) | Any partial leases for the platform are released in the `ipam_error` rollback path. |
 
-## Backends and NAT Setup
+## Backend plugin hooks
 
-Bridge creation uses netlink. NAT installation uses a probe-based backend selection:
+Two optional symbols are `dlsym`'d on the container-backend plugin. A backend that does not provide
+them simply contributes nothing.
 
-1. If `nft` is available (`command -v nft` succeeds), install a `table ip nat` with a `postrouting` chain of `srcnat` priority, containing one `ip saddr <subnet> oifname != "<bridge>" masquerade` rule per pool.
-2. Otherwise, if `iptables` is available, fall back to `iptables -t nat -A POSTROUTING -s <subnet> ! -o <bridge> -j MASQUERADE`.
-3. If neither is available, a warning is logged and the pool runs without NAT.
+| Symbol | Called from | Effect |
+|--------|-------------|--------|
+| `pv_validate_container_config(p, conf_file)` | `pv_platform_start`, before IPAM allocation | Non-zero refuses the start. The LXC plugin uses it to reject a pool-using container whose `lxc.container.conf` bakes `lxc.net.*` entries. `lxc.namespace.keep = net` is not flagged |
+| `pv_enumerate_static_ips(p, conf_file, cb, ctx)` | `pv_platforms_reserve_static_ips`, once at startup after `pv_ipam_setup_bridges` | Invokes `cb(ip_in_host_order, ctx)` per hard-coded address found. The LXC plugin greps `lxc.net.N.ipv4.address = X.Y.Z.W[/M]`, ignoring the `auto` and `dhcp` sentinels |
 
-The preference order is nftables-first because every modern Linux kernel (3.13+, so any host from 2014 onward) has nftables native, and recent distros ship iptables as a compat shim over nftables anyway.
+Each enumerated address is routed into `pv_ipam_reserve_static(ip, source)`:
 
-## Static-IP Reservation from Backend Config
+| Address | Disposition |
+|---------|-------------|
+| Inside a pool's subnet | Leased to that pool, tagged `pv:static:<source>`, so `is_ip_available()` skips it |
+| Outside every pool's subnet | Logged at DEBUG, ignored |
+| Equal to a pool's gateway | Logged at WARN, not reserved |
+| Already leased | Skipped |
 
-A second plugin hook — `pv_enumerate_static_ips(p, conf_file, cb, ctx)` — lets pantavisor reserve any hard-coded IPv4 addresses in the container's backend config from the pool allocator, so IPAM never hands the same address out twice.
+## NAT backend
 
-Called once at startup from `pv_platforms_reserve_static_ips(state)` right after `pv_ipam_setup_bridges()`. For each platform that has a backend with this hook, every configured address file is scanned; the hook invokes `cb(ip_in_host_order, ctx)` for each hard-coded address it finds. The default callback routes that into `pv_ipam_reserve_static(ip, source)`:
+NAT is installed per pool with `nat: true`, using the first available backend:
 
-- If the IP falls inside any pool's subnet, a lease tagged `pv:static:<source>` is added to that pool. `is_ip_available()` already filters these out, so no change to `pv_ipam_allocate()` is needed.
-- If the IP is outside every pool's subnet: logged at DEBUG, ignored. The container is managing its own networking on a bridge pantavisor doesn't know about.
-- If the IP clashes with a pool's gateway: logged at WARN, not reserved. The container will likely fail to bring that interface up anyway.
-- Duplicate reservations (same IP already leased) are skipped.
+| Order | Condition | Rule installed |
+|-------|-----------|----------------|
+| 1 | `nft` is on `PATH` | `table ip nat`, `postrouting` chain at `srcnat` priority, one `ip saddr <subnet> oifname != "<bridge>" masquerade` rule per pool |
+| 2 | `iptables` is on `PATH` | `iptables -t nat -A POSTROUTING -s <subnet> ! -o <bridge> -j MASQUERADE` |
+| 3 | neither | WARN logged; the pool runs without NAT |
 
-The LXC plugin implements this by grepping `lxc.container.conf` for `lxc.net.N.ipv4.address = X.Y.Z.W[/M]` lines, ignoring the `auto` and `dhcp` sentinels. Plugins without the hook contribute no reservations — IPAM then allocates from the full subnet minus the gateway and existing dynamic leases.
-
-## Pre-start Validation
-
-Container-backend plugins can reject a start with backend-specific config problems via `pv_validate_container_config(p, conf_file)` — a dlsym'd symbol on the backend plugin library. If present, pantavisor calls it from `pv_platform_start` before the IPAM allocation block. A non-zero return refuses the start; `pv_state_run` returns `-1` and the error bubbles into `PV_STATE_ROLLBACK` (TESTING update) or `PV_STATE_REBOOT` (steady state).
-
-The LXC plugin uses this hook to refuse a pool-using container whose `lxc.container.conf` bakes `lxc.net.*` entries. That combination is ambiguous: pantavisor's own `lxc.net.0.*` injection at start time would overwrite parts of the baked config but can leave orphan attributes from the previous type. The defensive policy is to refuse and ask the user to remove the conflict. `lxc.namespace.keep = net` (present in pvr's default template) is not flagged — pantavisor strips `net` from the keep list at runtime when it injects the veth.
+Bridge creation itself uses netlink.
 
 ## Error Handling
 
@@ -146,13 +151,3 @@ The LXC plugin uses this hook to refuse a pool-using container whose `lxc.contai
 | Static IP already in use | Refuse at `pv_platform_start`. Bubbles up. |
 | Pool exhausted (no free IPs) | Refuse at `pv_platform_start`. Bubbles up. |
 | NAT setup fails | Logged as WARN; the pool is still usable for same-pool traffic. |
-
-## Zero-Impact Invariant for Non-IPAM Devices
-
-If a device's `device.json` has no `network.pools` block and no container's `run.json` has a `network` block:
-
-- `pv_ipam_init()` / `pv_ipam_setup_bridges()` are called but operate on an empty registry — no bridges, no netfilter rules, no routes.
-- All per-container IPAM code paths in `platforms.c`, `state.c`, and `plugins/pv_lxc.c` are guarded by `p->network && p->network->mode == NET_MODE_POOL` and skip.
-- The LXC plugin's `pv_validate_container_config` hook also short-circuits when the platform is not in `NET_MODE_POOL`.
-
-Net observable effect: two INFO log lines at boot (`IPAM subsystem initialized` and a no-op setup). No behavioral change otherwise.

--- a/docs/reference/pantavisor-metadata.md
+++ b/docs/reference/pantavisor-metadata.md
@@ -6,6 +6,9 @@ description: "User-defined and system-managed device metadata reference."
 
 # Pantavisor Metadata
 
+**Overview:** [Storage → Metadata](../overview/storage.md#metadata) explains where metadata lives and how
+it is exchanged with Pantacor Hub.
+
 This page contains reference information about [Pantavisor metadata](../overview/storage.md#metadata).
 
 ## Device metadata
@@ -16,11 +19,10 @@ This is the device metadata created by Pantavisor that will give you useful info
 | --- | ----- | ----------- |
 | `interfaces` | json | network interfaces of the device, keyed by `<iface>.<family>` where family is `ipv4`, `ipv6` or `mac` (see below) |
 | `pantahub.address` | IP:port | Pantacor Hub address the client is communicating with |
-| `pantahub.claimed` | 0 or 1 | 1 if claimed in Pantacor Hub |
+| `pantahub.claimed` | 0 or 1 | `0` while the device is unclaimed, `1` once it has been claimed |
 | `pantahub.online` | 0 or 1 | 1 if connection to Pantacor Hub was established |
 | `pantahub.state` | string | [see Pantacor Hub states](../overview/remote-control.md#pantacor-hub-client) (init, register, claim, sync, login, wait hub, report, idle, prep download or download) |
 | `pantavisor.arch` | string | CPU architecture |
-| `pantavisor.claimed` | 0 or 1 | 1 if device has ever been claimed (local or remote) |
 | `pantavisor.cpumodel` | string | CPU model name |
 | `pantavisor.dtmodel` | string | Device Tree model name |
 | `pantavisor.mode` | local or remote | [see operation modes](../overview/pantavisor-architecture.md#communication-with-the-outside-world) |
@@ -102,12 +104,13 @@ The `interfaces` device metadata is a JSON object keyed by `<iface>.<family>`. E
 
 ## User metadata
 
-This is the user metadata that can be set by the user which is parsed and have some actions on Pantavisor:
+This is the user metadata that can be set by the user. Some keys are interpreted by Pantavisor
+itself; others are only consumed by containers running on the device:
 
 | Key | Value | Description |
 | --- | ----- | ----------- |
 | `pvr-sdk.authorized_keys` | SSH pub key | set [public key](../../meta-pantavisor/getting-started/operate/device-access/local-network.md) to get SSH access |
-| `pvr-auto-follow.url` | URL | device will automatically pull every change in the device associated to that [clone URL](../../meta-pantavisor/getting-started/develop/cli-tools/pvr-cli.md) |
+| `pvr-auto-follow.url` | URL | consumed by the `pvr-sdk` container, not by Pantavisor: it pulls every change from the device associated to that [clone URL](../../meta-pantavisor/getting-started/develop/cli-tools/pvr-cli.md) |
 | `pantahub.log.push` | 0 or 1 | disable/enable log pushing to Pantacor Hub. Overrides [PV_LOG_PUSH](pantavisor-configuration.md#summary) |
 | `<config-key>` | config-value | override any [configuration](pantavisor-configuration.md#summary) keys that allow RUN level |
 | `<container>/<key>` | value | send user metadata that can be consumed by one of the containers |

--- a/docs/reference/pantavisor-power.md
+++ b/docs/reference/pantavisor-power.md
@@ -1,0 +1,92 @@
+---
+title: "Power"
+sidebar_position: 9
+description: "Power modes, wakelock scopes, PV_POWER_* keys, and the /wakelocks response."
+---
+
+# Pantavisor Power
+
+**Overview:** [Power and Wakelocks](../overview/wakelocks.md) explains why suspend is blocked the way
+it is, how managed mode schedules wakes, and what happens without kernel wakelock support.
+
+## Power modes
+
+Set with [`PV_POWER_MODE`](pantavisor-configuration.md#summary).
+
+| Value | Suspend | Behaviour |
+|-------|---------|-----------|
+| `disabled` | never | No power management; wakelock calls are no-ops |
+| `locks` | opportunistic | Kernel autosleep on; Pantavisor holds a wakelock whenever busy, so the device suspends only when idle and resumes on an external wake source. Default |
+| `managed` | opportunistic + timed wake | As `locks`, plus Pantavisor arms an RTC alarm and wakes itself to poll Pantacor Hub, so no external wake source is required |
+
+### Kernel requirement
+
+`locks` and `managed` need `CONFIG_PM_WAKELOCKS` and a writable
+`<PV_POWER_SYSFS_DIR>/wake_lock`.
+
+| Mode | Kernel support missing |
+|------|------------------------|
+| `disabled` | Tolerated |
+| `locks` | Degrades: one WARN, wakelocks become no-ops, boot proceeds. Reported as `degraded` in [`GET /wakelocks`](#get-wakelocks) |
+| `managed` | Fatal: init fails and Pantavisor does not start, so a try-boot into such a revision never confirms and rolls back |
+
+## Wakelock scopes
+
+All suspend blocking goes through one kernel wakelock named `pantavisor`, reference-counted in
+userspace. Each scope owns a guard and contributes at most one to the count.
+
+| Scope | Held while |
+|-------|------------|
+| `boot` | From start until the state machine first reaches steady state (`RUN` → `WAIT`) |
+| `update` | An [update](../overview/updates.md) downloads, installs and passes the post-boot test/commit |
+| `update_check` | A poll-for-updates roundtrip is in flight |
+| `devmeta` | A local [device-metadata](pantavisor-metadata.md#device-metadata) change is not yet synced to Pantacor Hub, bounded by `PV_POWER_DEVMETA_MAX_HELD` |
+| `usrmeta` | A [user-metadata](pantavisor-metadata.md#user-metadata) GET is in flight |
+| `shutdown` | Teardown (sync, unmount) during shutdown |
+| `debug_shell` | A debug/serial shell session is open |
+| `poll` | A managed-mode wake window is open |
+
+## Configuration keys
+
+Full rows, levels included, are in the [configuration reference](pantavisor-configuration.md#summary).
+Every key below except `PV_POWER_MODE` and `PV_POWER_SYSFS_DIR` is a duration: it takes a bare
+number of seconds or a single-unit value — `30s`, `10min`, `1h`, `1d`.
+
+| Key | Default | Applies to | Meaning |
+|-----|---------|------------|---------|
+| `PV_POWER_MODE` | `locks` | all | [Power mode](#power-modes) |
+| `PV_POWER_SYSFS_DIR` | `/sys/power` | `locks`, `managed` | Base dir of the wakelock sysfs nodes |
+| `PV_POWER_DEVMETA_EAGER_PUSH` | `0` | all | Push a dirty `devmeta` change out-of-band immediately instead of waiting up to a full devmeta interval |
+| `PV_POWER_DEVMETA_MAX_HELD` | `300` | all | Max seconds the `devmeta` scope is held awaiting a Hub ack |
+| `PV_POWER_AUTOSLEEP_SETTLE` | `90` | `managed` | Delay after ready before autosleep is enabled |
+| `PV_POWER_WAKE_INTERVAL` | `3600` | `managed` | Seconds between timed wakes |
+| `PV_POWER_WAKE_MIN_AWAKE` | `10` | `managed` | Minimum awake seconds per wake window |
+| `PV_POWER_WAKE_MAX_AWAKE` | `60` | `managed` | Maximum awake seconds per wake window |
+| `PV_POWER_WAKE_RUN_WINDOW` | `0` | `managed` | Extra awake seconds after the wake's payloads complete, as the containers' guaranteed run window |
+
+## `GET /wakelocks`
+
+Served by the [control socket](pantavisor-commands.md#wakelocks), and wrapped by
+[`pvcontrol wakelocks ls`](../tools/pvcontrol.md).
+
+```bash
+pvcontrol wakelocks ls
+```
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `mode` | string | The **active** power mode (`disabled` / `locks` / `managed`), which may lag the configured one until the next config apply |
+| `count` | number | Current reference count on the `pantavisor` wakelock; `0` means the device is free to suspend |
+| `degraded` | bool | `true` when `locks` mode fell back to no-op wakelocks because the kernel lacks wakelock support (`managed` fails init instead) |
+| `autosleep` | bool | `true` once managed mode has enabled kernel autosleep, after the settle delay |
+| `settling` | bool | `true` while managed mode is waiting out `PV_POWER_AUTOSLEEP_SETTLE` before enabling autosleep |
+| `polling` | bool | `true` while a managed wake window is open — the device woke to poll Hub and/or run containers |
+| `run_window` | bool | `true` only while `polling` is true and the guaranteed container run window has not yet elapsed |
+| `held.boot` | bool | Held from start until the state machine first reaches steady state |
+| `held.update` | bool | An update is downloading, installing, or in its post-boot test/commit |
+| `held.update_check` | bool | A poll-for-updates roundtrip is in flight |
+| `held.devmeta` | bool | A local device-metadata change is not yet synced to Hub |
+| `held.usrmeta` | bool | A user-metadata GET is in flight |
+| `held.shutdown` | bool | Teardown (sync, unmount) is running during shutdown |
+| `held.debug_shell` | bool | A debug/serial shell session is open |
+| `held.poll` | bool | A managed-mode wake window is open (mirrors `polling`) |

--- a/docs/reference/pantavisor-state-format-v2.md
+++ b/docs/reference/pantavisor-state-format-v2.md
@@ -6,6 +6,10 @@ description: "state.json schema (v2): root keys and all manifest definitions."
 
 # Pantavisor State Format (state.json)
 
+**Overview:** [Revisions](../overview/revisions.md) explains what a revision is and how state.json
+represents it. [Disks](../overview/disks.md) and [Containers](../overview/containers.md) explain the
+subsystems the `device.json` and `run.json` manifests configure.
+
 A Pantavisor revision is defined by a single JSON object called `state.json`. It acts as a **virtual filesystem manifest** where every key represents a relative file path within the revision, and every value is either a nested configuration object or a SHA256 identifier for a binary artifact.
 
 ## 1. Root Level (`state.json`)
@@ -111,14 +115,42 @@ examples.
 | `mode` | enum | **Mandatory** (crypt) | `mainline` or `nxp`. Selects key subsystem. |
 | `format` | enum | `ext4` | Filesystem format: `ext4`, `ext3`, or `swap`. |
 | `provision` | string | empty | Backend provisioning: `zram`, `file`, or a custom value. Required for swap; optional for `volume-disk` (absent → bind-mount backend). |
-| `provision_ops` | string | empty | Backend-specific options (e.g. `disksize=128M comp_algorithm=lz4`). |
+| `provision_options` | string | empty | Backend-specific options (e.g. `disksize=128M comp_algorithm=lz4`). |
 | `mount_target` | path | empty | Where to mount the disk on the host. Required for `volume-disk`. |
 | `mount_options` | string | empty | Comma-separated mount flags (e.g. `MS_NOATIME,MS_NOSUID`). |
 | `format_options` | string | empty | Arguments for the `mkfs` or `mkswap` command. |
 | `default` | string | `"no"` | If `"yes"`, this disk is used for all volumes without a `disk` key. |
 | `uuid` | string | empty | Disk UUID. |
 | `disks` | array | **Mandatory** (dual) | Sub-disk names: `["primary-name", "secondary-name"]`. |
-| `init_order` | array | **Mandatory** (dual) | Actions tried in sequence: `primary`, `secondary`, `create-primary`, `create-secondary`, `copy-once-to-primary`. |
+| `init_order` | array | **Mandatory** (dual) | Actions tried in sequence, see below. |
+
+#### `init_order` actions
+
+| Action | Description |
+|--------|-------------|
+| `primary` | Mount the existing primary disk (`--no-create`). Fails if it is not initialized. |
+| `secondary` | Mount the existing secondary disk (`--no-create`). Fails if it is not initialized. |
+| `create-primary` | Create, format and mount the primary disk. |
+| `create-secondary` | Create, format and mount the secondary disk. |
+| `copy-once-to-primary` | Mount the secondary read-only, create the primary, and copy all data with file-level verification. Skipped once the dual `init_done` marker is set. |
+
+#### Required fields per disk type
+
+| Type | Mandatory | Optional | Ignored |
+|------|-----------|----------|---------|
+| `swap-disk` | `name`, `provision` (`file`, `zram`, or any other value for a block device), `path` unless `provision` is `zram`; `provision_options` must carry `size=<value>` when `provision` is `file` | `format_options` (passed to `mkswap`), `mount_options` (passed to `swapon`) | `path` when `provision` is `zram` |
+| `volume-disk` without `provision` | `name` | `aliases` | `path`, `format`, `mount_target` |
+| `volume-disk` with `provision` | `name`, `format` (`ext4` or `ext3`), `mount_target`, `path` unless `provision` is `zram` | `format_options`, `mount_options`, `provision_options` | `path` when `provision` is `zram` |
+| `dm-crypt-caam`, `dm-crypt-dcp`, `dm-crypt-versatile` | `name`, `path`, `mode` (`mainline` or `nxp`) | `format`, `format_options`, `mount_options` | — |
+| `dual` | `name`, `disks`, `init_order` | `aliases` | `path`, `format` |
+
+`mount_options` accepts a comma-separated list of: `MS_NOATIME`, `MS_NODEV`, `MS_NOEXEC`,
+`MS_NOSUID`, `MS_RDONLY`, `MS_RELATIME`, `MS_SYNCHRONOUS`, `MS_DIRSYNC`, `MS_LAZYTIME`,
+`MS_MANDLOCK`, `MS_NODIRATIME`, `MS_REC`, `MS_SILENT`, `MS_STRICTATIME`.
+
+When `provision` is `zram`, `provision_options` is a space-separated list of `key=value` pairs
+written to `/sys/block/zramX/*` (e.g. `disksize=128M comp_algorithm=lz4`), and `path` is overwritten
+with the allocated `/dev/zramX`.
 
 ---
 
@@ -198,3 +230,102 @@ JWS-based artifact verification.
 | `signature` | base64 string | The cryptographic signature of the protected header and payload. |
 | `x5c` | array | (In protected) Certificate chain for verification. |
 | `jwk` | object | (In protected) JSON Web Key for verification. |
+
+---
+
+## 10. Complete example
+
+A minimal revision made of a BSP and one container named `awconnect`:
+
+```
+{
+  "#spec": "pantavisor-service-system@1",
+  "_hostconfig/pvr/docker.json": {
+    "platforms": [
+      "linux/arm64",
+      "linux/arm"
+    ]
+  },
+  "awconnect/lxc.container.conf": "153d58588b0327f73c8424c214c039fcdd975814bc075bc5c72f82fd3cdfd7b6",
+  "awconnect/root.squashfs": "e1ddabe573021b48dd5d66d59593d94fbc57b7a2f85dac59628959ae6955d2e2",
+  "awconnect/root.squashfs.docker-digest": "828054813b64d71d26756903010a52828941f6bb0859e878cb70f6f1e0ec7d2d",
+  "awconnect/run.json": {
+    "#spec": "service-manifest-run@1",
+    "config": "lxc.container.conf",
+    "name": "awconnect",
+    "root-volume": "root.squashfs",
+    "storage": {
+      "docker--etc-NetworkManager-system-connections": {
+        "persistence": "permanent"
+      },
+      "lxc-overlay": {
+        "persistence": "boot"
+      }
+    },
+    "type": "lxc",
+    "volumes": []
+  },
+  "awconnect/src.json": {
+    "#spec": "service-manifest-src@1",
+    "docker_config": {
+      "AttachStderr": false,
+      "AttachStdin": false,
+      "AttachStdout": false,
+      "Cmd": [
+        "/lib/systemd/systemd"
+      ],
+      "Domainname": "",
+      "Env": [
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      ],
+      "Hostname": "",
+      "Image": "sha256:a8c4da0f0bde245a971a4a63a205cf56e071611f78b3d650715f309b7cefc57b",
+      "OpenStdin": false,
+      "StdinOnce": false,
+      "Tty": false,
+      "User": "",
+      "Volumes": {
+        "/etc/NetworkManager/system-connections/": {}
+      },
+      "WorkingDir": "/opt/wifi-connect/"
+    },
+    "docker_digest": "registry.gitlab.com/pantacor/pv-platforms/wifi-connect@sha256:b2ad073c0a41d186b6338fb8b81714eb1b8da9421383bbf8914fb86a01bbcafb",
+    "docker_name": "registry.gitlab.com/pantacor/pv-platforms/wifi-connect",
+    "docker_source": "remote,local",
+    "docker_tag": "arm32v5",
+    "persistence": {},
+    "template": "builtin-lxc-docker"
+  },
+  "bsp/addon-plymouth.cpio.xz4": "beae6a7bb235916cac52bcfece64c30615cded8c4c640e6941e7ecabe53b4920",
+  "bsp/build.json": {
+    "altrepogroups": "",
+    "branch": "master",
+    "commit": "e2a4911eb35de2032e85f74c8f239de81c6f622b",
+    "gitdescribe": "014-rc14-18-ge2a4911",
+    "pipeline": "436189414",
+    "platform": "rpi64",
+    "project": "pantacor/pv-manifest",
+    "pvrversion": "pvr version 026-52-gbf3bd5d6",
+    "target": "arm-rpi64",
+    "time": "2021-12-24 01:25:27 +0000"
+  },
+  "bsp/firmware.squashfs": "f37e9699ea8add7042e2843d095e68a316e6344d832b74d41244cb0bca29464e",
+  "bsp/kernel.img": "990f8b0fcab8b99f631497753cc55b70f6f522a1d91cd4ae0777a7747b98509e",
+  "bsp/modules.squashfs": "0e202a7ee3a575bc502ec3869251a3587a3110079f221fc15c63da1e8d8a08ae",
+  "bsp/pantavisor": "1e6561f75cba98500f023e09aae430557fe0d1b02aeb1fa9adb3c2d3b6d250c6",
+  "bsp/run.json": {
+    "addons": [
+      "addon-plymouth.cpio.xz4"
+    ],
+    "firmware": "firmware.squashfs",
+    "initrd": "pantavisor",
+    "initrd_config": "",
+    "linux": "kernel.img",
+    "modules": "modules.squashfs"
+  },
+  "bsp/src.json": {
+    "#spec": "bsp-manifest-src@1",
+    "pvr": "https://pvr.pantahub.com/pantahub-ci/arm_rpi64_bsp_latest#bsp"
+  }
+}
+```

--- a/docs/reference/pantavisor-xconnect.md
+++ b/docs/reference/pantavisor-xconnect.md
@@ -6,18 +6,13 @@ description: "Service mesh manifest formats and mediation patterns."
 
 # Pantavisor xconnect
 
-The `pv-xconnect` service mesh facilitates efficient container-to-container and container-to-host interactions. It uses a plugin-driven architecture to inject resources (Unix sockets, D-Bus proxies, DRM nodes) into consumer containers on demand.
+**Overview:** [Inter-Container Communication](../overview/xconnect.md) explains what the service mesh
+is for, how mediation works, and the security model. This page is the manifest and mediation
+reference.
 
-For information on how to inspect or manage the service mesh via the Pantavisor Control API, see the [Pantavisor Control Socket](pantavisor-commands.md#xconnect-graph) reference.
-
-## Architecture
-
-To manage interactions between containers, a dedicated process called `pv-xconnect` handles the mediation logic via on-demand plugins. It runs as a managed daemon spawned by Pantavisor init and is enabled for all init modes (embedded, standalone, and appengine).
-
-### Core Responsibilities
-- **Discovery & Reconciliation**: Periodically consumes an `xconnect-graph` from Pantavisor's `pv-ctrl` socket and maintains the state of active connects.
-- **Plumbing**: Provides namespace-aware helpers to inject virtual resources (sockets/device nodes) inside the consumer's namespace.
-- **Security**: Acts as the single point of truth for role-based access control.
+To inspect or manage the mesh at runtime, see
+[`/xconnect-graph`](pantavisor-commands.md#xconnect-graph) and
+[`/daemons`](pantavisor-commands.md#daemons).
 
 ## Service Manifests
 
@@ -70,19 +65,20 @@ Containers that consume services define their requirements in `args.json` during
 
 ## Mediation Patterns
 
-### Raw Unix Sockets
-Provides direct proxying of Unix Domain Sockets between containers. It supports high-performance features like FD passing (SCM_RIGHTS) and Shared Memory handles.
+| `type` | What is injected | Notes |
+|--------|------------------|-------|
+| `unix` | A proxied Unix domain socket | Supports FD passing (`SCM_RIGHTS`) and shared-memory handles |
+| `rest` | HTTP over a Unix socket | `X-PV-Client` and `X-PV-Role` headers are injected into the first request so the provider can identify the consumer |
+| `dbus` | A policy-aware system-bus proxy | Role-based identity masquerading, see below |
+| `drm` | A DRM/KMS device node | |
+| `wayland` | A mediated Wayland socket | |
 
-### REST
-Identity-injected HTTP over UDS. `pv-xconnect` automatically injects `X-PV-Client` and `X-PV-Role` headers into the first request, allowing the provider to identify the consumer.
+### D-Bus identity masquerading
 
-### D-Bus
-Policy-aware proxy for the system bus. It performs **Role-Based Identity Masquerading**:
-1. `pv-xconnect` intercepts the D-Bus SASL authentication phase.
-2. It takes the **Role** from the link and looks up the corresponding **UID** in the provider container's `/etc/passwd`.
-3. It replaces the consumer's identity with the resolved UID.
-
-This allows the provider's standard `dbus-daemon` to enforce fine-grained permissions using standard XML policy files based on the assigned role.
+`pv-xconnect` intercepts the D-Bus SASL authentication phase, takes the **Role** from the link,
+looks up the corresponding UID in the provider container's `/etc/passwd`, and substitutes it for
+the consumer's identity. The provider's standard `dbus-daemon` then enforces its own XML policy
+files against that role.
 
 #### Pantavisor-Hosted System Bus
 
@@ -220,8 +216,5 @@ Mediates the Wayland protocol for isolated UI rendering, allowing a containerize
 
 ## Tools
 
-### pvcurl
-A lightweight shell script wrapping `nc` for HTTP-over-Unix-socket communication. It is preferred in App Engine environments where standard `curl` might not be available.
-
-### pvcontrol
-A high-level CLI wrapper around `pvcurl` for common Pantavisor control operations.
+Inspect and drive the mesh with [`pvcontrol`](../tools/pvcontrol.md#xconnect-graph) or, where a full
+`curl` is unavailable, [`pvcurl`](../tools/pantavisor-tools.md#pvcurl).

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,10 +1,14 @@
 ---
 title: "Tools"
-sidebar_position: 3
+sidebar_position: 0
 description: "On-device CLI tools: pventer, pvcurl, pvcontrol, and pvtx."
 ---
 
 # Tools
 
-- [Tools](pantavisor-tools.md) — On-device CLI tools: `pventer`, `pvcurl`, `pvcontrol`, and `pvtx` — commands, flags, and usage examples
-- [pvcontrol](pvcontrol.md) — Full `pvcontrol` CLI reference: options, socket auto-detection, and worked examples for every command
+How to drive Pantavisor from a shell on the device. What these tools talk to is explained in
+[Local Control](../overview/local-control.md); the endpoints behind them are in the
+[Control Socket reference](../reference/pantavisor-commands.md).
+
+- [Tools](pantavisor-tools.md) — `pventer`, `pvcurl`, `pvcontrol` and `pvtx`: what each is for, with usage examples
+- [pvcontrol](pvcontrol.md) — full `pvcontrol` CLI reference: options, socket auto-detection, exit codes, and a worked example for every command

--- a/docs/tools/pantavisor-tools.md
+++ b/docs/tools/pantavisor-tools.md
@@ -6,6 +6,9 @@ description: "On-device CLI tools: pventer, pvcurl, pvcontrol, and pvtx."
 
 # Pantavisor Tools
 
+**Overview:** [Local Control](../overview/local-control.md) explains what these tools talk to. For the
+endpoints behind them, see the [Control Socket reference](../reference/pantavisor-commands.md).
+
 On-device CLI tools shipped with Pantavisor for development, debugging, and container control.
 
 ## pventer
@@ -88,7 +91,6 @@ pvcontrol daemons restart <name>
 
 # Status signals (sent by a container to signal readiness)
 pvcontrol signal ready               # signal container is ready
-pvcontrol signal alive               # signal container is alive (watchdog)
 
 # System commands
 pvcontrol cmd reboot [message]

--- a/docs/tools/pvcontrol.md
+++ b/docs/tools/pvcontrol.md
@@ -6,6 +6,9 @@ description: "Full pvcontrol CLI reference with worked examples."
 
 # pvcontrol
 
+**Overview:** [Local Control](../overview/local-control.md) explains where `pvcontrol` fits; the
+[Control Socket reference](../reference/pantavisor-commands.md) documents the endpoints it calls.
+
 `pvcontrol` is the on-device CLI for controlling Pantavisor from inside a
 container. It is a small POSIX-shell wrapper (`tools/pvcontrol`) around
 [`pvcurl`](pantavisor-tools.md#pvcurl) that talks to the pv-ctrl REST API over
@@ -41,8 +44,8 @@ When `-s` is not given, the socket is selected in this order:
 2. `/pv/pv-ctrl` — alternative embedded path
 3. `/pantavisor/pv-ctrl` — default location inside a container (fallback)
 
-If the chosen socket does not exist, `pvcontrol` prints `ERROR: <socket> not
-found` and exits non-zero.
+If the chosen socket does not exist, `pvcontrol` prints `ERROR: <socket> not found`
+and exits non-zero.
 
 ### Environment variables
 
@@ -61,8 +64,15 @@ printed to stderr):
 | `0` | Success (HTTP 200). |
 | `48` | Not enough disk space available. |
 | `60` | Object has bad checksum. |
-| `70` | State verification failed. |
+| `70` | State verification failed. Not currently reachable — see the note below. |
+| `75` | HTTP 503: an update is ongoing, or another command is still pending. Retry after the interval in the response's `Retry-After` header — see [Rejections](../reference/pantavisor-commands.md#rejections). |
 | `255` | Any other non-200 response. |
+
+:::note
+Exit code `70` matches on an error string Pantavisor does not currently emit, so a real
+state-verification failure on `steps put` or `steps install` exits `255` with the actual reason
+(`Storage: …`, `Secureboot: …` or `Parser: …`) on stderr.
+:::
 
 > Because errors surface only through the exit code, assert HTTP status codes
 > with raw `pvcurl -w '%{http_code}'` when you need to distinguish, e.g., 404
@@ -169,8 +179,9 @@ autosleep/settle/poll are active, and which scopes are held. Example output:
 {"mode":"locks","count":0,"degraded":false,"autosleep":false,"settling":false,"polling":false,"run_window":false,"held":{"boot":false,"update":false,"update_check":false,"devmeta":false,"usrmeta":false,"shutdown":false,"debug_shell":false,"poll":false}}
 ```
 
-See [wakelocks.md](../overview/wakelocks.md#inspecting-state) for the
-field-by-field semantics and the `PV_POWER_*` configuration keys.
+See [`GET /wakelocks`](../reference/pantavisor-power.md#get-wakelocks) for the field-by-field
+semantics and [Power](../reference/pantavisor-power.md#configuration-keys) for the `PV_POWER_*`
+configuration keys.
 
 ---
 
@@ -270,12 +281,13 @@ one non-management endpoint — it does not require management-socket access.
 
 ```bash
 pvcontrol signal ready    # container has finished starting
-pvcontrol signal alive    # liveness/watchdog heartbeat
 ```
 
+`ready` is the only signal Pantavisor implements. `pvcontrol` will send any other value the
+CLI accepts, but the runtime answers "signal not supported".
+
 > Signals issued from a platform container (e.g. pvr-sdk) may return HTTP 500
-> because that caller is not ready-gated; this is expected. `alive` is not a
-> supported signal type on all builds.
+> because that caller is not ready-gated; this is expected.
 
 ---
 
@@ -487,7 +499,7 @@ On a platform without managed drivers these are effectively no-ops returning
 | `daemons start\|stop\|restart <name>` | PUT | `/daemons/{name}` |
 | `graph ls` | GET | `/xconnect-graph` |
 | `wakelocks ls` | GET | `/wakelocks` |
-| `signal ready\|alive` | POST | `/signal` |
+| `signal ready` | POST | `/signal` |
 | `cmd <subcommand>` | POST | `/commands` |
 | `storage gc` | POST | `/storage/gc` |
 | `devmeta ls` | GET | `/device-meta` |

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,247 @@
+#!/bin/sh
+# Validate docs/ against the code and against docs/CONTRIBUTING.md.
+# Usage: scripts/check-docs.sh
+set -e
+cd "$(dirname "$0")/.."
+exec python3 - "$PWD" <<'PYEOF'
+import os, re, sys
+
+root = sys.argv[1]
+DOCS = os.path.join(root, 'docs')
+fail = []
+def bad(check, msg):
+    fail.append("%-14s %s" % (check + ':', msg))
+
+def read(p):
+    with open(os.path.join(root, p)) as f:
+        return f.read()
+
+# ---------------------------------------------------------------- config keys
+cfg_c = read('config.c')
+defines = dict(re.findall(r'^#define\s+([A-Z0-9_]+_DEF)\s+(.+?)\s*$', cfg_c, re.M))
+# entries[] rows: { TYPE, "KEY", levels, modified, secret, .value.X = DEFAULT }
+entries = {}
+for m in re.finditer(r'\{\s*([A-Z_0-9]+)\s*,\s*"([A-Z0-9_]+)"\s*,[^{}]*?'
+                     r'\.value\.([sib])\s*=\s*([^,}]+?)\s*\}', cfg_c):
+    typ, key, slot, dflt = m.groups()
+    entries[key] = (typ, slot, dflt.strip())
+
+cfg_md = read('docs/reference/pantavisor-configuration.md').split('\n')
+def table_keys(sep_prefix):
+    i = next(n for n, l in enumerate(cfg_md) if l.startswith(sep_prefix))
+    out = {}
+    n = i + 1
+    while n < len(cfg_md) and cfg_md[n].startswith('|'):
+        km = re.match(r'\|\s*`([^`]+)`', cfg_md[n])
+        if km:
+            out[km.group(1)] = cfg_md[n]
+        n += 1
+    return out
+
+summary = table_keys('|-----|-------|---------|-------------|')
+levels  = table_keys('|-----|-------------------------')
+
+# keys implemented outside entries[] but legitimately documented
+EXTRA_OK = {'PV_SYSCTL_*', 'PV_SYSCTL_KERNEL_CORE_PATTERN', 'PV_REMOUNT_POLICY'}
+
+for key in sorted(entries):
+    if key not in summary:
+        bad('config', "%s is in config.c entries[] but missing from the Summary table" % key)
+    if key not in levels:
+        bad('config', "%s is in config.c entries[] but missing from the Levels table" % key)
+for key in sorted(set(summary) - set(entries) - EXTRA_OK):
+    bad('config', "%s is documented but not in config.c entries[]" % key)
+for key in sorted(set(levels) - set(summary)):
+    bad('config', "%s is in the Levels table but not in the Summary table" % key)
+for name, tbl in (('Summary', summary), ('Levels', levels)):
+    ks = list(tbl)
+    if ks != sorted(ks):
+        bad('config', "the %s table is not sorted alphabetically" % name)
+
+# defaults, where both sides are mechanically comparable
+def code_default(slot, raw):
+    raw = defines.get(raw, raw)
+    if slot == 'b':
+        return '1' if raw == 'true' else '0'
+    if slot == 'i':
+        return raw if re.fullmatch(r'-?\d+', raw) else None
+    if raw == 'NULL':
+        return ''
+    m = re.fullmatch(r'"(.*)"', raw)
+    return m.group(1) if m else None
+
+for key, (typ, slot, raw) in sorted(entries.items()):
+    want = code_default(slot, raw)
+    if want is None or key not in summary:
+        continue
+    cells = [c.strip() for c in summary[key].split('|')]
+    if len(cells) < 5:
+        continue
+    got = cells[3]
+    got = '' if got == 'empty' else got
+    gm = re.match(r'`([^`]*)`', got)
+    got = gm.group(1) if gm else got
+    if got != want:
+        bad('config', "%s default is `%s` in the doc but `%s` in config.c" % (key, got or 'empty', want or 'empty'))
+
+# ------------------------------------------------------------- ctrl endpoints
+cmds_md = read('docs/reference/pantavisor-commands.md')
+sections = set(re.findall(r'^## (/\S+)', cmds_md, re.M))
+routes = set()
+for fn in sorted(os.listdir(os.path.join(root, 'ctrl'))):
+    if not fn.endswith('.c'):
+        continue
+    for m in re.finditer(r'pv_ctrl_add_endpoint\(\s*"([^"]+)"', read('ctrl/' + fn)):
+        routes.add(m.group(1))
+for r in sorted(routes):
+    segs = [s for s in r.split('/') if s and s != '{}']
+    if not segs:
+        continue
+    if '/' + segs[0] not in sections:
+        bad('ctrl', "route %s has no '## /%s' section in pantavisor-commands.md" % (r, segs[0]))
+        continue
+    for s in segs[1:]:
+        if s not in cmds_md:
+            bad('ctrl', "route %s: segment '%s' is not mentioned in pantavisor-commands.md" % (r, s))
+
+# ------------------------------------------------------------- devmeta keys
+meta_md = read('docs/reference/pantavisor-metadata.md')
+meta_h = read('metadata.h')
+srcs = []
+for dirpath, dirs, names in os.walk(root):
+    dirs[:] = [d for d in dirs if d not in ('.git', 'docs', 'build')]
+    for n in names:
+        if n.endswith(('.c', '.h')):
+            srcs.append(os.path.join(dirpath, n))
+def macro_uses(macro):
+    n = 0
+    for f in srcs:
+        try:
+            with open(f, errors='ignore') as fh:
+                n += fh.read().count(macro)
+        except OSError:
+            pass
+    return n
+for m in re.finditer(r'^#define\s+(DEVMETA_KEY_\w+)\s+"([^"]+)"', meta_h, re.M):
+    macro, key = m.groups()
+    # a macro nothing references produces no metadata, so it is not a doc gap
+    if macro_uses(macro) < 2:
+        continue
+    if ('`%s`' % key) not in meta_md:
+        bad('metadata', "device metadata key '%s' is not documented in pantavisor-metadata.md" % key)
+
+# ------------------------------------------- frontmatter, indexes, and links
+pages = []
+for dirpath, _, names in os.walk(DOCS):
+    for n in names:
+        if n.endswith('.md'):
+            pages.append(os.path.relpath(os.path.join(dirpath, n), DOCS))
+
+def frontmatter(rel):
+    txt = read(os.path.join('docs', rel))
+    if not txt.startswith('---\n'):
+        return {}
+    end = txt.index('\n---\n', 4)
+    fm = {}
+    for line in txt[4:end].split('\n'):
+        if ':' in line:
+            k, v = line.split(':', 1)
+            fm[k.strip()] = v.strip().strip('"')
+    return fm
+
+positions = {}
+for rel in sorted(pages):
+    fm = frontmatter(rel)
+    if not fm:
+        bad('frontmatter', "%s has no frontmatter" % rel)
+        continue
+    if fm.get('draft') == 'true':
+        continue
+    for field in ('title', 'sidebar_position', 'description'):
+        if field not in fm:
+            bad('frontmatter', "%s is missing '%s'" % (rel, field))
+    folder = os.path.dirname(rel)
+    pos = fm.get('sidebar_position')
+    if pos is not None:
+        if (folder, pos) in positions:
+            bad('frontmatter', "%s and %s share sidebar_position %s" % (positions[(folder, pos)], rel, pos))
+        positions[(folder, pos)] = rel
+    # index membership
+    if os.path.basename(rel) != 'index.md':
+        idx = os.path.join(folder, 'index.md')
+        if idx in pages and os.path.basename(rel) not in read(os.path.join('docs', idx)):
+            bad('index', "%s is not linked from %s" % (rel, idx))
+
+LINK = re.compile(r'\[[^\]]*\]\(([^)\s]+)\)')
+def anchors_of(rel):
+    out = set()
+    for line in read(os.path.join('docs', rel)).split('\n'):
+        m = re.match(r'^#+\s+(.*)', line)
+        if m:
+            a = re.sub(r'[^\w\s-]', '', m.group(1).lower()).strip().replace(' ', '-')
+            out.add(a)
+    return out
+anchors = {rel: anchors_of(rel) for rel in pages}
+
+for rel in sorted(pages):
+    txt = read(os.path.join('docs', rel))
+    # strip fenced blocks by line, then inline code spans, so only prose is checked
+    prose_lines, fenced = [], False
+    for line in txt.split('\n'):
+        if line.lstrip().startswith('```'):
+            fenced = not fenced
+            continue
+        if not fenced:
+            prose_lines.append(re.sub(r'`[^`]*`', '', line))
+    prose = '\n'.join(prose_lines)
+    # the site renders MDX: a bare {expr} or <tag> outside code is evaluated as JSX
+    for m in re.finditer(r'\{[A-Za-z_]|<[a-zA-Z][a-zA-Z0-9_-]*>', prose):
+        bad('mdx', "%s has unescaped MDX syntax '%s' outside a code span" % (rel, m.group(0)))
+    if '!!!' in prose:
+        bad('mdx', "%s uses MkDocs '!!!' admonition syntax" % rel)
+    if ':material-' in prose:
+        bad('mdx', "%s uses a MkDocs Material icon code" % rel)
+    for target in LINK.findall(txt):
+        if target.startswith(('http', '#', 'mailto', '/')):
+            continue
+        path, _, anc = target.partition('#')
+        if not path or not path.endswith('.md'):
+            continue
+        tgt = os.path.normpath(os.path.join(os.path.dirname(rel), path))
+        if tgt.startswith('..'):        # cross-repo: only resolves on the site
+            continue
+        if tgt not in pages:
+            bad('link', "%s -> %s (no such file)" % (rel, target))
+        elif anc and anc not in anchors[tgt]:
+            bad('link', "%s -> %s (no such anchor)" % (rel, target))
+
+# ----------------------------------------------------- docs.pantahub.com redirects
+# The pages listed in CONTRIBUTING.md are 301 targets from the retired MkDocs site.
+# Renaming, deleting or drafting one turns a live redirect into a 404.
+frozen = []
+contrib = read('docs/CONTRIBUTING.md').split('\n')
+i = next((n for n, l in enumerate(contrib) if l.startswith('| Page | Redirected from |')), None)
+if i is None:
+    bad('redirect', "CONTRIBUTING.md has no 'Page | Redirected from' table")
+else:
+    for line in contrib[i + 2:]:
+        if not line.startswith('|'):
+            break
+        m = re.match(r'\|\s*\[`([^`]+)`\]', line)
+        if m:
+            frozen.append(m.group(1))
+for rel in frozen:
+    if rel not in pages:
+        bad('redirect', "%s is a docs.pantahub.com redirect target but no longer exists" % rel)
+    elif frontmatter(rel).get('draft') == 'true':
+        bad('redirect', "%s is a docs.pantahub.com redirect target but is draft: true" % rel)
+
+# ------------------------------------------------------------------- verdict
+if fail:
+    print("docs check FAILED (%d):\n" % len(fail))
+    for line in fail:
+        print("  " + line)
+    sys.exit(1)
+print("docs check OK: %d config keys, %d ctrl routes, %d pages, %d frozen URLs"
+      % (len(entries), len(routes), len(pages), len(frozen)))
+PYEOF


### PR DESCRIPTION
This PR adds a docs/CONTRIBUTING.md to try to clearly separate what belongs in docs overview and what belongs in reference:
* **overview**: High level explanation on how things work. How does this work, and why is it built this way? 
* **reference**: Factual, concise and complete information for quick consultation. What exactly are the valid values?

It includes the reference and overview changes for correctness based on the contract.

Additionally, it enforces part of the contract with a new script executed from CI that checks completition on config keys/defaults, ctrl endpoints, and devmeta keys against the source, permanent pages for redirection, frontmatter, indexes, links and MDX hazards.