### PR TITLE
ci: run build and docs jobs on runners labelled bsp-builder

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ on:
 jobs:
   check:
     name: "check docs against code"
-    runs-on: ["self-hosted"]
+    runs-on: ["bsp-builder"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -29,7 +29,7 @@ jobs:
           - machine_name: docker-x86_64-scarthgap
             configs: kas/build-configs/release/docker-x86_64-scarthgap.yaml:kas/build-configs/shared-vols.yaml
 
-    runs-on: ["self-hosted"]
+    runs-on: ["bsp-builder"]
     container:
       image: ghcr.io/pantacor/kas/kas:next-v7
       volumes:


### PR DESCRIPTION
Build and docs-check jobs now run on runners labelled `bsp-builder` instead of any `self-hosted` runner.

Land after the builder runners carry the `bsp-builder` label. Companion: pantavisor/meta-pantavisor#489.