### PR TITLE
ci: cancel superseded runs of the same PR

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,10 @@ on:
       - "tools/pvcontrol"
       - ".github/workflows/docs.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: "check docs against code"

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -15,6 +15,10 @@ on:
       - "**"
       - "!docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: "build (${{ matrix.machine_name }})"


### PR DESCRIPTION
Key the concurrency group on the branch name so a push supersedes the ready_for_review run of the same PR; master runs are never cancelled.