### PR TITLE
docs: fix config defaults, exit code and tool gaps found against source

### DIFF
--- a/docs/reference/pantavisor-configuration.md
+++ b/docs/reference/pantavisor-configuration.md
@@ -86,14 +86,14 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_LOG_CAPTURE` | `0` or `1` | `1` | capture logs from containers |
 | `PV_LOG_CAPTURE_DMESG` | `0` or `1` | `1` | capture dmesg logs |
 | `PV_LOG_DIR` | path | `/storage/logs/` | set [logs](../overview/storage.md#logs) directory |
-| `PV_LOG_DIR_MAXSIZE` | integer with optional suffix `B`(default),`K`,`KB`,`M`,`MB`,`G`,`GB`,`T`,`TB`,`%`; `0` for auto 10% (100% if tmpfs) | `16777216` | max size of log directory |
+| `PV_LOG_DIR_MAXSIZE` | integer with optional suffix `B`(default),`K`,`KB`,`M`,`MB`,`G`,`GB`,`T`,`TB`,`%`; `0` for auto 10% (100% if tmpfs) | `0` | max size of log directory |
 | `PV_LOG_FILETREE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for filetree logs |
 | `PV_LOG_HYSTERESIS_FACTOR` | positive integer | `4` | controls the gap between high and low watermarks for [log directory cleanup](../overview/storage.md#log-directory-size-management) |
 | `PV_LOG_LEVEL` | `0` to `5` | `0` | set Pantavisor log level (0: FATAL to 5: TRACE) |
 | `PV_LOG_LOGGERS` | `0` or `1` | `1` | enable loggers for containers |
 | `PV_LOG_PUSH` | `0` or `1` | `1` | push logs to [Pantacor Hub](../overview/remote-control.md#pantacor-hub) |
 | `PV_LOG_ROTATE_FACTOR` | integer | `5` | determines per-file rotation threshold for [log directory cleanup](../overview/storage.md#log-directory-size-management) |
-| `PV_LOG_SERVER_OUTPUTS` | string | `filetree` | set log server outputs (comma separated) |
+| `PV_LOG_SERVER_OUTPUTS` | string | `filetree` | set [log server outputs](../overview/storage.md#output-types) (comma separated) |
 | `PV_LOG_AUTO_DEVLOG` | `0` or `1` | `1` | globally enable or disable the [/dev/log](logserver-sockets.md#devlog) bind-mount into containers; can be overridden per-container with `dev-log` in `run.json` |
 | `PV_LOG_SINGLEFILE_TIMESTAMP_FORMAT` | format string | empty | timestamp format for single-file logs |
 | `PV_LOG_STDOUT_TIMESTAMP_FORMAT` | format string | empty | timestamp format for stdout logs |
@@ -119,8 +119,8 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_SECUREBOOT_CHECKSUM` | `0` or `1` | `1` | enable artifact [checksum validation](../overview/storage.md#artifact-checksum) |
 | `PV_SECUREBOOT_HANDLERS` | `0` or `1` | `1` | enable handlers verification |
 | `PV_SECUREBOOT_MODE` | `disabled`, `audit`, `lenient` or `strict` | `lenient` | set secureboot mode |
-| `PV_SECUREBOOT_OEM_TRUSTSTORE` | path | `/etc/pantavisor/certs/oem` | set path to OEM truststore |
-| `PV_SECUREBOOT_TRUSTSTORE` | path | `/etc/pantavisor/certs` | set path to Pantavisor truststore |
+| `PV_SECUREBOOT_OEM_TRUSTSTORE` | truststore name | `ca-oem-certificates` | set OEM truststore, read from `<PV_SYSTEM_ETCDIR>/pantavisor/pvs/trust/<name>.crt`. Also accepted under the legacy misspelled alias `PV_SECUREBOOT_OEM_TRUSTORE` |
+| `PV_SECUREBOOT_TRUSTSTORE` | truststore name | `ca-certificates` | set Pantavisor truststore, read from `<PV_SYSTEM_ETCDIR>/pantavisor/pvs/trust/<name>.crt` |
 | `PV_STORAGE_DEVICE` | string | empty | set storage device name |
 | `PV_STORAGE_FSTYPE` | string | empty | set storage filesystem type |
 | `PV_STORAGE_GC_KEEP_FACTORY` | `0` or `1` | `0` | keep factory revision during GC |
@@ -145,7 +145,7 @@ This table contains the currently supported list of configuration keys, sorted a
 | `PV_SYSTEM_LIBDIR` | path | `/lib` | set system library directory |
 | `PV_SYSTEM_MEDIADIR` | path | `/media` | set system media directory |
 | `PV_SYSTEM_MOUNT_SECURITYFS` | `0` or `1` | `0` | mount securityfs |
-| `PV_SYSTEM_RUNDIR` | path | `/run/pantavisor/pv` | set system run directory |
+| `PV_SYSTEM_RUNDIR` | path | `/pv` | set system run directory. Images that run Pantavisor outside its own mount namespace (appengine) override this to `/run/pantavisor/pv` |
 | `PV_SYSTEM_USRDIR` | path | `/usr` | set system usr directory |
 | `PV_UPDATER_COMMIT_DELAY` | time (in seconds) | `25` | delay before committing an update |
 | `PV_UPDATER_GOALS_TIMEOUT` | time (in seconds) | `120` | timeout for reaching update goals |

--- a/docs/tools/pantavisor-tools.md
+++ b/docs/tools/pantavisor-tools.md
@@ -18,7 +18,7 @@ pventer -c <container-name> [CMD ...]
 
 `-c`/`--container` is required; `--container` is the long-form alias of `-c`.
 
-Without a command, drops into the container's default shell. With a command, executes it inside the container's namespace. Uses `fallbear-cmd` under the hood via LXC paths.
+Without a command, drops into the container's default shell. With a command, executes it inside the container's namespace. Uses `fallbear-cmd` under the hood via LXC paths — `LXC_PATH` (default `/usr/var/lib/lxc`) overrides where those are looked up.
 
 ```bash
 # Drop into a shell inside the container
@@ -158,10 +158,10 @@ pvtx queue process [base] [queue] [object]
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PVTXDIR` | `/var/cache/pvtx` (root), `~/.local/share/pvtx` (non-root) | Temp directory for transaction state |
-| `PVTX_OBJECT_BUF_SIZE` | — | Buffer size for saving objects (512B–10M) |
+| `PVTX_OBJECT_BUF_SIZE` | `512B` | Buffer size for saving objects (512B–10M) |
 | `PVTX_CTRL_BUF_SIZE` | — | Buffer size for pv-ctrl I/O (16K–10M) |
 
-Socket paths (auto-detected): `/pv/pv-ctrl` (container root) or `/pantavisor/pv-ctrl` (inside containers).
+Socket paths (auto-detected, in order): `/run/pantavisor/pv/pv-ctrl` (appengine / embedded mode), `/pv/pv-ctrl` (container root) or `/pantavisor/pv-ctrl` (inside containers).
 
 ```bash
 # Remote transaction: modify current revision and commit

--- a/docs/tools/pvcontrol.md
+++ b/docs/tools/pvcontrol.md
@@ -23,6 +23,10 @@ directly.
 pvcontrol [options] <command> [arguments]
 ```
 
+Several commands accept aliases: `ls`/`list`, `cmd`/`command`/`commands`,
+`conf`/`configuration`, and `devmeta save`/`devmeta upload`. The forms used
+throughout this page are the canonical ones.
+
 ### Options
 
 | Option | Description |
@@ -62,6 +66,7 @@ printed to stderr):
 | `48` | Not enough disk space available. |
 | `60` | Object has bad checksum. |
 | `70` | State verification failed. |
+| `75` | HTTP 503 — the operation is already in progress (e.g. a running GC cycle). |
 | `255` | Any other non-200 response. |
 
 > Because errors surface only through the exit code, assert HTTP status codes


### PR DESCRIPTION
## Origin

docs-framework code check [`codechecks/pantavisor/2026-09-03-all-5ae3894-claude-opus-5.md`](https://github.com/pantavisor/pantavisor) — repo=`pantavisor`, section=`all`, commit `5ae3894`, 2026-09-03. The check diffs this repo's `docs/` tree against its own source (CLI tools, `config.h`/`config.c`, `ctrl/*_ep.c`), not against the rendered site.

## What the code says

- **Major (mismatched) — `PV_SECUREBOOT_TRUSTSTORE` / `PV_SECUREBOOT_OEM_TRUSTSTORE`.** Source: `config.c:112-113`, `271-274` default to `SECUREBOOT_TRUSTSTORE_DEF` / `SECUREBOOT_OEM_TRUSTSTORE_DEF` = `"ca-certificates"` / `"ca-oem-certificates"` (`paths.h:159-160`), which `pv_paths_secureboot_trust_crts()` (`paths.c:428-435`) expands to `<PV_SYSTEM_ETCDIR>/pantavisor/pvs/trust/<name>.crt`. Docs: `pantavisor-configuration.md:122-123` gave type `path` and defaults `/etc/pantavisor/certs` / `/etc/pantavisor/certs/oem` — neither the value nor the right *kind* of value.
- **Major (mismatched) — `PV_LOG_DIR_MAXSIZE`.** Source: `config.c:222` — `.value.s = "0"`, and `config.c:744-746` treats `"0"` as 10% of the partition (100% on tmpfs). Docs: `:89` said `16777216`, contradicting the same row's own type column ("`0` for auto 10% (100% if tmpfs)").
- **Major (mismatched) — `PV_SYSTEM_RUNDIR`.** Source: `config.c:119` — `#define SYSTEM_RUNDIR_DEF "/pv"`. Docs: `:148` said `/run/pantavisor/pv`, which is the appengine value other pages observe, leaving no way to tell which is the default.
- **Major (mismatched) — `pvcontrol` exit code `75`.** Source: `tools/pvcontrol:865` — `[ "$http_code" = "503" ] && code=75`. Docs: `pvcontrol.md:54-65` listed only `0`/`48`/`60`/`70`/`255` and asserted "`255` — Any other non-200 response", while `:310` already tells the reader `run-gc` can return 503.
- **Minor (unlinked) — `PV_LOG_SERVER_OUTPUTS` token vocabulary.** Source: `config.c:565-596` parses seven tokens. Docs: all seven are listed in `overview/storage.md:180-186`, but the configuration reference row gave type `string` with no link, while sibling log rows (e.g. `:95`) do link into `storage.md`.
- **Trivial (undocumented) — `pvcontrol` aliases.** Source: `tools/pvcontrol:282` (`save|upload`), `:293`/`:318` (`ls|list`), `:578` (`cmd|command|commands`), `:599` (`configuration|conf`) — and `usage_conf()` at `:169` prints `<configuration|conf>` itself. Docs: zero matches for any of them.
- **Trivial (undocumented) — `LXC_PATH`.** Source: `tools/pventer:12`, default `/usr/var/lib/lxc`, used at `:36`. Docs: the pventer section said "Uses `fallbear-cmd` under the hood via LXC paths" without naming the variable.
- **Trivial (mismatched) — pvtx socket list.** Source: `pvtx/src/pvtx_ctrl.c:47-49` tries three paths. Docs: `pantavisor-tools.md:164` listed only two, omitting `/run/pantavisor/pv/pv-ctrl` — the first one tried, and the one the same page lists first for pvcurl at `:40`.
- **Trivial (undocumented) — `PVTX_OBJECT_BUF_SIZE` default.** Source: `pvtx_txn.c:151-152` passes `512`; `pvtx.c:333-336` prints "Default: 512B". Docs: `:161` had an empty Default column.
- **Trivial (undocumented) — `PV_SECUREBOOT_OEM_TRUSTORE`.** Source: `config.c:419` — a misspelled legacy alias in the alias table, the only key literal in `config.c` with no mention in `docs/`.

## What changed and why

- `docs/reference/pantavisor-configuration.md` — corrected the `PV_SECUREBOOT_*TRUSTSTORE` rows (type `truststore name`, real defaults, resolution path, plus the legacy `PV_SECUREBOOT_OEM_TRUSTORE` alias), the `PV_LOG_DIR_MAXSIZE` default (`0`), and the `PV_SYSTEM_RUNDIR` default (`/pv`, noting the appengine override); linked `PV_LOG_SERVER_OUTPUTS` to `storage.md#output-types`.
- `docs/tools/pvcontrol.md` — added the `75` exit-code row and a one-paragraph note on the accepted command aliases.
- `docs/tools/pantavisor-tools.md` — named `LXC_PATH` and its default in the pventer section, added the third pvtx socket path, filled in `PVTX_OBJECT_BUF_SIZE`'s default.

**Not changed:** `PVTEST_EXEC` (`tools/pvcontrol:3`, `tools/pventer:3`) is a `pvtest` harness hook; the check flagged it for completeness and its own suggested fix is to close it as intentional rather than document it in user-facing docs. Nothing here was already resolved — all ten edits were still needed at `5ae3894`.

## Status

Draft, opened from an automated docs-eval fix pass. Not verified against the rendered site — the defaults and line references were read from source at commit `5ae3894`, but a human should confirm the `PV_SYSTEM_RUNDIR` and truststore wording matches how these are actually provisioned on shipping images before merging.
