### PR TITLE
docs: name the config keys and command behind remote control and updates

### DIFF
--- a/docs/overview/remote-control.md
+++ b/docs/overview/remote-control.md
@@ -13,7 +13,13 @@ To interact with Pantacor Hub, you can either use the [web user interface](https
 
 ### Pantacor Hub Client
 
-Pantavisor includes a build-in Pantacor Hub client which is [enabled by default](../reference/pantavisor-configuration.md#summary). To begin remote control and monitoring of devices with [Pantacor Hub](https://hub.pantacor.com), it is necessary to create an account and [claim the device to it](../../meta-pantavisor/getting-started/operate/device-access/remote-pantahub.md). From that moment on, the device will be attached to that account and will try to keep the connection with Pantacor Hub opened, except if a [local revision](../reference/pantavisor-commands.md#steps) is installed. In that case, the device will turn to [local control](local-control.md) until a [go remote command](../reference/pantavisor-commands.md#commands) is issued. This behavior can be avoided with the [remote always configuration](../reference/pantavisor-configuration.md#summary).
+Pantavisor includes a build-in Pantacor Hub client which is [enabled by default](../reference/pantavisor-configuration.md#summary) (`PV_CONTROL_REMOTE`, default `1`). To begin remote control and monitoring of devices with [Pantacor Hub](https://hub.pantacor.com), it is necessary to create an account and [claim the device to it](../../meta-pantavisor/getting-started/operate/device-access/remote-pantahub.md). From that moment on, the device will be attached to that account and will try to keep the connection with Pantacor Hub opened, except if a [local revision](../reference/pantavisor-commands.md#steps) is installed. In that case, the device will turn to [local control](local-control.md) until a [go remote command](../reference/pantavisor-commands.md#commands) is issued:
+
+```bash
+pvcontrol cmd go-remote
+```
+
+This behavior can be avoided with the [remote always configuration](../reference/pantavisor-configuration.md#summary) (`PV_CONTROL_REMOTE_ALWAYS`, default `0`).
 
 The main features offered by remote control are:
 

--- a/docs/overview/updates.md
+++ b/docs/overview/updates.md
@@ -75,7 +75,7 @@ Installing or progressing to this revision. Transitions to new revisions can eit
 
 [Hooks](hooks.md) fire at key points during installation: before and after the bootloader writes the new revision (`system-before-install-update` / `system-after-install-update`), and once the revision has been committed after a successful try-boot (`system-boot-done`).
 
-To finish this state, it is necessary that all [status goals](containers.md#status-goal) existing in the new revision have been achieved. Also, in the case of a [remote](remote-control.md#pantacor-hub) update, Pantavisor needs to have performed communication with Pantacor Hub. If these two conditions are not met within a [configurable](../reference/pantavisor-state-format-v2.md#5-orchestration-groupsjson) time, Pantavisor will [rollback](#error) the revision.
+To finish this state, it is necessary that all [status goals](containers.md#status-goal) existing in the new revision have been achieved. Also, in the case of a [remote](remote-control.md#pantacor-hub) update, Pantavisor needs to have performed communication with Pantacor Hub. If these two conditions are not met within a configurable time, Pantavisor will [rollback](#error) the revision. The wait is set per group by `timeout` in [groups.json](../reference/pantavisor-state-format-v2.md#5-orchestration-groupsjson), falling back to [`PV_UPDATER_GOALS_TIMEOUT`](../reference/pantavisor-configuration.md#summary) (seconds, default `120`) for any group that does not set it.
 
 | Messages |
 | ---------|
@@ -108,7 +108,7 @@ In this case, Pantavisor will only stop the containers that were affected by the
 
 Waiting to see if the revision is stable. During this stage, Pantavisor checks if all containers are running and will [rollback](#error) if any of them exits. Besides that, in the case of a [remote](remote-control.md#pantacor-hub) update, it will also [rollback](#error) in case Pantacor Hub communication is lost.
 
-If any container has a [stable_timeout](containers.md#stability-tracking), the commit is held even after the commit delay timer expires, until all containers have survived their stability window. If a container with [auto-recovery](containers.md#auto-recovery) exhausts its `max_retries` during TESTING, a rollback is triggered immediately regardless of the configured `backoff_policy`.
+If any container has a [stable_timeout](containers.md#stability-tracking), the commit is held even after the commit delay timer ([`PV_UPDATER_COMMIT_DELAY`](../reference/pantavisor-configuration.md#summary), seconds, default `25`) expires, until all containers have survived their stability window. If a container with [auto-recovery](containers.md#auto-recovery) exhausts its `max_retries` during TESTING, a rollback is triggered immediately regardless of the configured `backoff_policy`.
 
 | Messages |
 | ---------|


### PR DESCRIPTION
## Origin

docs-framework audit `audits/pantavisor/2026-09-03-all-development-claude-opus-5.md` — repo=`pantavisor`, version=`development`, section=`all`, 2026-09-03. The audit checks the docs **as published on `docs.pantavisor.io/development/`** against this repo's own `AGENTS.md` (Documentation, Actionability, Link conventions). 28 pages, all read in full.

## What the rule requires

`AGENTS.md` → **Actionability (docs/)**: "Alongside (or right after) the conceptual explanation of a feature, show the concrete command, config key, or endpoint that exercises it… Prefer a short fenced code block over prose describing what a command does."

- **Minor (actionability) — `overview/remote-control`.** A 763-word feature page with **zero** fenced code blocks and **zero** inline code spans. Evidence: "a build-in Pantacor Hub client which is [enabled by default](…/pantavisor-configuration#summary)" — links to a 115-row table without naming `PV_CONTROL_REMOTE`; "This behavior can be avoided with the [remote always configuration](…/pantavisor-configuration#summary)" — same anchor, never names `PV_CONTROL_REMOTE_ALWAYS`; "until a [go remote command](…/pantavisor-commands#commands) is issued" — never names the `GO_REMOTE` op or `pvcontrol cmd go-remote`.
- **Minor (actionability) — `overview/updates`.** A 1346-word page with zero fenced blocks describing two configurable timers without naming either key. Evidence: "the commit is held even after the commit delay timer expires" — never names `PV_UPDATER_COMMIT_DELAY`; "If these two conditions are not met within a [configurable](…/pantavisor-state-format-v2#5-orchestration-groupsjson) time" — links to the state-format page rather than naming `PV_UPDATER_GOALS_TIMEOUT`.

## What changed and why

- `docs/overview/remote-control.md` — names `PV_CONTROL_REMOTE` (default `1`) at "enabled by default", adds a `pvcontrol cmd go-remote` fenced block where the page says a go-remote command is issued, and names `PV_CONTROL_REMOTE_ALWAYS` (default `0`) at "the remote always configuration".
- `docs/overview/updates.md` — names `PV_UPDATER_COMMIT_DELAY` (default `25`s) at TESTING's commit-delay timer, and replaces INPROGRESS's bare "[configurable] time" with the actual resolution order: `groups.json`'s per-group `timeout`, falling back to `PV_UPDATER_GOALS_TIMEOUT` (default `120`s) when a group omits it.

Per `AGENTS.md`'s "Verify every command, config key, path, and filename you add against the actual source", all four values were read from source rather than from the docs: `config.c:309-311` for the two `PV_UPDATER_*` defaults, `config.c` `entries[]` for the two `PV_CONTROL_REMOTE*` defaults, and `parser/parser_system1.c:2135-2151` for the groups.json-`timeout` → `PV_UPDATER_GOALS_TIMEOUT` fallback.

## Noted, not changed

`reference/pantavisor-state-format-v2.md`'s orchestration table gives the `groups.json` `timeout` field a default of `30`, but source falls back to `PV_UPDATER_GOALS_TIMEOUT`'s `120` when the field is absent (`parser_system1.c:2147`). That's a source-vs-docs mismatch rather than an audit finding, so it is left for a separate pass rather than folded into this PR.

## Status

Draft, opened from an automated docs-eval fix pass. Not verified against the rendered site. The audit found no Critical issues in this repo; its three remaining findings are deliberately not in this PR — two are `AGENTS.md` rule-table gaps (`AUDITBOOK.md` raises those for a human rather than resolving them), and the sitemap drift belongs to `docs.pantavisor`'s generation.
