### PR TITLE
feat(pvtest): point a whole run at another Hub via PVTEST_HUB_URL

### DIFF
--- a/pvtest/common.in
+++ b/pvtest/common.in
@@ -46,3 +46,30 @@ pvtest_ssh_cmd() {
 pvtest_normalize_cfg() {
 	printf '%s\n' $1 | grep -v '^$' | sort | tr '\n' ' ' | sed 's/ *$//'
 }
+
+# Pantavisor config tokens pointing a target at the Hub at URL $1 (https://host[:port])
+pvtest_hub_cfg() {
+	local _hp _host _port
+	_hp=${1#*://}; _hp=${_hp%%/*}
+	_host=${_hp%%:*}
+	_port=${_hp#"$_host"}; _port=${_port#:}
+	[ -n "$_host" ] || return 1
+	printf 'PH_CREDS_HOST=%s' "$_host"
+	[ -n "$_port" ] && printf ' PH_CREDS_PORT=%s' "$_port"
+	printf '\n'
+}
+
+# Config $1 plus the Hub tokens for URL $2 when it enables remote control and names no Hub itself
+pvtest_cfg_with_hub() {
+	local _n
+	_n=$(pvtest_normalize_cfg "$1")
+	case " $_n " in
+	*" PV_CONTROL_REMOTE=1 "*)
+		case " $_n " in
+		*" PH_CREDS_HOST="*) ;;
+		*) _n="$_n $(pvtest_hub_cfg "$2")" ;;
+		esac
+		;;
+	esac
+	pvtest_normalize_cfg "$_n"
+}

--- a/pvtest/pvtest-run.in
+++ b/pvtest/pvtest-run.in
@@ -59,6 +59,7 @@ usage() {
 	echo "  PVTEST_LIBDIR    where utils/common live (default: /usr/share/pantavisor/pvtest)"
 	echo "  APPENGINE_LOGS   dir of <target>.log files, tailed into each test's log"
 	echo "  PH_USER/PH_PASS  Hub credentials, for self-claim and Hub-side usrmeta"
+	echo "  PVTEST_HUB_URL   Hub the run targets (default: https://api.pantahub.com)"
 	echo ""
 	echo "See docs/overview/testing/automated/."
 	echo ""
@@ -153,7 +154,7 @@ _hub_usrmeta_delete() {
 	curl -s -X PATCH \
 		-H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
 		-d "{\"$key\": null}" \
-		"${PVTEST_HUB_URL:-https://api.pantahub.com}/devices/$device_id/user-meta" \
+		"$PVTEST_HUB_URL/devices/$device_id/user-meta" \
 		> /dev/null 2>&1
 }
 
@@ -166,7 +167,7 @@ _hub_usrmeta_set() {
 		curl -sf -X PATCH \
 			-H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
 			-d "{\"$key\": \"$value\"}" \
-			"${PVTEST_HUB_URL:-https://api.pantahub.com}/devices/$device_id/user-meta" \
+			"$PVTEST_HUB_URL/devices/$device_id/user-meta" \
 			> /dev/null 2>&1 && return 0
 		attempt=$((attempt + 1))
 		[ $attempt -le 4 ] && sleep 5
@@ -211,7 +212,7 @@ _sweep_tracked_devices() {
 	while IFS= read -r d; do
 		[ -n "$d" ] || continue
 		pvtest_log WARN "sweeping leftover self-claimed device $d"
-		_pvr_auth dev delete -y "$d" > /dev/null 2>&1
+		_pvr_auth dev delete -y "$(pvr_device_url "$d")" > /dev/null 2>&1
 	done < "$f"
 	: > "$f" 2>/dev/null || true
 }
@@ -426,7 +427,7 @@ _dev_unclaim() {
 	fi
 	if [ -n "$dev" ]; then
 		pvtest_log INFO "deleting device $dev from Hub"
-		_pvr_logged dev delete -y "$dev"
+		_pvr_logged dev delete -y "$(pvr_device_url "$dev")"
 		_track_device del "$dev"
 	fi
 	pvtest_log INFO "device unclaimed"
@@ -461,7 +462,7 @@ _dev_claim() {
 			pvtest_log ERROR "cannot claim (attempt $_try): missing device-id ('$device_id') or challenge"
 		else
 			pvtest_log INFO "claiming device $device_id (attempt $_try)..."
-			if _pvr_logged claim -c "$challenge" "$device_id"; then
+			if _pvr_logged claim -c "$challenge" "$(pvr_device_url "$device_id")"; then
 				_claimed=1; break
 			fi
 		fi
@@ -485,7 +486,7 @@ _dev_delete_only() {
 	local device_id="${1:-$(_dev_read_file /var/run/pantavisor/pv/device-id)}"
 	[ -n "$device_id" ] || return 0
 	pvtest_log INFO "deleting claimed device $device_id"
-	_pvr_logged dev delete -y "$device_id"
+	_pvr_logged dev delete -y "$(pvr_device_url "$device_id")"
 	_track_device del "$device_id"
 }
 
@@ -541,7 +542,7 @@ handle_self_claim() {
 
 	if [ -n "$pre_unclaimed_device" ]; then
 		pvtest_log INFO "deleting device $pre_unclaimed_device from Hub"
-		_pvr_logged dev delete -y "$pre_unclaimed_device"
+		_pvr_logged dev delete -y "$(pvr_device_url "$pre_unclaimed_device")"
 		_track_device del "$pre_unclaimed_device"
 		pre_unclaimed_device=
 	fi
@@ -1094,6 +1095,8 @@ parse_test() {
 	fi
 
 	required_env=$(jq -r '.setup.config.env // ""' "$j")
+	# remote tests need the target pointed at the run's Hub, unless the test names its own
+	required_env=$(pvtest_cfg_with_hub "$required_env" "$PVTEST_HUB_URL")
 	usrmeta=$(jq -r '.setup.config.usrmeta // ""' "$j")
 	tarballs=$(jq -r '.setup.containers.tarballs[]? // empty' "$j")
 	commit_initial=$(jq -r '.setup."commit-initial" // "true"' "$j")
@@ -1368,7 +1371,7 @@ run_slot_pool() {
 	# One line per test: "<rank>\t<cfg>\t<jsonpath>"
 	# rank 0=self-claim
 	for _j in $test_json_list; do
-		_req=$(pvtest_normalize_cfg "$(jq -r '.setup.config.env // ""' "$_j")")
+		_req=$(pvtest_cfg_with_hub "$(jq -r '.setup.config.env // ""' "$_j")" "$PVTEST_HUB_URL")
 		_sc=$(jq -r '.setup."self-claim" // "false"' "$_j")
 		_rank=1
 		case " $_req " in
@@ -1452,6 +1455,7 @@ tmp_err_path=
 _run_scope=${test_selector#"$PVTEST_ROOT"/}
 _run_scope=${_run_scope%/}
 pvtest_log INFO "starting test run: ${_run_scope:-all}"
+pvtest_log INFO "Hub: $PVTEST_HUB_URL"
 
 wait_for_netsim
 

--- a/pvtest/utils.in
+++ b/pvtest/utils.in
@@ -7,6 +7,14 @@
 # common, which is shared with the host orchestrator (test.docker.sh)
 . "${PVTEST_LIBDIR:-/usr/share/pantavisor/pvtest}/common"
 
+# Hub the whole run targets; pvr and the tests' Hub calls follow it
+: "${PVTEST_HUB_URL:=https://api.pantahub.com}"
+PVTEST_HUB_URL=${PVTEST_HUB_URL%/}
+export PVTEST_HUB_URL PVR_BASEURL="$PVTEST_HUB_URL"
+
+# Device endpoint on the run's Hub; pvr claim/dev delete with a bare id are hard-wired to prod
+pvr_device_url() { printf '%s/devices/%s\n' "$PVTEST_HUB_URL" "$1"; }
+
 pv_exec() {
 	local prog="$1"; shift
 	if [ -n "$PVTEST_EXEC" ]; then


### PR DESCRIPTION
Tester-container half of pointing a whole pvtest run at another Pantacor Hub (e.g. api.stage.pantahub.com). Host half: pantavisor/meta-pantavisor#491.

- `utils` exports `PVTEST_HUB_URL` (default `https://api.pantahub.com`) and `PVR_BASEURL`, so pvr and the tests' Hub calls follow it.
- `common` (duplicated byte-for-byte in meta) gains `pvtest_hub_cfg` / `pvtest_cfg_with_hub`: any test with `PV_CONTROL_REMOTE=1` and no `PH_CREDS_HOST` of its own gets `PH_CREDS_HOST[/PH_CREDS_PORT]` added to its required config, both in `parse_test` and in the slot pool's signature, so the target boots on that Hub through the normal re-type path. Local tests are untouched.
- Claim and Hub-side delete go through `pvr_device_url`: pvr's bare-id `claim` / `dev delete` are hard-wired to prod (fixed upstream in pvr MR https://gitlab.com/pantacor/pvr/-/merge_requests/501).

Validated on prod and stage with `remote/control`: identical results on both (4/6, the two failures are the known host cgroup-v1 issue and manual-claim after auto-claim in the persistent pool; both pass alone).